### PR TITLE
[examples] Add flipper contract to examples folder

### DIFF
--- a/examples/lang/flipper/.cargo/config
+++ b/examples/lang/flipper/.cargo/config
@@ -1,0 +1,5 @@
+[target.wasm32-unknown-unknown]
+rustflags = [
+	"-C", "overflow-checks=on",
+	"-C", "link-args=-z stack-size=65536 --import-memory"
+]

--- a/examples/lang/flipper/.gitignore
+++ b/examples/lang/flipper/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/examples/lang/flipper/Cargo.toml
+++ b/examples/lang/flipper/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "flipper"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2018"
+
+[dependencies]
+pdsl_core = { path = "../../../core" }
+pdsl_model = { path = "../../../model" }
+pdsl_lang = { path = "../../../lang" }
+# pdsl_core = { git = "https://github.com/Robbepop/pdsl", package = "pdsl_core" }
+# pdsl_model = { git = "https://github.com/Robbepop/pdsl", package = "pdsl_model" }
+# pdsl_lang = { git = "https://github.com/Robbepop/pdsl", package = "pdsl_lang" }
+parity-codec = { version = "3.3", default-features = false, features = ["derive"] }
+
+[lib]
+name = "flipper"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+test-env = [
+    "pdsl_core/test-env",
+    "pdsl_model/test-env",
+    "pdsl_lang/test-env",
+]
+generate-api-description = [
+    "pdsl_lang/generate-api-description"
+]
+
+[profile.release]
+panic = "abort"
+lto = true
+opt-level = "z"

--- a/examples/lang/flipper/Cargo.toml
+++ b/examples/lang/flipper/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "flipper"
 version = "0.1.0"
-authors = ["[your_name] <[your_email]>"]
+authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-pdsl_core = { path = "../../../core" }
-pdsl_model = { path = "../../../model" }
-pdsl_lang = { path = "../../../lang" }
-# pdsl_core = { git = "https://github.com/Robbepop/pdsl", package = "pdsl_core" }
-# pdsl_model = { git = "https://github.com/Robbepop/pdsl", package = "pdsl_model" }
-# pdsl_lang = { git = "https://github.com/Robbepop/pdsl", package = "pdsl_lang" }
+ink_core = { path = "../../../core" }
+ink_model = { path = "../../../model" }
+ink_lang = { path = "../../../lang" }
 parity-codec = { version = "3.3", default-features = false, features = ["derive"] }
 
 [lib]
@@ -20,12 +17,12 @@ crate-type = ["cdylib"]
 [features]
 default = []
 test-env = [
-    "pdsl_core/test-env",
-    "pdsl_model/test-env",
-    "pdsl_lang/test-env",
+    "ink_core/test-env",
+    "ink_model/test-env",
+    "ink_lang/test-env",
 ]
 generate-api-description = [
-    "pdsl_lang/generate-api-description"
+    "ink_lang/generate-api-description"
 ]
 
 [profile.release]

--- a/examples/lang/flipper/build.sh
+++ b/examples/lang/flipper/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+PROJNAME=flipper
+
+# cargo clean
+# rm Cargo.lock
+
+CARGO_INCREMENTAL=0 cargo build --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
+wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
+cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
+wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
+wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
+wasm-prune --exports call,deploy target/$PROJNAME-opt.wasm target/$PROJNAME-pruned.wasm

--- a/examples/lang/flipper/src/lib.rs
+++ b/examples/lang/flipper/src/lib.rs
@@ -1,9 +1,9 @@
 #![no_std]
 
-use pdsl_core::storage;
-use pdsl_lang::contract;
-use pdsl_core::env::println;
-use pdsl_core::memory::format;
+use ink_core::storage;
+use ink_lang::contract;
+use ink_core::env::println;
+use ink_core::memory::format;
 
 contract! {
     /// This simple dummy contract has a `bool` value that can

--- a/examples/lang/flipper/src/lib.rs
+++ b/examples/lang/flipper/src/lib.rs
@@ -1,9 +1,11 @@
 #![no_std]
 
-use ink_core::storage;
+use ink_core::{
+    env::println,
+    memory::format,
+    storage,
+};
 use ink_lang::contract;
-use ink_core::env::println;
-use ink_core::memory::format;
 
 contract! {
     /// This simple dummy contract has a `bool` value that can

--- a/examples/lang/flipper/src/lib.rs
+++ b/examples/lang/flipper/src/lib.rs
@@ -1,0 +1,53 @@
+#![no_std]
+
+use pdsl_core::storage;
+use pdsl_lang::contract;
+use pdsl_core::env::println;
+use pdsl_core::memory::format;
+
+contract! {
+    /// This simple dummy contract has a `bool` value that can
+    /// alter between `true` and `false` using the `flip` message.
+    /// Users can retrieve its current state using the `get` message.
+    struct Flipper {
+        /// The current state of our flag.
+        value: storage::Value<bool>,
+    }
+
+    impl Deploy for Flipper {
+        /// Initializes our state to `false` upon deploying our smart contract.
+        fn deploy(&mut self) {
+            self.value.set(false)
+        }
+    }
+
+    impl Flipper {
+        /// Flips the current state of our smart contract.
+        pub(external) fn flip(&mut self) {
+            if *self.value {
+                self.value.set(false)
+            } else {
+                self.value.set(true)
+            }
+        }
+
+        /// Returns the current state.
+        pub(external) fn get(&self) -> bool {
+            println(&format!("Flipper Value: {:?}", *self.value));
+            *self.value
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Flipper;
+
+    #[test]
+    fn it_works() {
+        let mut flipper = Flipper::deploy_mock();
+        assert_eq!(flipper.get(), true);
+        incrementer.flip();
+        assert_eq!(flipper.get(), false);
+    }
+}

--- a/examples/lang/flipper/src/lib.rs
+++ b/examples/lang/flipper/src/lib.rs
@@ -42,8 +42,8 @@ mod tests {
     #[test]
     fn it_works() {
         let mut flipper = Flipper::deploy_mock();
-        assert_eq!(flipper.get(), true);
-        incrementer.flip();
         assert_eq!(flipper.get(), false);
+        flipper.flip();
+        assert_eq!(flipper.get(), true);
     }
 }

--- a/examples/lang/flipper/src/lib.rs
+++ b/examples/lang/flipper/src/lib.rs
@@ -24,11 +24,7 @@ contract! {
     impl Flipper {
         /// Flips the current state of our smart contract.
         pub(external) fn flip(&mut self) {
-            if *self.value {
-                self.value.set(false)
-            } else {
-                self.value.set(true)
-            }
+            *self.value = !*self.value;
         }
 
         /// Returns the current state.

--- a/examples/lang/incrementer/Cargo.toml
+++ b/examples/lang/incrementer/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
 name = "incrementer"
 version = "0.1.0"
-authors = ["[your_name] <[your_email]>"]
+authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
 ink_core = { path = "../../../core" }
 ink_model = { path = "../../../model" }
 ink_lang = { path = "../../../lang" }
-# ink_core = { git = "https://github.com/Robbepop/pdsl", package = "ink_core" }
-# ink_model = { git = "https://github.com/Robbepop/pdsl", package = "ink_model" }
-# ink_lang = { git = "https://github.com/Robbepop/pdsl", package = "ink_lang" }
 parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
 
 [lib]


### PR DESCRIPTION
This adds the minimal flipper contract to the examples folder in parity-ink.