### PR TITLE
Make std crate feature default for all ink crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,11 @@ before_script:
 script:
 - |
   cargo check --verbose --all --all-features &&
-  cargo fmt --verbose --all -- --check
+  cargo check --verbose --all --no-default-features &&
+  cargo fmt --verbose --all -- --check &&
   cargo clippy --verbose --all --all-features -- -D warnings &&
+  cargo clippy --verbose --all --no-default-features -- -D warnings &&
   cargo test --verbose --all --all-features &&
   cargo kcov --verbose --coveralls --all --no-clean-rebuild &&
-  cargo build --verbose --all --release --target=wasm32-unknown-unknown &&
+  cargo build --verbose --all --no-default-features --release --target=wasm32-unknown-unknown &&
   bash <(curl -s https://codecov.io/bash)

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -21,5 +21,5 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 wee_alloc = { version = "0.4", default-features = false }
 
 [features]
-default = []
+default = ["std"]
 std = []

--- a/alloc/src/lib.rs
+++ b/alloc/src/lib.rs
@@ -15,13 +15,7 @@
 // along with ink!.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(
-    not(feature = "std"),
-    feature(
-        alloc_error_handler,
-        core_intrinsics,
-    )
-)]
+#![cfg_attr(not(feature = "std"), feature(alloc_error_handler, core_intrinsics,))]
 
 // Use `wee_alloc` as the global allocator.
 #[cfg(not(feature = "std"))]

--- a/cli/template/Cargo.toml
+++ b/cli/template/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2018"
 
 [dependencies]
-ink_core = { git = "https://github.com/paritytech/ink", package = "ink_core" }
-ink_model = { git = "https://github.com/paritytech/ink", package = "ink_model" }
-ink_lang = { git = "https://github.com/paritytech/ink", package = "ink_lang" }
+ink_core = { git = "https://github.com/paritytech/ink", package = "ink_core", default-features = false }
+ink_model = { git = "https://github.com/paritytech/ink", package = "ink_model", default-features = false }
+ink_lang = { git = "https://github.com/paritytech/ink", package = "ink_lang", default-features = false }
 parity-codec = { version = "3.3", default-features = false, features = ["derive"] }
 
 [lib]
@@ -15,8 +15,15 @@ name = "{{name}}"
 crate-type = ["cdylib"]
 
 [features]
