### PR TITLE
Add ExtCurrentBlockNumber and BlockNumber EnvTypes.

### DIFF
--- a/core/src/env/srml/srml_only/impls.rs
+++ b/core/src/env/srml/srml_only/impls.rs
@@ -89,6 +89,7 @@ where
     type Balance = <T as EnvTypes>::Balance;
     type Hash = <T as EnvTypes>::Hash;
     type Moment = <T as EnvTypes>::Moment;
+    type BlockNumber = <T as EnvTypes>::BlockNumber;
 }
 
 macro_rules! impl_getters_for_srml_env {
@@ -122,6 +123,7 @@ where
         (caller, ext_caller, <Self as EnvTypes>::AccountId),
         (random_seed, ext_random_seed, <Self as EnvTypes>::Hash),
         (now, ext_now, <Self as EnvTypes>::Moment),
+        (current_block, ext_current_block, <Self as EnvTypes>::BlockNumber),
         (gas_price, ext_gas_price, <Self as EnvTypes>::Balance),
         (gas_left, ext_gas_left, <Self as EnvTypes>::Balance),
         (value_transferred, ext_value_transferred, <Self as EnvTypes>::Balance)

--- a/core/src/env/srml/srml_only/sys.rs
+++ b/core/src/env/srml/srml_only/sys.rs
@@ -114,4 +114,7 @@ extern "C" {
 
     /// Load the latest block timestamp into the scratch buffer.
     pub fn ext_now();
+
+    /// Load the latest block number into the scratch buffer.
+    pub fn ext_current_block();
 }

--- a/core/src/env/srml/types.rs
+++ b/core/src/env/srml/types.rs
@@ -34,6 +34,7 @@ impl EnvTypes for DefaultSrmlTypes {
     type Balance = Balance;
     type Hash = Hash;
     type Moment = Moment;
+    type BlockNumber = BlockNumber;
 }
 
 /// The default SRML address type.
@@ -79,3 +80,6 @@ impl<'a> TryFrom<&'a [u8]> for Hash {
 
 /// The default SRML moment type.
 pub type Moment = u64;
+
+/// The default SRML blocknumber type.
+pub type BlockNumber = u64;

--- a/core/src/env/test_env.rs
+++ b/core/src/env/test_env.rs
@@ -208,6 +208,7 @@ impl TestEnvData {
         self.input.clear();
         self.random_seed.clear();
         self.now.clear();
+        self.current_block.clear();
         self.expected_return.clear();
         self.total_reads.set(0);
         self.total_writes = 0;

--- a/core/src/env/test_env.rs
+++ b/core/src/env/test_env.rs
@@ -150,6 +150,12 @@ pub struct TestEnvData {
     ///
     /// The current timestamp can be adjusted by `TestEnvData::set_now`.
     now: Vec<u8>,
+    /// The current block number for the next contract invocation.
+    ///
+    /// # Note
+    ///
+    /// The current current block number can be adjusted by `TestEnvData::set_current_block`.
+    current_block: Vec<u8>,
     /// The expected return data of the next contract invocation.
     ///
     /// # Note
@@ -180,6 +186,7 @@ impl Default for TestEnvData {
             input: Vec::new(),
             random_seed: Vec::new(),
             now: Vec::new(),
+            current_block: Vec::new(),
             expected_return: Vec::new(),
             total_reads: Cell::new(0),
             total_writes: 0,
@@ -281,6 +288,11 @@ impl TestEnvData {
         self.now = timestamp;
     }
 
+    /// Sets the current block number for the next contract invocation.
+    pub fn set_current_block(&mut self, current_block: Vec<u8>) {
+        self.current_block = current_block;
+    }
+
     /// Returns an iterator over all emitted events.
     pub fn emitted_events(&self) -> impl Iterator<Item = &[u8]> {
         self.events
@@ -348,6 +360,10 @@ impl TestEnvData {
 
     pub fn now(&self) -> Vec<u8> {
         self.now.clone()
+    }
+
+    pub fn current_block(&self) -> Vec<u8> {
+        self.current_block.clone()
     }
 
     pub fn gas_price(&self) -> Vec<u8> {
@@ -438,7 +454,8 @@ impl<T> TestEnv<T> where T: EnvTypes {
         (set_balance, balance, T::Balance),
         (set_caller, caller, T::AccountId),
         (set_random_seed, random_seed, T::Hash),
-        (set_now, now, T::Moment)
+        (set_now, now, T::Moment),
+        (set_current_block, current_block, T::BlockNumber)
     );
 
     /// Returns an iterator over all emitted events.
@@ -473,6 +490,7 @@ where
     type Balance = <T as EnvTypes>::Balance;
     type Hash = <T as EnvTypes>::Hash;
     type Moment = <T as EnvTypes>::Moment;
+    type BlockNumber = <T as EnvTypes>::BlockNumber;
 }
 
 impl<T> Env for TestEnv<T> where T: EnvTypes
@@ -484,6 +502,7 @@ impl<T> Env for TestEnv<T> where T: EnvTypes
         (input, Vec<u8>),
         (random_seed, T::Hash),
         (now, T::Moment),
+        (current_block, T::BlockNumber),
         (gas_price, T::Balance),
         (gas_left, T::Balance),
         (value_transferred, T::Balance)

--- a/core/src/env/traits.rs
+++ b/core/src/env/traits.rs
@@ -31,6 +31,8 @@ pub trait EnvTypes {
     type Hash: Codec + Clone + PartialEq + Eq;
     /// The type of timestamps.
     type Moment: Codec + Clone + PartialEq + Eq;
+    /// The type of block number.
+    type BlockNumber: Codec + Clone + PartialEq + Eq;
 }
 
 #[cfg(feature = "test-env")]
@@ -44,6 +46,8 @@ pub trait EnvTypes {
     type Hash: Codec + Clone + PartialEq + Eq + core::fmt::Debug;
     /// The type of timestamps.
     type Moment: Codec + Clone + PartialEq + Eq + core::fmt::Debug;
+    /// The type of block number.
+    type BlockNumber: Codec + Clone + PartialEq + Eq + core::fmt::Debug;
 }
 
 /// Types implementing this can act as contract storage.
@@ -92,6 +96,9 @@ pub trait Env: EnvTypes {
 
     /// Get the timestamp of the latest block.
     fn now() -> <Self as EnvTypes>::Moment;
+
+    /// Get the block number of the latest block.
+    fn current_block() -> <Self as EnvTypes>::BlockNumber;
 
     /// Returns the current gas price.
     fn gas_price() -> <Self as EnvTypes>::Balance;

--- a/lang/src/api.rs
+++ b/lang/src/api.rs
@@ -267,6 +267,8 @@ pub enum PrimitiveTypeDescription {
     Hash,
     /// The SRML moment type.
     Moment,
+    /// The SRML block number type.
+    BlockNumber,
 }
 
 impl TryFrom<&syn::TypePath> for PrimitiveTypeDescription {
@@ -291,6 +293,7 @@ impl TryFrom<&syn::TypePath> for PrimitiveTypeDescription {
             "Balance" => Ok(PrimitiveTypeDescription::Balance),
             "Hash" => Ok(PrimitiveTypeDescription::Hash),
             "Moment" => Ok(PrimitiveTypeDescription::Moment),
+            "BlockNumber" => Ok(PrimitiveTypeDescription::BlockNumber),
             unsupported => {
                 bail!(
                     ty,
@@ -582,6 +585,10 @@ mod tests {
         assert_eq_type_description(
             parse_quote!(Moment),
             Primitive(PrimitiveTypeDescription::Moment),
+        );
+        assert_eq_type_description(
+            parse_quote!(BlockNumber),
+            Primitive(PrimitiveTypeDescription::BlockNumber),
         );
     }
 

--- a/lang/src/gen/build.rs
+++ b/lang/src/gen/build.rs
@@ -60,7 +60,7 @@ fn codegen_for_contract_env(tokens: &mut TokenStream2, contract: &hir::Contract)
             pub type Balance = <ContractEnv<#env_types> as EnvTypes>::Balance;
             pub type Hash = <ContractEnv<#env_types> as EnvTypes>::Hash;
             pub type Moment = <ContractEnv<#env_types> as EnvTypes>::Moment;
-            pub type BlockNumber = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::BlockNumber;
+            pub type BlockNumber = <ContractEnv<#env_types> as EnvTypes>::BlockNumber;
         }
 
         use types::{

--- a/lang/src/gen/build.rs
+++ b/lang/src/gen/build.rs
@@ -60,6 +60,7 @@ fn codegen_for_contract_env(tokens: &mut TokenStream2, contract: &hir::Contract)
             pub type Balance = <ContractEnv<#env_types> as EnvTypes>::Balance;
             pub type Hash = <ContractEnv<#env_types> as EnvTypes>::Hash;
             pub type Moment = <ContractEnv<#env_types> as EnvTypes>::Moment;
+            pub type BlockNumber = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::BlockNumber;
         }
 
         use types::{
@@ -67,6 +68,7 @@ fn codegen_for_contract_env(tokens: &mut TokenStream2, contract: &hir::Contract)
             Balance,
             Hash,
             Moment,
+            BlockNumber,
         };
     })
 }

--- a/lang/src/tests/events.rs
+++ b/lang/src/tests/events.rs
@@ -76,6 +76,7 @@ fn contract_compiles() {
                 pub type Balance = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Balance;
                 pub type Hash = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Hash;
                 pub type Moment = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Moment;
+                pub type BlockNumber = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::BlockNumber;
             }
 
             use types::{
@@ -83,6 +84,7 @@ fn contract_compiles() {
                 Balance,
                 Hash,
                 Moment,
+                BlockNumber,
             };
 
             ink_model::state! {

--- a/lang/src/tests/flipper.rs
+++ b/lang/src/tests/flipper.rs
@@ -56,6 +56,7 @@ fn contract_compiles() {
                 pub type Balance = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Balance;
                 pub type Hash = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Hash;
                 pub type Moment = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Moment;
+                pub type BlockNumber = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::BlockNumber;
             }
 
             use types::{
@@ -63,6 +64,7 @@ fn contract_compiles() {
                 Balance,
                 Hash,
                 Moment,
+                BlockNumber,
             };
 
             ink_model::state! {

--- a/lang/src/tests/incrementer.rs
+++ b/lang/src/tests/incrementer.rs
@@ -62,6 +62,7 @@ fn contract_compiles() {
                 pub type Balance = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Balance;
                 pub type Hash = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Hash;
                 pub type Moment = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Moment;
+                pub type BlockNumber = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::BlockNumber;
             }
 
             use types::{
@@ -69,6 +70,7 @@ fn contract_compiles() {
                 Balance,
                 Hash,
                 Moment,
+                BlockNumber,
             };
 
             ink_model::state! {

--- a/lang/src/tests/noop.rs
+++ b/lang/src/tests/noop.rs
@@ -46,6 +46,7 @@ fn contract_compiles() {
                 pub type Balance = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Balance;
                 pub type Hash = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Hash;
                 pub type Moment = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::Moment;
+                pub type BlockNumber = <ContractEnv<DefaultSrmlTypes> as EnvTypes>::BlockNumber;
             }
 
             use types::{
@@ -53,6 +54,7 @@ fn contract_compiles() {
                 Balance,
                 Hash,
                 Moment,
+                BlockNumber,
             };
 
             ink_model::state! {

--- a/model/src/exec_env.rs
+++ b/model/src/exec_env.rs
@@ -176,4 +176,8 @@ impl<T: Env> EnvHandler<T> {
     pub fn now(&self) -> T::Moment {
         T::now()
     }
+
+    pub fn current_block(&self) -> T::BlockNumber {
+        T::current_block()
+    }
 }


### PR DESCRIPTION
# What does it do?
We want to call current block number from contracts. So, I implement ext_current_block methods in srml::contract.
ext_current_block means that gets base chains current block number.

Dependence PR: https://github.com/paritytech/substrate/pull/3047