### PR TITLE
Add initial call builder implementation

### DIFF
--- a/core/src/env/api.rs
+++ b/core/src/env/api.rs
@@ -17,17 +17,20 @@
 use super::ContractEnvStorage;
 use crate::{
     env::{
-        CallError,
         traits::{
             Env,
             EnvTypes,
         },
+        CallError,
         EnvStorage as _,
     },
     memory::vec::Vec,
     storage::Key,
 };
-use scale::{Encode, Decode};
+use scale::{
+    Decode,
+    Encode,
+};
 
 /// Stores the given value under the specified key in the contract storage.
 ///

--- a/core/src/env/mod.rs
+++ b/core/src/env/mod.rs
@@ -45,6 +45,12 @@ pub use self::srml::{
     DefaultSrmlTypes,
 };
 
+#[cfg(not(feature = "test-env"))]
+pub use self::srml::{
+    CallAbi,
+    CallBuilder,
+};
+
 /// The storage environment implementation that is currently being used.
 ///
 /// This may be either

--- a/core/src/env/srml/mod.rs
+++ b/core/src/env/srml/mod.rs
@@ -27,6 +27,8 @@ pub use self::types::{
 #[cfg(not(feature = "test-env"))]
 pub use self::srml_only::{
     sys,
+    CallAbi,
+    CallBuilder,
     SrmlEnv,
     SrmlEnvStorage,
 };

--- a/core/src/env/srml/srml_only/calls.rs
+++ b/core/src/env/srml/srml_only/calls.rs
@@ -14,11 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with ink!.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::env::{
-    self,
-    CallError,
-    Env,
-    EnvTypes,
+use crate::{
+    env::{
+        self,
+        CallError,
+        Env,
+        EnvTypes,
+    },
+    memory::vec::{
+        self,
+        Vec,
+    },
 };
 use core::marker::PhantomData;
 use scale::Decode;
@@ -92,6 +98,35 @@ where
             return_type: PhantomData,
             raw_input: CallAbi::new(selector),
         }
+    }
+}
+
+impl<E, R> CallBuilder<E, R>
+where
+    E: EnvTypes,
+{
+    /// Sets the maximumly allowed gas costs for the call.
+    pub fn gas_cost(self, gas_cost: u64) -> Self {
+        let mut this = self;
+        this.gas_cost = gas_cost;
+        this
+    }
+
+    /// Sets the value transferred upon the execution of the call.
+    pub fn value(self, value: E::Balance) -> Self {
+        let mut this = self;
+        this.value = value;
+        this
+    }
+
+    /// Pushes an argument to the inputs of the call.
+    pub fn push_arg<A>(self, arg: &A) -> Self
+    where
+        A: scale::Encode,
+    {
+        let mut this = self;
+        this.raw_input = this.raw_input.push_arg(arg);
+        this
     }
 }
 

--- a/core/src/env/srml/srml_only/calls.rs
+++ b/core/src/env/srml/srml_only/calls.rs
@@ -1,0 +1,145 @@
+// Copyright 2018-2019 Parity Technologies (UK) Ltd.
+// This file is part of ink!.
+//
+// ink! is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// ink! is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::env::{
+    self,
+    CallError,
+    Env,
+    EnvTypes,
+};
+use core::marker::PhantomData;
+use scale::Decode;
+
+/// Consists of the input data to a call.
+/// The first four bytes are the function selector and the rest are SCALE encoded inputs.
+pub struct CallAbi {
+    /// Already encoded function selector and inputs.
+    raw: Vec<u8>,
+}
+
+impl CallAbi {
+    /// Creates new call ABI data for the given selector.
+    pub fn new(selector: u32) -> Self {
+        let bytes = selector.to_le_bytes();
+        Self {
+            raw: vec![bytes[0], bytes[1], bytes[2], bytes[3]],
+        }
+    }
+
+    /// Pushes the given argument onto the call ABI data in encoded form.
+    pub fn push_arg<A>(self, arg: &A) -> Self
+    where
+        A: scale::Encode,
+    {
+        let mut this = self;
+        this.raw.extend(&arg.encode());
+        this
+    }
+
+    /// Returns the underlying byte representation.
+    pub fn to_bytes(&self) -> &[u8] {
+        &self.raw
+    }
+}
+
+/// Represents a return type.
+///
+/// Used as a marker type to differentiate at compile-time between invoke and evaluate.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ReturnType<T>(PhantomData<T>);
+
+/// Builds up a call.
+pub struct CallBuilder<E, R>
+where
+    E: EnvTypes,
+{
+    /// The account ID of the to-be-called smart contract.
+    account_id: E::AccountId,
+    /// The maximum gas costs allowed for the call.
+    gas_cost: u64,
+    /// The transferred value for the call.
+    value: E::Balance,
+    /// The expected return type.
+    return_type: PhantomData<ReturnType<R>>,
+    /// The already encoded call ABI data.
+    raw_input: CallAbi,
+}
+
+impl<E, R> CallBuilder<E, ReturnType<R>>
+where
+    E: EnvTypes,
+    E::Balance: Default,
+{
+    /// Instantiates an evaluatable (returns data) remote smart contract call.
+    pub fn eval(account_id: E::AccountId, selector: u32) -> Self {
+        Self {
+            account_id,
+            gas_cost: 0,
+            value: E::Balance::default(),
+            return_type: PhantomData,
+            raw_input: CallAbi::new(selector),
+        }
+    }
+}
+
+impl<E> CallBuilder<E, ()>
+where
+    E: EnvTypes,
+    E::Balance: Default,
+{
+    /// Instantiates a non-evaluatable (returns no data) remote smart contract call.
+    pub fn invoke(account_id: E::AccountId, selector: u32) -> Self {
+        Self {
+            account_id,
+            gas_cost: 0,
+            value: E::Balance::default(),
+            return_type: PhantomData,
+            raw_input: CallAbi::new(selector),
+        }
+    }
+}
+
+impl<E, R> CallBuilder<E, ReturnType<R>>
+where
+    E: Env,
+    R: Decode,
+{
+    /// Fires the call to the remote smart contract.
+    /// Returns the returned data back to the caller.
+    pub fn fire(self) -> Result<R, CallError> {
+        env::call_evaluate::<E, R>(
+            self.account_id,
+            self.gas_cost,
+            self.value,
+            self.raw_input.to_bytes(),
+        )
+    }
+}
+
+impl<E> CallBuilder<E, ()>
+where
+    E: Env,
+{
+    /// Fires the call to the remote smart contract.
+    pub fn fire(self) -> Result<(), CallError> {
+        env::call_invoke::<E>(
+            self.account_id,
+            self.gas_cost,
+            self.value,
+            self.raw_input.to_bytes(),
+        )
+    }
+}

