### PR TITLE
[cli] pin subxt to v0.1 branch to avoid breaking changes

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,7 +28,7 @@ pwasm-utils = "0.11.0"
 parity-wasm = "0.40.2"
 cargo_metadata = "0.8.2"
 substrate-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-primitives" }
-subxt = { git = "https://github.com/paritytech/substrate-subxt/", package = "substrate-subxt" }
+subxt = { git = "https://github.com/paritytech/substrate-subxt/", branch = "v0.1", package = "substrate-subxt" }
 tokio = "0.1.21"
 url = "1.7"
 


### PR DESCRIPTION
Currently we have a github dependency to the `master` branch of `subxt` (introduced in #131), which is prone to breaking changes.

It cannot be released to cargo until the `substrate` dependencies are also published.

This PR changes the dependency to the `v0.1` branch.