### PR TITLE
Fix flush

### DIFF
--- a/core/src/env/test_env.rs
+++ b/core/src/env/test_env.rs
@@ -387,7 +387,7 @@ thread_local! {
     /// The test environment data.
     ///
     /// This needs to be thread local since tests are run
-    /// in paralell by default which may lead to data races otherwise.
+    /// in parallel by default which may lead to data races otherwise.
     pub static TEST_ENV_DATA: RefCell<TestEnvData> = {
         RefCell::new(TestEnvData::default())
     };

--- a/core/src/storage/alloc/dyn_alloc.rs
+++ b/core/src/storage/alloc/dyn_alloc.rs
@@ -32,7 +32,7 @@ use crate::storage::{
 /// Searches for free cells and chunks via first-fit approach which
 /// can be slow (more than 2 reads) for more than 3000 dynamic allocations
 /// at the same time. This is subject to change in the future if
-/// experiments show that this is a bottle neck.
+/// experiments show that this is a bottleneck.
 #[derive(Debug)]
 pub struct DynAlloc {
     /// Bitmap indicating free cell slots.

--- a/core/src/storage/chunk/sync_chunk/chunk.rs
+++ b/core/src/storage/chunk/sync_chunk/chunk.rs
@@ -27,7 +27,7 @@ use crate::storage::{
 
 /// A chunk of synchronized cells.
 ///
-/// Provides mutable and read-optimized access to the associated constract storage slot.
+/// Provides mutable and read-optimized access to the associated contract storage slot.
 ///
 /// # Guarantees
 ///

--- a/core/src/storage/chunk/sync_chunk/chunk.rs
+++ b/core/src/storage/chunk/sync_chunk/chunk.rs
@@ -48,11 +48,12 @@ pub struct SyncChunk<T> {
 impl<T> Flush for SyncChunk<T>
 where
     T: parity_codec::Encode,
+    T: Flush,
 {
     fn flush(&mut self) {
         for (n, dirty_val) in self.cache.iter_dirty() {
-            match dirty_val.get() {
-                Some(val) => self.chunk.store(n, val),
+            match dirty_val.get_mut() {
+                Some(val) => val.flush_at(self.chunk.cells_key() + n),
                 None => self.chunk.clear(n),
             }
             dirty_val.mark_clean();

--- a/core/src/storage/chunk/typed_chunk.rs
+++ b/core/src/storage/chunk/typed_chunk.rs
@@ -113,7 +113,7 @@ impl<T> parity_codec::Decode for TypedChunk<T> {
 }
 
 impl<T> TypedChunk<T> {
-    /// Returns the unterlying key to the cells.
+    /// Returns the underlying key to the cells.
     ///
     /// # Note
     ///

--- a/core/src/storage/collections/bitvec/block.rs
+++ b/core/src/storage/collections/bitvec/block.rs
@@ -19,6 +19,10 @@ use parity_codec::{
     Decode,
     Encode,
 };
+use crate::storage::{
+    Flush,
+    Key
+};
 
 /// A block of 1024 bits.
 #[derive(Debug, Copy, Clone, Encode, Decode)]
@@ -125,6 +129,14 @@ impl BitBlock {
             }
         }
         None
+    }
+}
+
+impl Flush for BitBlock where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
     }
 }
 

--- a/core/src/storage/collections/hash_map/impls.rs
+++ b/core/src/storage/collections/hash_map/impls.rs
@@ -18,6 +18,7 @@
 // This might change in future versions of the pDSL.
 #![allow(clippy::implicit_hasher)]
 
+use parity_codec::Encode;
 use crate::storage::{
     self,
     alloc::{
@@ -26,6 +27,7 @@ use crate::storage::{
         Initialize,
     },
     chunk::SyncChunk,
+    Key,
     Flush,
 };
 use core::{
@@ -75,6 +77,14 @@ pub enum Entry<K, V> {
     Occupied(OccupiedEntry<K, V>),
     /// A removed slot that was occupied before.
     Removed,
+}
+
+impl<K, V> Flush for Entry<K, V> where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
 }
 
 /// An occupied entry of a storage map.

--- a/core/src/storage/collections/stash/impls.rs
+++ b/core/src/storage/collections/stash/impls.rs
@@ -82,6 +82,14 @@ struct StashHeader {
     max_len: u32,
 }
 
+impl Flush for StashHeader where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
+}
+
 /// Iterator over the values of a stash.
 #[derive(Debug)]
 pub struct Values<'a, T> {
@@ -220,6 +228,14 @@ enum Entry<T> {
     Vacant(u32),
     /// An occupied entry containing the value.
     Occupied(T),
+}
+
+impl<T> Flush for Entry<T> where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
 }
 
 impl<T> Encode for Stash<T> {

--- a/core/src/storage/flush.rs
+++ b/core/src/storage/flush.rs
@@ -31,7 +31,83 @@
 /// All abstractions built upon them that do not have their own caching mechanism
 /// shall simply forward flushing to their interiors. Examples for this are
 /// `storage::Vec` or `storage::Value`.
+
+use parity_codec::Encode;
+use crate::storage::key::Key;
+
 pub trait Flush {
     /// Flushes the cached state back to the contract storage, if any.
-    fn flush(&mut self);
+    fn flush(&mut self) {
+        unreachable!();
+    }
+
+    /// Default implementation which forwards to flush.
+    /// This realizes recursive behavior for e.g. nested vectors.
+    fn flush_at(&mut self, _at: Key) {
+        self.flush();
+    }
+}
+
+impl Flush for i8 where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
+}
+
+impl Flush for i16 where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
+}
+
+impl Flush for i32 where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
+}
+
+impl Flush for i64 where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
+}
+
+impl Flush for u16 where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
+}
+
+impl Flush for u32 where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
+}
+
+impl Flush for u64 where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
+}
+
+impl Flush for bool where Self: Encode {
+    fn flush_at(&mut self, at: Key) {
+        unsafe {
+            crate::env::store(at, &self.encode()[..]);
+        }
+    }
 }

