### PR TITLE
[examples] Update to show `env.emit` inside non-message function

### DIFF
--- a/examples/lang/events/src/lib.rs
+++ b/examples/lang/events/src/lib.rs
@@ -52,6 +52,12 @@ contract! {
         ///
         /// Also emits an event.
         pub(external) fn dec(&mut self) {
+            self.dec_internal(env);
+        }
+    }
+
+    impl CallCounter {
+        fn dec_internal(&mut self, env: &mut ink_model::EnvHandler) {
             self.count -= 1;
             env.emit(DecCalled { current: *self.count });
         }


### PR DESCRIPTION
Modified the example ever so slightly so that we can show how to do the `env` magic inside non-message functions.