### PR TITLE
Make contract! work again

### DIFF
--- a/lang/src/api.rs
+++ b/lang/src/api.rs
@@ -87,8 +87,6 @@ impl TryFrom<&syn::TypePath> for OptionTypeDescription {
     }
 }
 
-}
-
 impl TryFrom<&syn::Type> for TypeDescription {
     type Error = Errors;
 

--- a/model/src/msg.rs
+++ b/model/src/msg.rs
@@ -50,7 +50,7 @@ macro_rules! messages {
 	) => {
 		$( #[$msg_meta] )*
 		#[derive(Copy, Clone)]
-		struct $msg_name;
+		pub(crate) struct $msg_name;
 
 		impl $crate::Message for $msg_name {
 			type Input = ($($param_ty),*);


### PR DESCRIPTION
Make the `contract!` macro work again