### PR TITLE
HotFix `current_block` method name changes to `block_number`.

### DIFF
--- a/core/src/env/srml/srml_only/impls.rs
+++ b/core/src/env/srml/srml_only/impls.rs
@@ -123,7 +123,7 @@ where
         (caller, ext_caller, <Self as EnvTypes>::AccountId),
         (random_seed, ext_random_seed, <Self as EnvTypes>::Hash),
         (now, ext_now, <Self as EnvTypes>::Moment),
-        (current_block, ext_current_block, <Self as EnvTypes>::BlockNumber),
+        (block_number, ext_block_number, <Self as EnvTypes>::BlockNumber),
         (gas_price, ext_gas_price, <Self as EnvTypes>::Balance),
         (gas_left, ext_gas_left, <Self as EnvTypes>::Balance),
         (value_transferred, ext_value_transferred, <Self as EnvTypes>::Balance)

--- a/core/src/env/srml/srml_only/sys.rs
+++ b/core/src/env/srml/srml_only/sys.rs
@@ -116,5 +116,5 @@ extern "C" {
     pub fn ext_now();
 
     /// Load the latest block number into the scratch buffer.
-    pub fn ext_current_block();
+    pub fn ext_block_number();
 }

--- a/core/src/env/test_env.rs
+++ b/core/src/env/test_env.rs
@@ -154,8 +154,8 @@ pub struct TestEnvData {
     ///
     /// # Note
     ///
-    /// The current current block number can be adjusted by `TestEnvData::set_current_block`.
-    current_block: Vec<u8>,
+    /// The current current block number can be adjusted by `TestEnvData::set_block_number`.
+    block_number: Vec<u8>,
     /// The expected return data of the next contract invocation.
     ///
     /// # Note
@@ -186,7 +186,7 @@ impl Default for TestEnvData {
             input: Vec::new(),
             random_seed: Vec::new(),
             now: Vec::new(),
-            current_block: Vec::new(),
+            block_number: Vec::new(),
             expected_return: Vec::new(),
             total_reads: Cell::new(0),
             total_writes: 0,
@@ -208,7 +208,7 @@ impl TestEnvData {
         self.input.clear();
         self.random_seed.clear();
         self.now.clear();
-        self.current_block.clear();
+        self.block_number.clear();
         self.expected_return.clear();
         self.total_reads.set(0);
         self.total_writes = 0;
@@ -290,8 +290,8 @@ impl TestEnvData {
     }
 
     /// Sets the current block number for the next contract invocation.
-    pub fn set_current_block(&mut self, current_block: Vec<u8>) {
-        self.current_block = current_block;
+    pub fn set_block_number(&mut self, block_number: Vec<u8>) {
+        self.block_number = block_number;
     }
 
     /// Returns an iterator over all emitted events.
@@ -363,8 +363,8 @@ impl TestEnvData {
         self.now.clone()
     }
 
-    pub fn current_block(&self) -> Vec<u8> {
-        self.current_block.clone()
+    pub fn block_number(&self) -> Vec<u8> {
+        self.block_number.clone()
     }
 
     pub fn gas_price(&self) -> Vec<u8> {
@@ -456,7 +456,7 @@ impl<T> TestEnv<T> where T: EnvTypes {
         (set_caller, caller, T::AccountId),
         (set_random_seed, random_seed, T::Hash),
         (set_now, now, T::Moment),
-        (set_current_block, current_block, T::BlockNumber)
+        (set_block_number, block_number, T::BlockNumber)
     );
 
     /// Returns an iterator over all emitted events.
@@ -503,7 +503,7 @@ impl<T> Env for TestEnv<T> where T: EnvTypes
         (input, Vec<u8>),
         (random_seed, T::Hash),
         (now, T::Moment),
-        (current_block, T::BlockNumber),
+        (block_number, T::BlockNumber),
         (gas_price, T::Balance),
         (gas_left, T::Balance),
         (value_transferred, T::Balance)

--- a/core/src/env/traits.rs
+++ b/core/src/env/traits.rs
@@ -98,7 +98,7 @@ pub trait Env: EnvTypes {
     fn now() -> <Self as EnvTypes>::Moment;
 
     /// Get the block number of the latest block.
-    fn current_block() -> <Self as EnvTypes>::BlockNumber;
+    fn block_number() -> <Self as EnvTypes>::BlockNumber;
 
     /// Returns the current gas price.
     fn gas_price() -> <Self as EnvTypes>::Balance;

--- a/model/src/exec_env.rs
+++ b/model/src/exec_env.rs
@@ -177,7 +177,7 @@ impl<T: Env> EnvHandler<T> {
         T::now()
     }
 
-    pub fn current_block(&self) -> T::BlockNumber {
-        T::current_block()
+    pub fn block_number(&self) -> T::BlockNumber {
+        T::block_number()
     }
 }


### PR DESCRIPTION
I implemented `current_block` method on ink!. (ref: https://github.com/paritytech/ink/pull/132)

At the same time, I implemented the `ext_current_block` method in srml::contract. At that time, It is requested changes, method name changes `block_number` from `current_block`.
(ref: https://github.com/paritytech/substrate/pull/3047#issuecomment-509992239)

Sorry for your inconvenience but please review again. @Robbepop @ascjones 