### PR TITLE
Encode selectors as 4-byte array of hex strings

### DIFF
--- a/abi/src/specs.rs
+++ b/abi/src/specs.rs
@@ -808,7 +808,10 @@ fn serialize_selector<S>(s: &[u8; 4], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let hex = format!("0x{:02X}{:02X}{:02X}{:02X}", s[0], s[1], s[2], s[3]);
+    let hex = format!(
+        r#"["0x{:02X}","0x{:02X}","0x{:02X}","0x{:02X}"]"#,
+        s[0], s[1], s[2], s[3]
+    );
     serializer.serialize_str(&hex)
 }
 
@@ -834,7 +837,7 @@ mod tests {
         // then
         assert_eq!(
             json,
-            "{\"name\":1,\"selector\":\"0x075BCD15\",\"args\":[],\"docs\":[]}"
+            r#"{"name":1,"selector":"[\"0x07\",\"0x5B\",\"0xCD\",\"0x15\"]","args":[],"docs":[]}"#
         );
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/paritytech/ink/issues/200.