### PR TITLE
[examples] add +nightly to build scripts

### DIFF
--- a/cli/template/build.sh
+++ b/cli/template/build.sh
@@ -7,7 +7,7 @@ PROJNAME={{name}}
 # rm Cargo.lock
 
 CARGO_INCREMENTAL=0 &&
-cargo build --no-default-features --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
+cargo +nightly build --no-default-features --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/core/erc20/build.sh
+++ b/examples/core/erc20/build.sh
@@ -10,7 +10,7 @@ PROJNAME=erc20
 cargo clean
 rm Cargo.lock
 
-CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo +nightly build --no-default-features --release --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/lang/erc20/build.sh
+++ b/examples/lang/erc20/build.sh
@@ -7,7 +7,7 @@ PROJNAME=erc20
 # cargo clean
 # rm Cargo.lock
 
-CARGO_INCREMENTAL=0 cargo build --no-default-features --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo +nightly build --no-default-features --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/lang/events/build.sh
+++ b/examples/lang/events/build.sh
@@ -5,7 +5,7 @@ PROJNAME=events
 # cargo clean
 # rm Cargo.lock
 
-CARGO_INCREMENTAL=0 cargo build --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo +nightly build --no-default-features --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/lang/flipper/build.sh
+++ b/examples/lang/flipper/build.sh
@@ -7,7 +7,7 @@ PROJNAME=flipper
 # cargo clean
 # rm Cargo.lock
 
-CARGO_INCREMENTAL=0 cargo build --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo +nightly build --no-default-features --release --features generate-api-description --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat

--- a/examples/model/erc20/build.sh
+++ b/examples/model/erc20/build.sh
@@ -8,7 +8,7 @@
 PROJNAME=erc20
 #cargo clean
 #rm Cargo.lock
-CARGO_INCREMENTAL=0 cargo build --release --target=wasm32-unknown-unknown --verbose
+CARGO_INCREMENTAL=0 cargo +nightly build --no-default-features --release --target=wasm32-unknown-unknown --verbose
 wasm2wat -o target/$PROJNAME.wat target/wasm32-unknown-unknown/release/$PROJNAME.wasm
 cat target/$PROJNAME.wat | sed "s/(import \"env\" \"memory\" (memory (;0;) 2))/(import \"env\" \"memory\" (memory (;0;) 2 16))/" > target/$PROJNAME-fixed.wat
 wat2wasm -o target/$PROJNAME.wasm target/$PROJNAME-fixed.wat


### PR DESCRIPTION
Following on from #148, which removes the nightly toolchain files, this PR adds the `+nightly` modifier to the build scripts in the examples.