### PR TITLE
[*] Rename Address to AccountId globally

### DIFF
--- a/core/src/env/api.rs
+++ b/core/src/env/api.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 /// The environmental address type.
-pub type Address = <ContractEnv as EnvTypes>::Address;
+pub type AccountId = <ContractEnv as EnvTypes>::AccountId;
 
 /// The environmental balance type.
 pub type Balance = <ContractEnv as EnvTypes>::Balance;
@@ -35,7 +35,7 @@ pub type Balance = <ContractEnv as EnvTypes>::Balance;
 pub type Hash = <ContractEnv as EnvTypes>::Hash;
 
 /// Returns the address of the caller of the current smart contract execution.
-pub fn caller() -> Address {
+pub fn caller() -> AccountId {
     ContractEnv::caller()
 }
 

--- a/core/src/env/srml/mod.rs
+++ b/core/src/env/srml/mod.rs
@@ -20,7 +20,7 @@ mod srml_only;
 mod types;
 
 pub use self::types::{
-    Address,
+    AccountId,
     Balance,
     DefaultSrmlTypes,
     Hash,

--- a/core/src/env/srml/srml_only/impls.rs
+++ b/core/src/env/srml/srml_only/impls.rs
@@ -50,7 +50,7 @@ impl<T> EnvTypes for SrmlEnv<T>
 where
     T: EnvTypes,
 {
-    type Address = <T as EnvTypes>::Address;
+    type AccountId = <T as EnvTypes>::AccountId;
     type Balance = <T as EnvTypes>::Balance;
     type Hash = <T as EnvTypes>::Hash;
 }
@@ -94,10 +94,10 @@ where
 impl<T> Env for SrmlEnv<T>
 where
     T: EnvTypes,
-    <T as EnvTypes>::Address: for<'a> TryFrom<&'a [u8]>,
+    <T as EnvTypes>::AccountId: for<'a> TryFrom<&'a [u8]>,
     <T as EnvTypes>::Hash: for<'a> TryFrom<&'a [u8]>,
 {
-    fn caller() -> <Self as EnvTypes>::Address {
+    fn caller() -> <Self as EnvTypes>::AccountId {
         unsafe { sys::ext_caller() };
         let size = unsafe { sys::ext_scratch_size() };
         let mut value = Vec::new();

--- a/core/src/env/srml/types.rs
+++ b/core/src/env/srml/types.rs
@@ -29,27 +29,27 @@ use parity_codec::{
 pub struct DefaultSrmlTypes;
 
 impl EnvTypes for DefaultSrmlTypes {
-    type Address = self::Address;
+    type AccountId = self::AccountId;
     type Balance = self::Balance;
     type Hash = self::Hash;
 }
 
 /// The default SRML address type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Encode, Decode)]
-pub struct Address([u8; 32]);
+pub struct AccountId([u8; 32]);
 
-impl From<[u8; 32]> for Address {
-    fn from(address: [u8; 32]) -> Address {
-        Address(address)
+impl From<[u8; 32]> for AccountId {
+    fn from(address: [u8; 32]) -> AccountId {
+        AccountId(address)
     }
 }
 
-impl<'a> TryFrom<&'a [u8]> for Address {
+impl<'a> TryFrom<&'a [u8]> for AccountId {
     type Error = TryFromSliceError;
 
-    fn try_from(bytes: &'a [u8]) -> Result<Address, TryFromSliceError> {
+    fn try_from(bytes: &'a [u8]) -> Result<AccountId, TryFromSliceError> {
         let address = <[u8; 32]>::try_from(bytes)?;
-        Ok(Address(address))
+        Ok(AccountId(address))
     }
 }
 

--- a/core/src/env/test.rs
+++ b/core/src/env/test.rs
@@ -17,7 +17,7 @@
 //! Public api to interact with the special testing environment.
 
 use super::ContractEnv;
-use crate::env::Address;
+use crate::env::AccountId;
 
 /// Returns the total number of reads to all storage entries.
 pub fn total_reads() -> u64 {
@@ -30,6 +30,6 @@ pub fn total_writes() -> u64 {
 }
 
 /// Sets the caller for the next calls to the given address.
-pub fn set_caller(address: Address) {
+pub fn set_caller(address: AccountId) {
     ContractEnv::set_caller(address)
 }

--- a/core/src/env/test_env.rs
+++ b/core/src/env/test_env.rs
@@ -108,7 +108,7 @@ pub struct TestEnvData {
     /// # Note
     ///
     /// The current caller can be adjusted by `TestEnvData::set_caller`.
-    caller: srml::Address,
+    caller: srml::AccountId,
     /// The input data for the next contract invocation.
     ///
     /// # Note
@@ -139,7 +139,7 @@ impl Default for TestEnvData {
     fn default() -> Self {
         Self {
             storage: HashMap::new(),
-            caller: srml::Address::from([0x0; 32]),
+            caller: srml::AccountId::from([0x0; 32]),
             input: Vec::new(),
             random_seed: srml::Hash::from([0x0; 32]),
             expected_return: Vec::new(),
@@ -154,7 +154,7 @@ impl TestEnvData {
     /// Resets `self` as if no contract execution happened so far.
     pub fn reset(&mut self) {
         self.storage.clear();
-        self.caller = srml::Address::from([0; 32]);
+        self.caller = srml::AccountId::from([0; 32]);
         self.input.clear();
         self.random_seed = srml::Hash::from([0; 32]);
         self.expected_return.clear();
@@ -199,7 +199,7 @@ impl TestEnvData {
     }
 
     /// Sets the caller address for the next contract invocation.
-    pub fn set_caller(&mut self, new_caller: srml::Address) {
+    pub fn set_caller(&mut self, new_caller: srml::AccountId) {
         self.caller = new_caller;
     }
 
@@ -237,7 +237,7 @@ impl TestEnvData {
     const FAILURE: i32 = -1;
 
     /// Returns the caller of the contract invocation.
-    pub fn caller(&self) -> srml::Address {
+    pub fn caller(&self) -> srml::AccountId {
         self.caller
     }
 
@@ -349,7 +349,7 @@ impl TestEnv {
     }
 
     /// Sets the caller address for the next contract invocation.
-    pub fn set_caller(new_caller: srml::Address) {
+    pub fn set_caller(new_caller: srml::AccountId) {
         TEST_ENV_DATA.with(|test_env| test_env.borrow_mut().set_caller(new_caller))
     }
 
@@ -368,7 +368,7 @@ impl TestEnv {
 const TEST_ENV_LOG_TARGET: &str = "test-env";
 
 impl EnvTypes for TestEnv {
-    type Address = srml::Address;
+    type AccountId = srml::AccountId;
     type Balance = srml::Balance;
     type Hash = srml::Hash;
 }
@@ -405,10 +405,10 @@ impl EnvStorage for TestEnv {
 
 impl Env for TestEnv
 where
-    <Self as EnvTypes>::Address: for<'a> TryFrom<&'a [u8]>,
+    <Self as EnvTypes>::AccountId: for<'a> TryFrom<&'a [u8]>,
     <Self as EnvTypes>::Hash: for<'a> TryFrom<&'a [u8]>,
 {
-    fn caller() -> <Self as EnvTypes>::Address {
+    fn caller() -> <Self as EnvTypes>::AccountId {
         log::debug!(target: TEST_ENV_LOG_TARGET, "TestEnv::caller()");
         TEST_ENV_DATA.with(|test_env| test_env.borrow().caller())
     }

--- a/core/src/env/traits.rs
+++ b/core/src/env/traits.rs
@@ -23,7 +23,7 @@ use parity_codec::Codec;
 /// The environmental types usable by contracts defined with pDSL.
 pub trait EnvTypes {
     /// The type of an address.
-    type Address: Codec + PartialEq + Eq;
+    type AccountId: Codec + PartialEq + Eq;
     /// The type of balances.
     type Balance: Codec;
     /// The type of hash.
@@ -60,7 +60,7 @@ pub trait EnvStorage {
 /// The environment API usable by contracts defined with pDSL.
 pub trait Env: EnvTypes + EnvStorage {
     /// Returns the chain address of the caller.
-    fn caller() -> <Self as EnvTypes>::Address;
+    fn caller() -> <Self as EnvTypes>::AccountId;
 
     /// Loads input data for contract execution.
     fn input() -> Vec<u8>;

--- a/examples/core/subpeep/README.md
+++ b/examples/core/subpeep/README.md
@@ -18,7 +18,7 @@ Decentralized message distribution inspired by Twitter.
 GLOBAL_PEEPS = [Peep; 10]
 
 // The address for the registered user
-AUTH = mapping Username -> Address
+AUTH = mapping Username -> AccountId
 // All peeps by a single user
 USER_PEEPS = mapping Username -> Vec<Peep>
 // All users that this user is following

--- a/examples/core/subpeep/src/lib.rs
+++ b/examples/core/subpeep/src/lib.rs
@@ -25,7 +25,7 @@ use parity_codec::{
 };
 use ink_core::{
     env::{
-        srml::Address,
+        srml::AccountId,
         ContractEnv,
         Env,
     },
@@ -62,7 +62,7 @@ impl Peep {
 #[derive(Debug, Encode, Decode)]
 pub struct UserData {
     /// Owner address.
-    owner: Address,
+    owner: AccountId,
     /// The peeps.
     peeps: storage::Vec<String>,
     /// The follows.
@@ -75,7 +75,7 @@ impl AllocateUsing for UserData {
         A: ink_core::storage::alloc::Allocate,
     {
         Self {
-            owner: Address::from(&[0x0; 32][..]),
+            owner: AccountId::from(&[0x0; 32][..]),
             peeps: storage::Vec::allocate_using(alloc),
             following: storage::Vec::allocate_using(alloc),
         }
@@ -83,7 +83,7 @@ impl AllocateUsing for UserData {
 }
 
 impl Initialize for UserData {
-    type Args = Address;
+    type Args = AccountId;
 
     fn initialize(&mut self, address: Self::Args) {
         self.owner = address;

--- a/examples/lang/erc20/src/lib.rs
+++ b/examples/lang/erc20/src/lib.rs
@@ -23,7 +23,7 @@ use parity_codec::{
 use ink_core::{
     env::{
         self,
-        Address,
+        AccountId,
         Balance,
     },
     memory::format,
@@ -36,14 +36,14 @@ use ink_lang::contract;
 enum Event {
     /// An approval for allowance was made.
     Approval {
-        from: Address,
-        to: Address,
+        from: AccountId,
+        to: AccountId,
         value: Balance,
     },
     /// A transfer has been done.
     Transfer {
-        from: Option<Address>,
-        to: Option<Address>,
+        from: Option<AccountId>,
+        to: Option<AccountId>,
         value: Balance,
     },
 }
@@ -57,13 +57,13 @@ contract! {
     /// The storage items for a typical ERC20 token implementation.
     struct Erc20 {
         /// All peeps done by all users.
-        balances: storage::HashMap<Address, Balance>,
+        balances: storage::HashMap<AccountId, Balance>,
         /// Balances that are spendable by non-owners.
         ///
         /// # Note
         ///
         /// Mapping: (from, to) -> allowed
-        allowances: storage::HashMap<(Address, Address), Balance>,
+        allowances: storage::HashMap<(AccountId, AccountId), Balance>,
         /// The total supply.
         total_supply: storage::Value<Balance>,
     }
@@ -87,19 +87,19 @@ contract! {
         }
 
         /// Returns the balance of the given address.
-        pub(external) fn balance_of(&self, owner: Address) -> Balance {
+        pub(external) fn balance_of(&self, owner: AccountId) -> Balance {
             let balance = *self.balances.get(&owner).unwrap_or(&0);
             env.println(&format!("Erc20::balance_of(owner = {:?}) = {:?}", owner, balance));
             balance
         }
 
         /// Returns the amount of tokens that an owner allowed to a spender.
-        pub(external) fn allowance(&self, owner: Address, spender: Address) -> Balance {
+        pub(external) fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
             self.allowance_or_zero(&owner, &spender)
         }
 
         /// Transfers token from the sender to the `to` address.
-        pub(external) fn transfer(&mut self, to: Address, value: Balance) -> bool {
+        pub(external) fn transfer(&mut self, to: AccountId, value: Balance) -> bool {
             env.println(&format!(
                 "Erc20::transfer(to = {:?}, value = {:?})",
                 to, value
@@ -109,7 +109,7 @@ contract! {
 
         /// Approve the passed address to spend the specified amount of tokens
         /// on the behalf of the message's sender.
-        pub(external) fn approve(&mut self, spender: Address, value: Balance) -> bool {
+        pub(external) fn approve(&mut self, spender: AccountId, value: Balance) -> bool {
             env.println(&format!(
                 "Erc20::approve(spender = {:?}, value = {:?})",
                 spender, value
@@ -124,7 +124,7 @@ contract! {
         }
 
         /// Transfer tokens from one address to another.
-        pub(external) fn transfer_from(&mut self, from: Address, to: Address, value: Balance) -> bool {
+        pub(external) fn transfer_from(&mut self, from: AccountId, to: AccountId, value: Balance) -> bool {
             env.println(&format!(
                 "Erc20::transfer_from(from: {:?}, to = {:?}, value = {:?})",
                 from, to, value
@@ -135,7 +135,7 @@ contract! {
 
     impl Erc20 {
         /// Decreases the allowance and returns if it was successful.
-        fn try_decrease_allowance(&mut self, from: &Address, to: &Address, by: Balance) -> bool {
+        fn try_decrease_allowance(&mut self, from: &AccountId, to: &AccountId, by: Balance) -> bool {
             // The owner of the coins doesn't need an allowance.
             if &env::caller() == from {
                 return true
@@ -149,7 +149,7 @@ contract! {
         }
 
         /// Returns the allowance or 0 of there is no allowance.
-        fn allowance_or_zero(&self, from: &Address, to: &Address) -> Balance {
+        fn allowance_or_zero(&self, from: &AccountId, to: &AccountId) -> Balance {
             let allowance = self.allowances.get(&(*from, *to)).unwrap_or(&0);
             env::println(&format!(
                 "Erc20::allowance_or_zero(from = {:?}, to = {:?}) = {:?}",
@@ -159,7 +159,7 @@ contract! {
         }
 
         /// Returns the balance of the address or 0 if there is no balance.
-        fn balance_of_or_zero(&self, of: &Address) -> Balance {
+        fn balance_of_or_zero(&self, of: &AccountId) -> Balance {
             let balance = self.balances.get(of).unwrap_or(&0);
             env::println(&format!(
                 "Erc20::balance_of_or_zero(of = {:?}) = {:?}",
@@ -169,7 +169,7 @@ contract! {
         }
 
         /// Transfers token from a specified address to another address.
-        fn transfer_impl(&mut self, from: Address, to: Address, value: Balance) -> bool {
+        fn transfer_impl(&mut self, from: AccountId, to: AccountId, value: Balance) -> bool {
             env::println(&format!(
                 "Erc20::transfer_impl(from = {:?}, to = {:?}, value = {:?})",
                 from, to, value
@@ -193,7 +193,7 @@ contract! {
         ///
         /// If `from` does not have enough balance.
         #[allow(unused)]
-        fn burn_for(&mut self, from: Address, value: Balance) {
+        fn burn_for(&mut self, from: AccountId, value: Balance) {
             let new_balance = self.balance_of_or_zero(&from) - value;
             self.balances.insert(from, new_balance);
             self.total_supply -= value;
@@ -201,7 +201,7 @@ contract! {
         }
 
         /// Increase balance for the receiver out of nowhere.
-        fn mint_for(&mut self, receiver: Address, value: Balance) {
+        fn mint_for(&mut self, receiver: AccountId, value: Balance) {
             env::println(&format!(
                 "Erc20::mint_for(receiver = {:?}, value = {:?})",
                 receiver, value
@@ -216,8 +216,8 @@ contract! {
     impl Erc20 {
         /// Emits an approval event.
         fn emit_approval(
-            from: Address,
-            to: Address,
+            from: AccountId,
+            to: AccountId,
             value: Balance,
         ) {
             assert_ne!(from, to);
@@ -232,8 +232,8 @@ contract! {
             value: Balance,
         )
         where
-            F: Into<Option<Address>>,
-            T: Into<Option<Address>>,
+            F: Into<Option<AccountId>>,
+            T: Into<Option<AccountId>>,
         {
             let (from, to) = (from.into(), to.into());
             assert!(from.is_some() || to.is_some());
@@ -253,8 +253,8 @@ mod tests {
     fn it_works() {
         // `alice` is always the caller in this example!
         let mut erc20 = Erc20::deploy_mock(1234);
-        let alice = Address::try_from([0x0; 32]).unwrap();
-        let bob = Address::try_from([0x1; 32]).unwrap();
+        let alice = AccountId::try_from([0x0; 32]).unwrap();
+        let bob = AccountId::try_from([0x1; 32]).unwrap();
         assert_eq!(erc20.total_supply(), 1234);
         assert_eq!(erc20.balance_of(alice), 1234);
         assert_eq!(erc20.transfer_from(alice, bob, 234), true);

--- a/examples/model/erc20/src/lib.rs
+++ b/examples/model/erc20/src/lib.rs
@@ -18,7 +18,7 @@
 
 use ink_core::{
     env::{
-        Address,
+        AccountId,
         Balance,
     },
     storage,
@@ -34,7 +34,7 @@ state! {
     /// A simple implementation of a rudimentary Erc20 token contract.
     struct Erc20Token {
         /// The balance for an address.
-        balances: storage::HashMap<Address, Balance>,
+        balances: storage::HashMap<AccountId, Balance>,
         /// The total supply.
         total: storage::Value<Balance>
     }
@@ -44,11 +44,11 @@ messages! {
     /// Returns the total supply.
     0 => TotalSupply() -> Balance;
     /// Returns the balance of the given address.
-    1 => BalanceOf(owner: Address) -> Balance;
+    1 => BalanceOf(owner: AccountId) -> Balance;
     /// Transfers balance from the caller to the given address.
     ///
     /// Returns `true` if the transfer was successful.
-    2 => Transfer(to: Address, amount: Balance) -> bool;
+    2 => Transfer(to: AccountId, amount: Balance) -> bool;
 }
 
 #[rustfmt::skip]

--- a/lang/src/api.rs
+++ b/lang/src/api.rs
@@ -93,7 +93,7 @@ pub enum PrimitiveTypeDescription {
     #[serde(rename = "i128")]
     I128,
     /// The SRML address type.
-    Address,
+    AccountId,
     /// The SRML balance type.
     Balance,
 }
@@ -116,7 +116,7 @@ impl TryFrom<&syn::Type> for PrimitiveTypeDescription {
             "i32" => Ok(PrimitiveTypeDescription::I32),
             "i64" => Ok(PrimitiveTypeDescription::I64),
             "i128" => Ok(PrimitiveTypeDescription::I128),
-            "Address" => Ok(PrimitiveTypeDescription::Address),
+            "AccountId" => Ok(PrimitiveTypeDescription::AccountId),
             "Balance" => Ok(PrimitiveTypeDescription::Balance),
             unsupported => {
                 bail!(

--- a/model/src/exec_env.rs
+++ b/model/src/exec_env.rs
@@ -125,7 +125,7 @@ impl Initialize for EnvHandler {
 
 impl EnvHandler {
     /// Returns the caller address of the current smart contract execution.
-    pub fn caller(&self) -> env::Address {
+    pub fn caller(&self) -> env::AccountId {
         env::caller()
     }
 


### PR DESCRIPTION
This should resolve confusions about Address and AccountId encoding/decoding.