-default = []
+default = ["std"]
+std = [
+    "ink_core/std",
+    "ink_model/std",
+    "ink_lang/std",
+    "parity-codec/std",
+]
 test-env = [
+    "std",
     "ink_core/test-env",
     "ink_model/test-env",
     "ink_lang/test-env",

--- a/cli/template/build.sh
+++ b/cli/template/build.sh
@@ -7,7 +7,7 @@ PROJNAME={{name}}
 # rm Cargo.lock
 
 CARGO_INCREMENTAL=0 &&
-cargo build --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
+cargo build --no-default-features --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,6 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_abi = { path = "../abi", default-features = false }
 ink_alloc = { path = "../alloc/", default-features = false }
 ink_utils = { path = "../utils/", default-features = false }
 parity-codec = { version = "4.1", default-features = false, features = ["derive", "full"] }
@@ -32,7 +31,6 @@ features = ["derive"]
 default = ["std"]
 test-env = ["std"]
 std = [
-	"ink_abi/std",
     "ink_alloc/std",
     "ink_utils/std",
 	"parity-codec/std",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,14 +18,23 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_alloc = { path = "../alloc/" }
-ink_utils = { path = "../utils/" }
-parity-codec = { version = "3.2", default-features = false, features = ["derive", "full"] }
+ink_abi = { path = "../abi", default-features = false }
+ink_alloc = { path = "../alloc/", default-features = false }
+ink_utils = { path = "../utils/", default-features = false }
+parity-codec = { version = "4.1", default-features = false, features = ["derive", "full"] }
+
+[dependencies.type-metadata]
+git = "https://github.com/type-metadata/type-metadata.git"
+default-features = false
+features = ["derive"]
 
 [features]
-default = []
+default = ["std"]
 test-env = ["std"]
 std = [
+	"ink_abi/std",
     "ink_alloc/std",
     "ink_utils/std",
+	"parity-codec/std",
+	"type-metadata/std",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,6 @@ test-env = ["std"]
 std = [
     "ink_alloc/std",
     "ink_utils/std",
-	"parity-codec/std",
-	"type-metadata/std",
+    "parity-codec/std",
+    "type-metadata/std",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,11 +22,6 @@ ink_alloc = { path = "../alloc/", default-features = false }
 ink_utils = { path = "../utils/", default-features = false }
 parity-codec = { version = "4.1", default-features = false, features = ["derive", "full"] }
 
-[dependencies.type-metadata]
-git = "https://github.com/type-metadata/type-metadata.git"
-default-features = false
-features = ["derive"]
-
 [features]
 default = ["std"]
 test-env = ["std"]
@@ -34,5 +29,4 @@ std = [
     "ink_alloc/std",
     "ink_utils/std",
     "parity-codec/std",
-    "type-metadata/std",
 ]

--- a/examples/core/erc20/Cargo.toml
+++ b/examples/core/erc20/Cargo.toml
@@ -5,16 +5,23 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_core = { path = "../../../core" }
-parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
+ink_core = { path = "../../../core", default-features = false }
+parity-codec = { version = "4.1", default-features = false, features = ["derive"] }
 
 [lib]
 name = "erc20"
 crate-type = ["cdylib"]
 
 [features]
-default = []
-test-env = ["ink_core/test-env"]
+default = ["std"]
+std = [
+	"ink_core/std",
+	"parity-codec/std",
+]
+test-env = [
+	"std",
+	"ink_core/test-env",
+]
 
 [profile.release]
 panic = "abort"

--- a/examples/lang/erc20/Cargo.toml
+++ b/examples/lang/erc20/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_core = { path = "../../../core" }
-ink_model = { path = "../../../model" }
-ink_lang = { path = "../../../lang" }
-parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
+ink_core = { path = "../../../core", default-features = false }
+ink_model = { path = "../../../model", default-features = false }
+ink_lang = { path = "../../../lang", default-features = false }
+parity-codec = { version = "4.1", default-features = false, features = ["derive"] }
 
 [lib]
 name = "erc20"
@@ -16,9 +16,17 @@ crate-type = ["cdylib"]
 
 [features]
 default = [
+	"std",
     "ink_lang/generate-api-description"
 ]
+std = [
+	"ink_core/std",
+	"ink_model/std",
+	"ink_lang/std",
+	"parity-codec/std",
+]
 test-env = [
+	"std",
 	"ink_core/test-env",
 	"ink_model/test-env",
     "ink_lang/test-env",
@@ -30,5 +38,5 @@ generate-api-description = [
 [profile.release]
 panic = "abort"
 lto = true
-# debug = true
 opt-level = "z"
+# debug = true

--- a/examples/lang/erc20/Cargo.toml
+++ b/examples/lang/erc20/Cargo.toml
@@ -16,19 +16,19 @@ crate-type = ["cdylib"]
 
 [features]
 default = [
-	"std",
+    "std",
     "ink_lang/generate-api-description"
 ]
 std = [
-	"ink_core/std",
-	"ink_model/std",
-	"ink_lang/std",
-	"parity-codec/std",
+    "ink_core/std",
+    "ink_model/std",
+    "ink_lang/std",
+    "parity-codec/std",
 ]
 test-env = [
-	"std",
-	"ink_core/test-env",
-	"ink_model/test-env",
+    "std",
+    "ink_core/test-env",
+    "ink_model/test-env",
     "ink_lang/test-env",
 ]
 generate-api-description = [

--- a/examples/lang/erc20/build.sh
+++ b/examples/lang/erc20/build.sh
@@ -7,7 +7,7 @@ PROJNAME=erc20
 # cargo clean
 # rm Cargo.lock
 
-CARGO_INCREMENTAL=0 cargo build --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo build --release --no-default-features --features generate-api-description --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/lang/erc20/build.sh
+++ b/examples/lang/erc20/build.sh
@@ -7,7 +7,7 @@ PROJNAME=erc20
 # cargo clean
 # rm Cargo.lock
 
-CARGO_INCREMENTAL=0 cargo build --release --no-default-features --features generate-api-description --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo build --no-default-features --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/model/erc20/Cargo.toml
+++ b/examples/model/erc20/Cargo.toml
@@ -7,15 +7,21 @@ edition = "2018"
 [dependencies]
 ink_core = { path = "../../../core" }
 ink_model = { path = "../../../model" }
-parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
+parity-codec = { version = "4.1", default-features = false, features = ["derive"] }
 
 [lib]
 name = "erc20"
 crate-type = ["cdylib"]
 
 [features]
-default = []
+default = ["std"]
+std = [
+	"ink_core/std",
+	"ink_model/std",
+	"parity-codec/std",
+]
 test-env = [
+	"std",
 	"ink_core/test-env",
 	"ink_model/test-env",
 ]

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -42,11 +42,11 @@ proc-macro = true
 default = ["std"]
 std = [
     "ink_utils/std",
-	"ink_model/std",
+    "ink_model/std",
     "parity-codec/std",
-	"itertools/use_std",
-	"either/use_std",
-	"serde/std",
+    "itertools/use_std",
+    "either/use_std",
+    "serde/std",
 ]
 test-env = [
     "ink_model/test-env",

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -18,18 +18,18 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_utils = { path = "../utils/" }
-ink_model = { path = "../model/" }
-parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
+ink_utils = { path = "../utils/", default-features = false }
+ink_model = { path = "../model/", default-features = false }
+parity-codec = { version = "4.1", default-features = false, features = ["derive"] }
 
 quote = "0.6"
 syn = { version = "0.15", features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = "0.4"
 heck = "0.3"
-itertools = "0.7"
-either = "1.5"
-serde = { version = "1.0.89", features = ["derive"] }
-serde_json = "1.0.39"
+itertools = { version = "0.8", default-features = false }
+either = { version = "1.5", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
@@ -39,10 +39,14 @@ name = "ink_lang"
 proc-macro = true
 
 [features]
-default = []
+default = ["std"]
 std = [
     "ink_utils/std",
+	"ink_model/std",
     "parity-codec/std",
+	"itertools/use_std",
+	"either/use_std",
+	"serde/std",
 ]
 test-env = [
     "ink_model/test-env",

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -14,10 +14,16 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-parity-codec = { version = "3.2", default-features = false, features = ["derive", "full"] }
-ink_core = { version = "0.1.0", path = "../core" }
+ink_core = { path = "../core", default-features = false }
+parity-codec = { version = "4.1", default-features = false, features = ["derive", "full"] }
 
 [features]
-default = []
-test-env = ["std", "ink_core/test-env"]
-std = ["ink_core/std"]
+default = ["std"]
+test-env = [
+	"std",
+	"ink_core/test-env",
+]
+std = [
+	"ink_core/std",
+	"parity-codec/std",
+]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -21,5 +21,5 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 tiny-keccak = "1.4"
 
 [features]
-default = []
+default = ["std"]
 std = []


### PR DESCRIPTION
Normalizes the `std` crate feature usage of ink! to be enabled by default.
To use `no_std` environment users can opt-out with `default-features = false` or `--no-default-features`.
Some dependencies have been updated.
The `std` feature flag is now correctly propagated to crate dependencies.