--- a/core/src/env/srml/srml_only/calls.rs
+++ b/core/src/env/srml/srml_only/calls.rs
@@ -21,10 +21,10 @@ use crate::{
         Env,
         EnvTypes,
     },
-    memory::{
-        vec,
-        vec::Vec,
-    }
+    memory::vec::{
+        self,
+        Vec,
+    },
 };
 use core::marker::PhantomData;
 use scale::Decode;

--- a/core/src/env/srml/srml_only/calls.rs
+++ b/core/src/env/srml/srml_only/calls.rs
@@ -21,10 +21,10 @@ use crate::{
         Env,
         EnvTypes,
     },
-    memory::vec::{
-        self,
-        Vec,
-    },
+    memory::{
+        vec,
+        vec::Vec,
+    }
 };
 use core::marker::PhantomData;
 use scale::Decode;

--- a/core/src/env/srml/srml_only/mod.rs
+++ b/core/src/env/srml/srml_only/mod.rs
@@ -14,10 +14,17 @@
 // You should have received a copy of the GNU General Public License
 // along with ink!.  If not, see <http://www.gnu.org/licenses/>.
 
+mod calls;
 mod impls;
 pub mod sys;
 
-pub use self::impls::{
-    SrmlEnv,
-    SrmlEnvStorage,
+pub use self::{
+    calls::{
+        CallAbi,
+        CallBuilder,
+    },
+    impls::{
+        SrmlEnv,
+        SrmlEnvStorage,
+    },
 };

--- a/core/src/env/srml/types.rs
+++ b/core/src/env/srml/types.rs
@@ -35,6 +35,7 @@ use type_metadata::Metadata;
 /// # Note
 ///
 /// This is currently just a placeholder for potential future error codes.
+#[derive(Debug, Copy, Clone)]
 pub struct CallError;
 
 /// The SRML fundamental types.


### PR DESCRIPTION
Adds an initial infrastructure for building up calls used by the upcoming `ink_lang` integration for calling remote smart contracts.

This features the `CallBuilder` type that allows users to build up calls in the following way:

```rust
CallBuilder::invoke(0xDEAD_BEEF, 1234)
    .gas_cost(123)
    .value(10_000)
    .push_arg(5)
    .push_arg("foo")
    .push_arg(true)
    .fire()
```
To fire of a call a method with a selector of `1234` to a smart contract at address `0xDEAD_BEEF` with maximumly alllowed gas costs of `123`, transferring a value of `10_000` and the arguments `5`, `"foo"` and `true`. The called method is expected not to return anything.
If we expected the method to return some value, e.g. a `[u32; 5]` we would have written the following:

```rust
CallBuilder::evaluate::<[u32; 5]>(0xDEAD_BEEF, 1234)
    .gas_cost(123)
    .value(10_000)
    .push_arg(5)
    .push_arg("foo")
    .push_arg(true)
    .fire()
```