### PR TITLE
[core] rename ext_scratch_copy to ext_scratch_read

### DIFF
--- a/core/src/env/srml/srml_only/impls.rs
+++ b/core/src/env/srml/srml_only/impls.rs
@@ -34,7 +34,7 @@ fn read_scratch_buffer() -> Vec<u8> {
     if size > 0 {
         value.resize(size as usize, 0);
         unsafe {
-            sys::ext_scratch_copy(value.as_mut_ptr() as u32, 0, size);
+            sys::ext_scratch_read(value.as_mut_ptr() as u32, 0, size);
         }
     }
     value

--- a/core/src/env/srml/srml_only/sys.rs
+++ b/core/src/env/srml/srml_only/sys.rs
@@ -85,8 +85,9 @@ extern "C" {
     /// Returns the length in bytes of the scratch buffer.
     pub fn ext_scratch_size() -> u32;
 
-    /// Copies the contents of the scratch buffer to `dest_ptr`.
-    pub fn ext_scratch_copy(dest_ptr: u32, offset: u32, len: u32);
+    /// Reads the contents of the scratch buffer at the host site starting at `offset` and writes them to the
+    /// buffer starting at `dst_ptr` with length `len` on the smart contract site.
+    pub fn ext_scratch_read(dst_ptr: u32, offset: u32, len: u32);
 
     /// Immediately returns contract execution to the caller
     /// with the provided data at `data_ptr`.


### PR DESCRIPTION
This is an important measure to stay in sync with the current SRML contracts.