### PR TITLE
[ci] Improve Travis CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,12 +61,95 @@ before_script:
 
 script:
 - |
-  cargo check --verbose --all --all-features &&
-  cargo check --verbose --all --no-default-features &&
-  cargo fmt --verbose --all -- --check &&
-  cargo clippy --verbose --all --all-features -- -D warnings &&
-  cargo clippy --verbose --all --no-default-features -- -D warnings &&
-  cargo test --verbose --all --all-features &&
-  cargo kcov --verbose --coveralls --all --no-clean-rebuild &&
-  cargo build --verbose --all --no-default-features --release --target=wasm32-unknown-unknown &&
+  cargo check --verbose --all --all-features
+  check_all_features=$?
+
+  cargo check --verbose --all --no-default-features
+  check_no_default=$?
+
+  cargo fmt --verbose --all -- --check
+  fmt=$?
+
+  cargo clippy --verbose --all --all-features -- -D warnings
+  clippy_all_features=$?
+
+  cargo clippy --verbose --all --no-default-features -- -D warnings
+  clippy_no_default=$?
+
+  cargo test --verbose --all --all-features
+  test=$?
+
+  cargo kcov --verbose --coveralls --all --no-clean-rebuild
+  kcov=$?
   bash <(curl -s https://codecov.io/bash)
+
+  cargo build --verbose --all --no-default-features --release --target=wasm32-unknown-unknown
+  build_wasm=$?
+
+  echo "CI Summary"
+  echo "=========="
+  echo ""
+  if [ $check_all_features -eq 0 ]
+  then
+    echo "compile (all-features):        ok"
+  else
+    echo "compile (all-features):        ERROR"
+  fi
+
+  if [ $check_no_default -eq 0 ]
+  then
+    echo "compile (no-default-features): ok"
+  else
+    echo "compile (no-default-features): ERROR"
+  fi
+
+  if [ $fmt -eq 0 ]
+  then
+    echo "formatting:                    ok"
+  else
+    echo "formatting:                    ERROR"
+  fi
+
+  if [ $clippy_all_features -eq 0 ]
+  then
+    echo "clippy (all-features):         ok"
+  else
+    echo "clippy (all-features):         ERROR"
+  fi
+
+  if [ $clippy_no_default -eq 0 ]
+  then
+    echo "clippy (no-default-features):  ok"
+  else
+    echo "clippy (no-default-features):  ERROR"
+  fi
+
+  if [ $test -eq 0 ]
+  then
+    echo "test (all-features):           ok"
+  else
+    echo "test (all-features):           ERROR"
+  fi
+
+  if [ $build_wasm -eq 0 ]
+  then
+    echo "build Wasm:                    ok"
+  else
+    echo "build Wasm:                    ERROR"
+  fi
+
+  if [ $kcov -eq 0 ]
+  then
+    echo "coverage analysis:             ok"
+  else
+    echo "coverage analysis:             ERROR"
+  fi
+
+  if [ $check_all_features -eq 0 ] && [ $check_no_default -eq 0 ] && [ $fmt -eq 0 ] && [ $clippy_all_features -eq 0 ] && [ $clippy_no_default -eq 0 ] && [ $test -eq 0 ] && [ $build_wasm -eq 0 ]
+  then
+    echo "All checks have passed!"
+    exit 0
+  else
+    echo "Some checks have not passed!"
+    exit 1
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ rust:
   # - stable
   # - beta
   - nightly
+  - nightly-2019-07-19
 
-# matrix:
-#   allow_failures:
-#     - rust: stable
-#     - rust: beta
+matrix:
+  allow_failures:
+    - rust: nightly
+    # - rust: stable
+    # - rust: beta
 
 env:
   global:

--- a/core/src/env/srml/types.rs
+++ b/core/src/env/srml/types.rs
@@ -14,10 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with ink!.  If not, see <http://www.gnu.org/licenses/>.
 
-use core::{array::TryFromSliceError, convert::TryFrom};
+use core::{
+    array::TryFromSliceError,
+    convert::TryFrom,
+};
 
-use crate::{env::EnvTypes, impl_empty_flush_for, storage::Flush};
-use parity_codec::{Decode, Encode};
+use crate::{
+    env::EnvTypes,
+    impl_empty_flush_for,
+    storage::Flush,
+};
+use parity_codec::{
+    Decode,
+    Encode,
+};
 
 /// The SRML fundamental types.
 #[allow(unused)]

--- a/lang/src/hir.rs
+++ b/lang/src/hir.rs
@@ -228,12 +228,10 @@ impl Contract {
                     }
                     Some(self_ty) => {
                         match self_ty {
-                            ast::FnArg::SelfValue(_) | ast::FnArg::Captured(_) => {
-                                bail!(
+                            ast::FnArg::SelfValue(_) | ast::FnArg::Captured(_) => bail!(
                                 self_ty,
                                 "contract messages must operate on `&self` or `&mut self`"
-                            )
-                            }
+                            ),
                             _ => (),
                         }
                     }


### PR DESCRIPTION
This fixes the used rust compiler channel to `nightly-2019-07-19` which is assumed to be working properly (at least on my machine). Also made normal `nightly` channel OK for failure. So it is not required to be working, unlike the `nightly-2019-07-19` channel. But with this in mind we can always check if the current nightly works.

Also this makes checks independent from each other. So all checks are always run.
On top of that it features a new CI summary that looks like the following upon success of failure:

**Success:**
```
CI Summary
==========

compile (all-features):        ok
compile (no-default-features): ok
formatting:                    ok
clippy (all-features):         ok
clippy (no-default-features):  ok
test (all-features):           ok
build Wasm:                    ok
coverage analysis:             ok
All checks have passed!
```

**Failure:**
```
CI Summary
==========

compile (all-features):        ERROR
compile (no-default-features): ok
formatting:                    ERROR
clippy (all-features):         ERROR
clippy (no-default-features):  ok
test (all-features):           ERROR
build Wasm:                    ok
coverage analysis:             ok
```