### PR TITLE
Move overflow-checks from .cargo/config to Cargo.toml

### DIFF
--- a/cli/template/.cargo/config
+++ b/cli/template/.cargo/config
@@ -1,5 +1,4 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
-	"-C", "overflow-checks=on",
 	"-C", "link-args=-z stack-size=65536 --import-memory"
 ]

--- a/cli/template/Cargo.toml
+++ b/cli/template/Cargo.toml
@@ -36,3 +36,4 @@ generate-api-description = [
 panic = "abort"
 lto = true
 opt-level = "z"
+overflow-checks = true

--- a/examples/core/erc20/.cargo/config
+++ b/examples/core/erc20/.cargo/config
@@ -1,5 +1,4 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
-	"-C", "overflow-checks=on",
 	"-C", "link-args=-z stack-size=65536 --import-memory"
 ]

--- a/examples/core/erc20/Cargo.toml
+++ b/examples/core/erc20/Cargo.toml
@@ -27,3 +27,4 @@ test-env = [
 panic = "abort"
 lto = true
 opt-level = "z"
+overflow-checks = true

--- a/examples/lang/erc20/.cargo/config
+++ b/examples/lang/erc20/.cargo/config
@@ -1,5 +1,4 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
-	"-C", "overflow-checks=on",
 	"-C", "link-args=-z stack-size=65536 --import-memory"
 ]

--- a/examples/lang/erc20/Cargo.toml
+++ b/examples/lang/erc20/Cargo.toml
@@ -39,4 +39,5 @@ generate-api-description = [
 panic = "abort"
 lto = true
 opt-level = "z"
+overflow-checks = true
 # debug = true

--- a/examples/lang/events/.cargo/config
+++ b/examples/lang/events/.cargo/config
@@ -1,5 +1,4 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
-	"-C", "overflow-checks=on",
 	"-C", "link-args=-z stack-size=65536 --import-memory"
 ]

--- a/examples/lang/events/Cargo.toml
+++ b/examples/lang/events/Cargo.toml
@@ -29,3 +29,4 @@ generate-api-description = [
 panic = "abort"
 lto = true
 opt-level = "z"
+overflow-checks = true

--- a/examples/lang/flipper/.cargo/config
+++ b/examples/lang/flipper/.cargo/config
@@ -1,5 +1,4 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
-	"-C", "overflow-checks=on",
 	"-C", "link-args=-z stack-size=65536 --import-memory"
 ]

--- a/examples/lang/flipper/Cargo.toml
+++ b/examples/lang/flipper/Cargo.toml
@@ -29,3 +29,4 @@ generate-api-description = [
 panic = "abort"
 lto = true
 opt-level = "z"
+overflow-checks = true

--- a/examples/lang/incrementer/.cargo/config
+++ b/examples/lang/incrementer/.cargo/config
@@ -1,5 +1,4 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
-	"-C", "overflow-checks=on",
 	"-C", "link-args=-z stack-size=65536 --import-memory"
 ]

--- a/examples/lang/incrementer/Cargo.toml
+++ b/examples/lang/incrementer/Cargo.toml
@@ -29,3 +29,4 @@ generate-api-description = [
 panic = "abort"
 lto = true
 opt-level = "z"
+overflow-checks = true

--- a/examples/lang/shared_vec/.cargo/config
+++ b/examples/lang/shared_vec/.cargo/config
@@ -1,5 +1,4 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
-	"-C", "overflow-checks=on",
 	"-C", "link-args=-z stack-size=65536 --import-memory"
 ]

--- a/examples/lang/shared_vec/Cargo.toml
+++ b/examples/lang/shared_vec/Cargo.toml
@@ -29,3 +29,4 @@ generate-api-description = [
 panic = "abort"
 lto = true
 opt-level = "z"
+overflow-checks = true

--- a/examples/model/erc20/.cargo/config
+++ b/examples/model/erc20/.cargo/config
@@ -1,5 +1,4 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
-	"-C", "overflow-checks=on",
 	"-C", "link-args=-z stack-size=65536 --import-memory"
 ]

--- a/examples/model/erc20/Cargo.toml
+++ b/examples/model/erc20/Cargo.toml
@@ -30,3 +30,4 @@ test-env = [
 panic = "abort"
 lto = true
 opt-level = "z"
+overflow-checks = true


### PR DESCRIPTION
Just saw that it is possible to specify the overflow checks in `Cargo.toml` so I think we should do that instead of `.cargo/config`.