### PR TITLE
Fix RUSTFLAGS in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ variables:
     - rustup show
     - bash --version
     # global RUSTFLAGS overrides the linker args so this way is better to pass the flags
-    - printf '[build]\nrustflags = ["-C", "link-dead-code"]' >> ${CARGO_HOME}/config
+    - printf '[build]\nrustflags = ["-C", "link-dead-code"]\n' >> ${CARGO_HOME}/config
     - sccache -s
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,8 @@ variables:
     - rustup show
     - bash --version
     # global RUSTFLAGS overrides the linker args so this way is better to pass the flags
-    - printf '[build]\nrustflags = ["-C", "link-dead-code"]\n' >> ${CARGO_HOME}/config
+    - echo ${CARGO_HOME}
+    - printf '[build]\nrustflags = ["-C", "link-dead-code"]\n' | tee ${CARGO_HOME}/config
     - sccache -s
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,6 @@ variables:
     - rustup show
     - bash --version
     # global RUSTFLAGS overrides the linker args so this way is better to pass the flags
-    - echo ${CARGO_HOME}
     - printf '[build]\nrustflags = ["-C", "link-dead-code"]\n' | tee ${CARGO_HOME}/config
     - sccache -s
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,6 @@ variables:
   SCCACHE_DIR:                     "/ci-cache/${CI_PROJECT_NAME}/sccache"
   CARGO_INCREMENTAL:               0
   CI_SERVER_NAME:                  "GitLab CI"
-  RUSTFLAGS:                       "-C link-dead-code"
   REGISTRY:                        registry.parity.io/parity/infrastructure/scripts
 
 .collect-artifacts:                &collect-artifacts
@@ -33,6 +32,8 @@ variables:
     - rustc -vV
     - rustup show
     - bash --version
+    # global RUSTFLAGS overrides the linker args so this way is better to pass the flags
+    - printf '[build]\nrustflags = ["-C", "link-dead-code"]' >> ${CARGO_HOME}/config
     - sccache -s
   only:
     - master


### PR DESCRIPTION
Fixes the state when global `RUSTFLAGS` overrides template project's linker arguments. https://github.com/paritytech/ink/issues/202
After this it's necessary to add all the other flags the same way, i.e. `echo "-Dwarnings" | tee -a ${CARGO_HOME}/config`