--- a/core/src/storage/key.rs
+++ b/core/src/storage/key.rs
@@ -103,7 +103,7 @@ impl core::ops::Sub for Key {
 
 /// The difference between two keys.
 ///
-/// This is the result of substracting one key from another.
+/// This is the result of subtracting one key from another.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyDiff([u8; 32]);
 

--- a/core/src/storage/mod.rs
+++ b/core/src/storage/mod.rs
@@ -24,7 +24,7 @@
 //! |:-------------|:------------|
 //! | `Owned`      | Disallows aliasing between different kinds of these primitives. |
 //! | `Typed`      | Automatically encodes and decodes the stored entity. |
-//! | `Opt. Reads` | Tries to avoid unnecesary reads to the storage. |
+//! | `Opt. Reads` | Tries to avoid unnecessary reads to the storage. |
 //! | `Mutable`    | Allows inplace mutation of the stored entity. |
 //! | `Safe Load`  | Guarantees to always have a valid element stored in the associated contract storage slot. |
 //!
@@ -45,7 +45,7 @@
 //!
 //! ### Entities
 //!
-//! The highest-level abstraction concerning constract storage primitive.
+//! The highest-level abstraction concerning contract storage primitive.
 //!
 //! They provide the most guarantees and should be preferred over the other
 //! primitive types if possible.

--- a/model/src/contract.rs
+++ b/model/src/contract.rs
@@ -232,7 +232,7 @@ where
 {
     /// Creates an instance of the contract declaration.
     ///
-    /// This assocates the state with the contract storage
+    /// This associates the state with the contract storage
     /// and defines its layout.
     pub fn instantiate(self) -> ContractInstance<State, DeployArgs, HandlerChain> {
         use ink_core::storage::{

--- a/model/src/contract.rs
+++ b/model/src/contract.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use core::marker::PhantomData;
 use ink_core::memory::vec::Vec;
-// Copyright {d+}-{d+} Parity Technologies (UK) Ltd.
+
 /// A marker struct to tell that the deploy handler requires no arguments.
 #[derive(Copy, Clone)]
 pub struct NoDeployArgs;


### PR DESCRIPTION
This implements recursive behavior for `flush()`, which is an issue discovered while investigating #37 and also brought up in #113.

I'm a bit unsure for which primitive types we should provide implementations of `flush()`. AFAIK `u8` substrate avoids usage of `u8`, `usize`, `isize` and floating points, due to different behaviors of different architectures.

I would have liked to add better tests (also asserting that the content is correct and not just the number of writes), but it seems that `test_env` is currently a bit limited. The other tests also don't do any "deep inspection". After trying it for a bit I settled on the easier tests for now, but maybe we can keep this in mind for the future (or create a follow up).