### PR TITLE
[lang] Implement docs parse and codegen for event syntax

### DIFF
--- a/lang/src/ast.rs
+++ b/lang/src/ast.rs
@@ -96,6 +96,7 @@ pub struct ItemEvent {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EventArg {
+    pub attrs: Vec<syn::Attribute>,
     pub ident: Ident,
     pub colon_tok: Token![:],
     pub ty: syn::Type,

--- a/lang/src/gen/build.rs
+++ b/lang/src/gen/build.rs
@@ -113,11 +113,17 @@ fn codegen_for_event_private_mod(tokens: &mut TokenStream2, contract: &hir::Cont
 
 impl quote::ToTokens for hir::Event {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
+        for attr in &self.attrs {
+            attr.to_tokens(tokens)
+        }
         <Token![pub]>::default().to_tokens(tokens);
         <Token![struct]>::default().to_tokens(tokens);
         self.ident.to_tokens(tokens);
         syn::token::Brace::default().surround(tokens, |inner| {
             for arg in self.args.iter() {
+                for attr in &arg.attrs {
+                    attr.to_tokens(inner)
+                }
                 <Token![pub]>::default().to_tokens(inner);
                 arg.to_tokens(inner);
                 <Token![,]>::default().to_tokens(inner);
@@ -139,7 +145,6 @@ fn codegen_for_events(tokens: &mut TokenStream2, contract: &hir::Contract) {
         let ident = &event.ident;
 
         tokens.extend(quote! {
-            /// The documentation for `BalanceChanged`.
             #[derive(parity_codec::Encode, parity_codec::Decode)]
             #event
 

--- a/lang/src/parser.rs
+++ b/lang/src/parser.rs
@@ -323,10 +323,12 @@ impl Parse for ast::ItemEvent {
 
 impl Parse for ast::EventArg {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let attrs = syn::Attribute::parse_outer(input)?;
         let ident = input.parse()?;
         let colon_tok = input.parse()?;
         let ty = input.parse()?;
         Ok(Self {
+            attrs,
             ident,
             colon_tok,
             ty,

--- a/lang/src/tests/events.rs
+++ b/lang/src/tests/events.rs
@@ -31,8 +31,17 @@ fn contract_compiles() {
                 }
             }
 
-            event IncCalled { current: u32 }
-            event DecCalled { current: u32 }
+            /// Fires when the value is incremented.
+            event IncCalled {
+                /// The current value.
+                current: u32
+            }
+
+            /// Fires when the value is decremented.
+            event DecCalled {
+                /// The current value.
+                current: u32
+            }
 
             impl CallCounter {
                 /// Increments the internal counter.
@@ -152,9 +161,10 @@ fn contract_compiles() {
                     pub trait Sealed { }
                 }
 
-                /// The documentation for `BalanceChanged`.
                 #[derive(parity_codec::Encode, parity_codec::Decode)]
+                /// Fires when the value is decremented.
                 pub struct DecCalled {
+                    /// The current value.
                     pub current: u32,
                 }
 
@@ -164,9 +174,10 @@ fn contract_compiles() {
                     }
                 }
 
-                /// The documentation for `BalanceChanged`.
                 #[derive(parity_codec::Encode, parity_codec::Decode)]
+                /// Fires when the value is incremented.
                 pub struct IncCalled {
+                    /// The current value.
                     pub current: u32,
                 }
 


### PR DESCRIPTION
Events written in the new event syntax were not able to be documented by the user.
Parsing and code gen is implemented in this PR.