### PR TITLE
Attempt to replicate dyn_alloc trapping on deployment

### DIFF
--- a/examples/lang/flipper/src/lib.rs
+++ b/examples/lang/flipper/src/lib.rs
@@ -60,12 +60,12 @@ contract! {
                 dyn_alloc
             };
 
-            for _ in 0..100 {
+            for _ in 0..3010 {
                 let mut inner_vec = unsafe {
                     Vec::<i32>::allocate_using(&mut alloc).initialize_into(())
                 };
 
-                for _ in 0..201 {
+                for _ in 0..3 {
                     inner_vec.push(1);
                 }
                 self.outer_vec.push(inner_vec);

--- a/examples/lang/flipper/src/lib.rs
+++ b/examples/lang/flipper/src/lib.rs
@@ -59,7 +59,6 @@ contract! {
                 dyn_alloc.initialize(());
                 dyn_alloc
             };
-            let mut alloc = unsafe { BumpAlloc::from_raw_parts(Key([0x0; 32])) };
 
             for _ in 0..100 {
                 let mut inner_vec = unsafe {

--- a/examples/lang/flipper/src/lib.rs
+++ b/examples/lang/flipper/src/lib.rs
@@ -52,7 +52,11 @@ contract! {
     impl Flipper {
         /// Flips the current state of our smart contract.
         pub(external) fn flip(&mut self) {
-            println(&format!("flip"));
+            *self.value = !*self.value;
+        }
+
+        /// Push some dynamically allocated entries.
+        pub(external) fn push_some(&mut self) {
             let mut alloc = unsafe {
                 let mut fw_alloc = storage::alloc::BumpAlloc::from_raw_parts(Key([0x0; 32]));
                 let mut dyn_alloc = storage::alloc::DynAlloc::allocate_using(&mut fw_alloc);
@@ -60,24 +64,40 @@ contract! {
                 dyn_alloc
             };
 
-            for _ in 0..3010 {
+            // Uncomment to test with BumpAlloc instead
+            // let mut alloc = unsafe { BumpAlloc::from_raw_parts(Key([0x0; 32])) };
+
+            for i in 0..1000 {
                 let mut inner_vec = unsafe {
                     Vec::<i32>::allocate_using(&mut alloc).initialize_into(())
                 };
 
+                println(&format!("Inner Vec about to push 3 elts: {:?}", i));
                 for _ in 0..3 {
                     inner_vec.push(1);
                 }
                 self.outer_vec.push(inner_vec);
+                println(&format!("Outer Vec len after pushing inner vec: {:?}", self.outer_vec.len()));
             }
             println(&format!("Outer Vec len after pushing: {:?}", self.outer_vec.len()));
+        }
 
-            for _ in 0..self.outer_vec.len() {
+        /// Pop some dynamically allocated entries.
+        pub(external) fn pop_some(&mut self) {
+            for a in 0..200 {
+                println(&format!("Outer Vec about to pop: {:?}", a));
                 self.outer_vec.pop();
             }
             println(&format!("Outer Vec len after popping: {:?}", self.outer_vec.len()));
+        }
 
-            *self.value = !*self.value;
+        /// Pop all dynamically allocated entries.
+        pub(external) fn pop_all(&mut self) {
+            for a in 0..self.outer_vec.len() {
+                println(&format!("Outer Vec about to pop: {:?}", a));
+                self.outer_vec.pop();
+            }
+            println(&format!("Outer Vec len after popping: {:?}", self.outer_vec.len()));
         }
 
         /// Returns the current state.

--- a/model/src/exec_env.rs
+++ b/model/src/exec_env.rs
@@ -20,7 +20,7 @@ use ink_core::{
     storage::alloc::{
         Allocate,
         AllocateUsing,
-        CellChunkAlloc,
+        DynAlloc,
         Initialize,
     },
 };
@@ -101,7 +101,7 @@ impl<State> ExecutionEnv<State> {
 /// allocations and deallocations.
 pub struct EnvHandler {
     /// The dynamic allocator.
-    pub dyn_alloc: CellChunkAlloc,
+    pub dyn_alloc: DynAlloc,
 }
 
 impl AllocateUsing for EnvHandler {


### PR DESCRIPTION
Do not merge!

This is my attempt at replicating the bug from #37. I didn't manage to replicate it, though according to private conversations this should have been sufficient. What I did:

* Modify `flipper` to repeatedly dynamically allocate entries in the vector and deallocate them again (by popping). In total 20.100 items are pushed into the vecs before deallocation begins.
* Modify substrate: deactivate check for `block production took too long`, increase endowment in genesis block hugely, decrease gas/rent/etc. price.
* Deploy contract, create instance and call flipper with generous endowment (`9999999`).

The transaction goes through successfully and I see this output from substrate:
```
...
Runtime: Outer Vec len after pushing: 100
Runtime: Outer Vec len after popping: 0
...
```