### PR TITLE
[chores] Remove `wasm-opt` from build script

### DIFF
--- a/cli/template/build.sh
+++ b/cli/template/build.sh
@@ -11,5 +11,4 @@ cargo build --release --features generate-api-description --target=wasm32-unknow
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
-wasm-prune --exports call,deploy target/$PROJNAME-opt.wasm target/$PROJNAME-pruned.wasm
+wasm-prune --exports call,deploy target/$PROJNAME.wasm target/$PROJNAME-pruned.wasm

--- a/examples/core/erc20/build.sh
+++ b/examples/core/erc20/build.sh
@@ -14,6 +14,5 @@ CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verb
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
 
 #wasm-build target enyzme --target-runtime=substrate --final=adder --save-raw=./target/enzyme-deployed.wasm --target wasm32-unknown-unknown

--- a/examples/core/incrementer/build.sh
+++ b/examples/core/incrementer/build.sh
@@ -12,6 +12,5 @@ CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verb
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
 
 #wasm-build target enyzme --target-runtime=substrate --final=adder --save-raw=./target/enzyme-deployed.wasm --target wasm32-unknown-unknown

--- a/examples/core/noop/build.sh
+++ b/examples/core/noop/build.sh
@@ -12,6 +12,5 @@ CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verb
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
 
 #wasm-build target enyzme --target-runtime=substrate --final=adder --save-raw=./target/enzyme-deployed.wasm --target wasm32-unknown-unknown

--- a/examples/core/subpeep/build.sh
+++ b/examples/core/subpeep/build.sh
@@ -12,6 +12,5 @@ CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verb
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
 
 #wasm-build target enyzme --target-runtime=substrate --final=adder --save-raw=./target/enzyme-deployed.wasm --target wasm32-unknown-unknown

--- a/examples/lang/erc20/build.sh
+++ b/examples/lang/erc20/build.sh
@@ -9,5 +9,4 @@ CARGO_INCREMENTAL=0 cargo build --release --features generate-api-description --
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
-wasm-prune --exports call,deploy target/$PROJNAME-opt.wasm target/$PROJNAME-pruned.wasm
+wasm-prune --exports call,deploy target/$PROJNAME.wasm target/$PROJNAME-pruned.wasm

--- a/examples/lang/events/build.sh
+++ b/examples/lang/events/build.sh
@@ -9,5 +9,4 @@ CARGO_INCREMENTAL=0 cargo build --release --features generate-api-description --
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
-wasm-prune --exports call,deploy target/$PROJNAME-opt.wasm target/$PROJNAME-pruned.wasm
+wasm-prune --exports call,deploy target/$PROJNAME.wasm target/$PROJNAME-pruned.wasm

--- a/examples/lang/flipper/build.sh
+++ b/examples/lang/flipper/build.sh
@@ -9,5 +9,4 @@ CARGO_INCREMENTAL=0 cargo build --release --features generate-api-description --
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
-wasm-prune --exports call,deploy target/$PROJNAME-opt.wasm target/$PROJNAME-pruned.wasm
+wasm-prune --exports call,deploy target/$PROJNAME.wasm target/$PROJNAME-pruned.wasm

--- a/examples/lang/incrementer/build.sh
+++ b/examples/lang/incrementer/build.sh
@@ -7,5 +7,4 @@ cargo +nightly build --release --features generate-api-description --target=wasm
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm &&
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat &&
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat &&
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
-wasm-prune --exports call,deploy target/$PROJNAME-opt.wasm target/$PROJNAME-pruned.wasm
+wasm-prune --exports call,deploy target/$PROJNAME.wasm target/$PROJNAME-pruned.wasm

--- a/examples/lang/shared_vec/build.sh
+++ b/examples/lang/shared_vec/build.sh
@@ -7,5 +7,4 @@ cargo +nightly build --release --features generate-api-description --target=wasm
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm &&
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat &&
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat &&
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
-wasm-prune --exports call,deploy target/$PROJNAME-opt.wasm target/$PROJNAME-pruned.wasm
+wasm-prune --exports call,deploy target/$PROJNAME.wasm target/$PROJNAME-pruned.wasm

--- a/examples/model/erc20/build.sh
+++ b/examples/model/erc20/build.sh
@@ -12,6 +12,5 @@ CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verb
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
 
 #wasm-build target enyzme --target-runtime=substrate --final=adder --save-raw=./target/enzyme-deployed.wasm --target wasm32-unknown-unknown

--- a/examples/model/incrementer/build.sh
+++ b/examples/model/incrementer/build.sh
@@ -12,6 +12,5 @@ CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verb
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat
-wasm-opt -Oz target/$PROJNAME.wasm -o target/$PROJNAME-opt.wasm
 
 #wasm-build target enyzme --target-runtime=substrate --final=adder --save-raw=./target/enzyme-deployed.wasm --target wasm32-unknown-unknown


### PR DESCRIPTION
After discussion, we determined that `wasm-opt` is not yet stable/reliable enough to be used in our pipeline.

Docs to be updated following this change.