### PR TITLE
fixed event & hashmap error when build erc20

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,7 +20,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 [dependencies]
 ink_alloc = { path = "../alloc/", default-features = false }
 ink_utils = { path = "../utils/", default-features = false }
-parity-codec = { version = "4.1", default-features = false, features = ["derive", "full"] }
+parity-codec = { version = "3.2", default-features = false, features = ["derive", "full"] }
 
 [features]
 default = ["std"]

--- a/core/src/env/srml/types.rs
+++ b/core/src/env/srml/types.rs
@@ -19,7 +19,12 @@ use core::{
     convert::TryFrom,
 };
 
-use crate::env::EnvTypes;
+use crate::{
+    env::EnvTypes,
+    impl_empty_flush_for,
+    storage::Flush,
+};
+
 use parity_codec::{
     Decode,
     Encode,
@@ -83,3 +88,5 @@ pub type Moment = u64;
 
 /// The default SRML blocknumber type.
 pub type BlockNumber = u64;
+
+impl_empty_flush_for!(AccountId, Hash);

--- a/core/src/storage/flush.rs
+++ b/core/src/storage/flush.rs
@@ -42,6 +42,7 @@ pub trait Flush {
     fn flush(&mut self);
 }
 
+#[macro_export]
 macro_rules! impl_empty_flush_for {
 	( $($ty:ty),* ) => {
 		$(

--- a/examples/core/erc20/Cargo.toml
+++ b/examples/core/erc20/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 ink_core = { path = "../../../core", default-features = false }
-parity-codec = { version = "4.1", default-features = false, features = ["derive"] }
+parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
 
 [lib]
 name = "erc20"

--- a/examples/lang/erc20/Cargo.toml
+++ b/examples/lang/erc20/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 ink_core = { path = "../../../core", default-features = false }
 ink_model = { path = "../../../model", default-features = false }
 ink_lang = { path = "../../../lang", default-features = false }
-parity-codec = { version = "4.1", default-features = false, features = ["derive"] }
+parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
 
 [lib]
 name = "erc20"

--- a/examples/model/erc20/Cargo.toml
+++ b/examples/model/erc20/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 ink_core = { path = "../../../core" }
 ink_model = { path = "../../../model" }
-parity-codec = { version = "4.1", default-features = false, features = ["derive"] }
+parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
 
 [lib]
 name = "erc20"

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -20,7 +20,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 [dependencies]
 ink_utils = { path = "../utils/", default-features = false }
 ink_model = { path = "../model/", default-features = false }
-parity-codec = { version = "4.1", default-features = false, features = ["derive"] }
+parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
 
 quote = "0.6"
 syn = { version = "0.15", features = ["parsing", "full", "extra-traits"] }

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -15,7 +15,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 ink_core = { path = "../core", default-features = false }
-parity-codec = { version = "4.1", default-features = false, features = ["derive", "full"] }
+parity-codec = { version = "3.2", default-features = false, features = ["derive", "full"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Event error is caused by parity-codec(version 4.1), and it is fixed by rolling back version 3.2 .
Hashmap error is fixed by [PR 151](https://github.com/paritytech/ink/pull/151).