### PR TITLE
Support `Vec` and `Result` types in message interfaces

### DIFF
--- a/lang/src/api.rs
+++ b/lang/src/api.rs
@@ -600,7 +600,7 @@ mod tests {
     }
 
     #[test]
-    fn option_json_err_qualified() {
+    fn option_json_failure() {
         expect_failure(
             parse_quote!(<Self as Foo>::Option<i32>),
             "invalid self qualifier or leading `::` for type",
@@ -609,18 +609,10 @@ mod tests {
             parse_quote!(::Option<i32>),
             "invalid self qualifier or leading `::` for type",
         );
-    }
-
-    #[test]
-    fn option_json_err_too_many_segs() {
         expect_failure(
             parse_quote!(Option<bool, i32>),
             "too many generic args for `Option` type",
         );
-    }
-
-    #[test]
-    fn option_json_err_invalid_params() {
         expect_failure(
             parse_quote!(Option<'a>),
             "invalid generic type args for `Option`",
@@ -628,9 +620,16 @@ mod tests {
     }
 
     #[test]
-    fn option_json() {
+    fn option_json_success() {
         assert_json_roundtrip(parse_quote!(Option<i32>), r#"{"Option<T>":{"T":"i32"}}"#);
-        assert_json_roundtrip(parse_quote!(Option<(bool, i32)>), r#"{"Option<T>":{"T":["bool","i32"]}}"#);
-        assert_json_roundtrip(parse_quote!(Option<Option<i32>>), r#"{"Option<T>":{"T":{"Option<T>":{"T":"i32"}}}}"#);
+        assert_json_roundtrip(
+            parse_quote!(Option<(bool, i32)>),
+            r#"{"Option<T>":{"T":["bool","i32"]}}"#,
+        );
+        assert_json_roundtrip(
+            parse_quote!(Option<Option<i32>>),
+            r#"{"Option<T>":{"T":{"Option<T>":{"T":"i32"}}}}"#,
+        );
+    }
     }
 }

--- a/lang/src/api.rs
+++ b/lang/src/api.rs
@@ -631,5 +631,34 @@ mod tests {
             r#"{"Option<T>":{"T":{"Option<T>":{"T":"i32"}}}}"#,
         );
     }
+
+    #[test]
+    fn vec_json_failure() {
+        expect_failure(
+            parse_quote!(<Self as Foo>::Vec<i32>),
+            "invalid self qualifier or leading `::` for type",
+        );
+        expect_failure(
+            parse_quote!(::Vec<i32>),
+            "invalid self qualifier or leading `::` for type",
+        );
+        expect_failure(
+            parse_quote!(Vec<bool, i32>),
+            "too many generic args for `Vec` type",
+        );
+        expect_failure(parse_quote!(Vec<'a>), "invalid generic type args for `Vec`");
+    }
+
+    #[test]
+    fn vec_json_success() {
+        assert_json_roundtrip(parse_quote!(Vec<i32>), r#"{"Vec<T>":{"T":"i32"}}"#);
+        assert_json_roundtrip(
+            parse_quote!(Vec<(bool, i32)>),
+            r#"{"Vec<T>":{"T":["bool","i32"]}}"#,
+        );
+        assert_json_roundtrip(
+            parse_quote!(Vec<Vec<i32>>),
+            r#"{"Vec<T>":{"T":{"Vec<T>":{"T":"i32"}}}}"#,
+        );
     }
 }

--- a/lang/src/api.rs
+++ b/lang/src/api.rs
@@ -151,21 +151,22 @@ impl TryFrom<&syn::Type> for TypeDescription {
             }
             syn::Type::Path(path) => {
                 if path.path.segments.len() != 1 || path.path.leading_colon.is_some() {
-                    bail!(
-                        path,
-                        "invalid self qualifier or leading `::` for type"
-                    )
+                    bail!(path, "invalid self qualifier or leading `::` for type")
                 }
                 let ident = &path.path.segments[0].ident;
                 match ident.to_owned_string().as_str() {
-                    "Option" => OptionTypeDescription::try_from(path).map(TypeDescription::Option),
-                    _ => PrimitiveTypeDescription::try_from(path).map(TypeDescription::Primitive),
+                    "Option" => {
+                        OptionTypeDescription::try_from(path).map(TypeDescription::Option)
+                    }
+                    // "Result" => ResultTypeDescription::try_from(path).map(TypeDescription::Result),
+                    "Vec" => VecTypeDescription::try_from(path).map(TypeDescription::Vec),
+                    _ => {
+                        PrimitiveTypeDescription::try_from(path)
+                            .map(TypeDescription::Primitive)
+                    }
                 }
             }
-            invalid => bail!(
-                invalid,
-                "invalid or unsupported type",
-            )
+            invalid => bail!(invalid, "invalid or unsupported type",),
         }
     }
 }


### PR DESCRIPTION
This enables support for `Vec<T>` and `Result<T,E>` for message parameters and return types such as:

```rust
pub(external) fn takes_vec(vec: Vec<i32>) -> Result<u32, [u8;10]>;
```

The support for `Option<T>` already came with an earlier commit.