### PR TITLE
[cli] add generate-abi command

### DIFF
--- a/cli/src/cmd/abi.rs
+++ b/cli/src/cmd/abi.rs
@@ -31,7 +31,7 @@ pub(crate) fn execute_generate_abi() -> Result<String> {
         "--package",
         "abi-gen",
         "--verbose",
-    ])?;
+    ], None)?;
 
     let metadata = MetadataCommand::new().exec()?;
     let mut abi_path = metadata.target_directory.clone();

--- a/cli/src/cmd/abi.rs
+++ b/cli/src/cmd/abi.rs
@@ -1,0 +1,44 @@
+// Copyright 2018-2019 Parity Technologies (UK) Ltd.
+// This file is part of ink!.
+//
+// ink! is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// ink! is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::cmd::{
+    Result,
+};
+use cargo_metadata::MetadataCommand;
+
+
+
+/// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.
+///
+/// It does so by invoking build by cargo and then post processing the final binary.
+pub(crate) fn execute_generate_abi() -> Result<String> {
+    println!(" Generating abi");
+
+    super::exec_cargo("run", &[
+        "--package",
+        "abi-gen",
+        "--verbose",
+    ])?;
+
+    let metadata = MetadataCommand::new().exec()?;
+    let mut abi_path = metadata.target_directory.clone();
+    abi_path.push("abi.json");
+
+    Ok(format!(
+        "Your abi file is ready.\nYou can find it here:\n{}",
+        abi_path.display()
+    ))
+}

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -88,13 +88,13 @@ pub fn collect_crate_metadata(working_dir: Option<&PathBuf>) -> Result<CrateMeta
 /// Invokes `cargo build` in the specified directory, defaults to the current directory.
 ///
 /// Currently it assumes that user wants to use `+nightly`.
-fn build_cargo_project() -> Result<()> {
+fn build_cargo_project(working_dir: Option<&PathBuf>) -> Result<()> {
     super::exec_cargo("build", &[
         "--no-default-features",
         "--release",
         "--target=wasm32-unknown-unknown",
         "--verbose",
-    ])
+    ], working_dir)
 }
 
 /// Ensures the wasm memory import of a given module has the maximum number of pages.

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -90,6 +90,7 @@ pub fn collect_crate_metadata() -> Result<CrateMetadata> {
 
 fn exec_cargo(command: &str, args: &[&'static str]) -> Result<()> {
     let output = Command::new("cargo")
+        .arg("+nightly")
         .arg(command)
         .args(args)
         .output()?;

--- a/cli/src/cmd/build.rs
+++ b/cli/src/cmd/build.rs
@@ -214,7 +214,7 @@ pub(crate) fn execute_build(gen_abi: bool) -> Result<String> {
     post_process_wasm(&crate_metadata)?;
 
     if gen_abi {
-        println!(" [{}/{}] Collecting crate metadata", steps, steps);
+        println!(" [{}/{}] Generating abi", steps, steps);
         generate_abi()?;
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -87,11 +87,10 @@ enum Command {
     },
     /// Builds the smart contract.
     #[structopt(name = "build")]
-    Build {
-        /// Generate the contract abi artifacts
-        #[structopt(long = "abi")]
-        generate_abi: bool,
-    },
+    Build {},
+    /// Generate abi artifacts
+    #[structopt(name = "generate-abi")]
+    GenerateAbi {},
     /// Test the smart contract off-chain.
     #[structopt(name = "test")]
     Test {},
@@ -135,7 +134,8 @@ fn exec(cmd: Command) -> cmd::Result<String> {
     use crate::cmd::CommandError;
     match &cmd {
         Command::New { layer, name } => cmd::execute_new(*layer, name),
-        Command::Build { generate_abi} => cmd::execute_build(*generate_abi),
+        Command::Build {} => cmd::execute_build(),
+        Command::GenerateAbi {} => cmd::execute_generate_abi(),
         Command::Test {} => Err(CommandError::UnimplementedCommand),
         Command::Deploy {
             url,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -87,7 +87,11 @@ enum Command {
     },
     /// Builds the smart contract.
     #[structopt(name = "build")]
-    Build {},
+    Build {
+        /// Generate the contract abi artifacts
+        #[structopt(long = "abi")]
+        generate_abi: bool,
+    },
     /// Test the smart contract off-chain.
     #[structopt(name = "test")]
     Test {},
@@ -131,7 +135,7 @@ fn exec(cmd: Command) -> cmd::Result<String> {
     use crate::cmd::CommandError;
     match &cmd {
         Command::New { layer, name } => cmd::execute_new(*layer, name),
-        Command::Build {} => cmd::execute_build(),
+        Command::Build { generate_abi} => cmd::execute_build(*generate_abi),
         Command::Test {} => Err(CommandError::UnimplementedCommand),
         Command::Deploy {
             url,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -145,7 +145,7 @@ fn exec(cmd: Command) -> cmd::Result<String> {
             target_dir,
         } => cmd::execute_new(*layer, name, target_dir.as_ref()),
         Command::Build {} => cmd::execute_build(None),
-        Command::GenerateAbi {} => cmd::execute_generate_abi(),
+        Command::GenerateAbi {} => cmd::execute_generate_abi(None),
         Command::Test {} => Err(CommandError::UnimplementedCommand),
         Command::Deploy {
             url,


### PR DESCRIPTION
~~cargo contract build --abi will execute the abi generation post build.~~

~~Alternatively we could have this as a separate command - but I decided to add it as a flag to `build`, since a developer might want to regenerate the abi as part of the build if the contract interface has changed.~~

**Edit** changed it to a separate command: `cargo contract generate-abi`