### PR TITLE
ink! 2.0: Improve Diagnostics follow-up

### DIFF
--- a/lang2/macro/src/ir/into_hir.rs
+++ b/lang2/macro/src/ir/into_hir.rs
@@ -686,13 +686,16 @@ fn split_items(
             Err(storages
                 .iter()
                 .map(|storage| {
-                    format_err!(storage.ident, "{} conflicting storage struct found", n)
+                    format_err!(storage.ident, "conflicting storage struct")
                 })
-                .fold1(|mut err1, err2| {
-                    err1.combine(err2);
-                    err1
-                })
-                .expect("there must be at least 2 conflicting storages; qed"))
+                .fold(
+                    format_err_span!(Span::call_site(), "encountered {} conflicting storage structs", n),
+                    |mut err1, err2| {
+                        err1.combine(err2);
+                        err1
+                    }
+                )
+            )
         }
     }?;
     let (events, impl_blocks): (Vec<ir::ItemEvent>, Vec<ir::ItemImpl>) =

--- a/lang2/macro/src/ir/into_hir.rs
+++ b/lang2/macro/src/ir/into_hir.rs
@@ -612,10 +612,23 @@ impl TryFrom<syn::Item> for ir::Item {
                             .map(ir::Item::Ink)
                     },
                     (None, None) => {
-                        Err(format_err!(
-                            item_struct,
-                            "encountered unsupported ink! markers for struct",
-                        ))
+                        Err(markers
+                            .iter()
+                            .map(|marker| {
+                                format_err_span!(
+                                    marker.span(),
+                                    "unsupported ink! marker for struct")
+                            })
+                            .fold(
+                                format_err!(
+                                    item_struct,
+                                    "encountered unsupported ink! markers for struct",
+                                ),
+                                |mut err1, err2| {
+                                err1.combine(err2);
+                                err1
+                            })
+                        )
                     }
                     (Some(storage_marker), Some(event_marker)) => {
                         // Special case: We have both #[ink(storage)] and #[ink(event)].

--- a/lang2/macro/src/ir/into_hir.rs
+++ b/lang2/macro/src/ir/into_hir.rs
@@ -665,6 +665,15 @@ fn split_items(
                 }
             }
         });
+    let storage_ident = &storage.ident;
+    for item_impl in &impl_blocks {
+        if item_impl.self_ty != storage_ident.to_string() {
+            bail!(
+                item_impl.self_ty,
+                "ink! impl blocks need to be implemented for the #[ink(storage)] struct"
+            )
+        }
+    }
     let functions = impl_blocks
         .into_iter()
         .map(|impl_block| impl_block.functions)

--- a/lang2/macro/src/ir/into_hir.rs
+++ b/lang2/macro/src/ir/into_hir.rs
@@ -386,7 +386,7 @@ impl TryFrom<syn::ImplItemMethod> for ir::Function {
                             selector: ir::FunctionSelector::from(&method.sig.ident),
                         }))
                     }
-                    unknown => Err(format_err!(unknown, "unknown ink! attribute found",)),
+                    _unknown => Err(format_err_span!(attr.span(), "unknown ink! marker",)),
                 }?;
                 if kind == ir::FunctionKind::Method {
                     kind = new_kind;
@@ -394,7 +394,7 @@ impl TryFrom<syn::ImplItemMethod> for ir::Function {
                 } else {
                     Err(format_err_span!(
                         attr.span(),
-                        "conflicting ink! attribute found",
+                        "conflicting ink! marker",
                     ))
                 }
             })

--- a/lang2/macro/src/ir/utils.rs
+++ b/lang2/macro/src/ir/utils.rs
@@ -16,6 +16,7 @@
 
 //! Contains general utilities for the ink! IR module.
 
+use crate::ir;
 use proc_macro2::Span;
 use syn::{
     parse::{
@@ -71,6 +72,18 @@ where
     I: IntoIterator<Item = &'a syn::Attribute> + 'a,
 {
     attrs.into_iter().filter(|attr| is_ink_attribute(attr))
+}
+
+/// Yields back the filtered `#[ink(..)]` markers converted into their ink! form if any.
+pub fn filter_map_ink_attributes<'a, I>(attrs: I) -> impl Iterator<Item = ir::Marker>
+where
+    I: IntoIterator<Item = &'a syn::Attribute> + 'a,
+{
+    use core::convert::TryFrom as _;
+    attrs
+        .into_iter()
+        .cloned()
+        .filter_map(|attr| ir::Marker::try_from(attr).ok())
 }
 
 /// Returns `true` if the attributes contain any `#[ink(..)]` markers.

--- a/lang2/macro/tests/compile_tests.rs
+++ b/lang2/macro/tests/compile_tests.rs
@@ -41,4 +41,5 @@ fn compile_tests() {
     t.compile_fail("tests/ui/fail/15-multiple-storage-structs.rs");
     t.compile_fail("tests/ui/fail/16-storage-impl-ident-conflict.rs");
     t.compile_fail("tests/ui/fail/17-conflicting-ink-markers.rs");
+    t.compile_fail("tests/ui/fail/18-conflicting-ink-markers-2.rs");
 }

--- a/lang2/macro/tests/compile_tests.rs
+++ b/lang2/macro/tests/compile_tests.rs
@@ -40,4 +40,5 @@ fn compile_tests() {
     t.compile_fail("tests/ui/fail/14-missing-storage-struct.rs");
     t.compile_fail("tests/ui/fail/15-multiple-storage-structs.rs");
     t.compile_fail("tests/ui/fail/16-storage-impl-ident-conflict.rs");
+    t.compile_fail("tests/ui/fail/17-conflicting-ink-markers.rs");
 }

--- a/lang2/macro/tests/compile_tests.rs
+++ b/lang2/macro/tests/compile_tests.rs
@@ -42,4 +42,5 @@ fn compile_tests() {
     t.compile_fail("tests/ui/fail/16-storage-impl-ident-conflict.rs");
     t.compile_fail("tests/ui/fail/17-conflicting-ink-markers.rs");
     t.compile_fail("tests/ui/fail/18-conflicting-ink-markers-2.rs");
+    t.compile_fail("tests/ui/fail/19-unknown-struct-ink-marker.rs");
 }

--- a/lang2/macro/tests/compile_tests.rs
+++ b/lang2/macro/tests/compile_tests.rs
@@ -38,4 +38,5 @@ fn compile_tests() {
     t.compile_fail("tests/ui/fail/12-const-constructor.rs");
     t.compile_fail("tests/ui/fail/13-abi-constructor.rs");
     t.compile_fail("tests/ui/fail/14-missing-storage-struct.rs");
+    t.compile_fail("tests/ui/fail/15-multiple-storage-structs.rs");
 }

--- a/lang2/macro/tests/compile_tests.rs
+++ b/lang2/macro/tests/compile_tests.rs
@@ -39,4 +39,5 @@ fn compile_tests() {
     t.compile_fail("tests/ui/fail/13-abi-constructor.rs");
     t.compile_fail("tests/ui/fail/14-missing-storage-struct.rs");
     t.compile_fail("tests/ui/fail/15-multiple-storage-structs.rs");
+    t.compile_fail("tests/ui/fail/16-storage-impl-ident-conflict.rs");
 }

--- a/lang2/macro/tests/compile_tests.rs
+++ b/lang2/macro/tests/compile_tests.rs
@@ -37,4 +37,5 @@ fn compile_tests() {
     t.compile_fail("tests/ui/fail/11-unsafe-constructor.rs");
     t.compile_fail("tests/ui/fail/12-const-constructor.rs");
     t.compile_fail("tests/ui/fail/13-abi-constructor.rs");
+    t.compile_fail("tests/ui/fail/14-missing-storage-struct.rs");
 }

--- a/lang2/macro/tests/compile_tests.rs
+++ b/lang2/macro/tests/compile_tests.rs
@@ -43,4 +43,5 @@ fn compile_tests() {
     t.compile_fail("tests/ui/fail/17-conflicting-ink-markers.rs");
     t.compile_fail("tests/ui/fail/18-conflicting-ink-markers-2.rs");
     t.compile_fail("tests/ui/fail/19-unknown-struct-ink-marker.rs");
+    t.compile_fail("tests/ui/fail/20-unknown-method-marker.rs");
 }

--- a/lang2/macro/tests/ui/fail/14-missing-storage-struct.rs
+++ b/lang2/macro/tests/ui/fail/14-missing-storage-struct.rs
@@ -1,0 +1,19 @@
+#![feature(proc_macro_hygiene)]
+
+use ink_lang2 as ink;
+
+#[ink::contract(version = "0.1.0")]
+mod noop {
+    // We are missing the #[ink(storage)] attribute here
+    struct Noop {}
+
+    impl Noop {
+        #[ink(constructor)]
+        fn new(&mut self) {}
+
+        #[ink(message)]
+        fn noop(&self) {}
+    }
+}
+
+fn main() {}

--- a/lang2/macro/tests/ui/fail/14-missing-storage-struct.stderr
+++ b/lang2/macro/tests/ui/fail/14-missing-storage-struct.stderr
@@ -1,0 +1,5 @@
+error: no #[ink(storage)] struct found but expected exactly 1
+ --> $DIR/14-missing-storage-struct.rs:5:1
+  |
+5 | #[ink::contract(version = "0.1.0")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lang2/macro/tests/ui/fail/15-multiple-storage-structs.rs
+++ b/lang2/macro/tests/ui/fail/15-multiple-storage-structs.rs
@@ -1,0 +1,31 @@
+#![feature(proc_macro_hygiene)]
+
+use ink_lang2 as ink;
+
+#[ink::contract(version = "0.1.0")]
+mod noop {
+    #[ink(storage)]
+    struct FirstStorage {}
+
+    // ink! currently doesn't allow for multiple #[ink(storage)] structs
+    #[ink(storage)]
+    struct SecondStorage {}
+
+    impl FirstStorage {
+        #[ink(constructor)]
+        fn new(&mut self) {}
+
+        #[ink(message)]
+        fn do_something(&self) {}
+    }
+
+    impl SecondStorage {
+        #[ink(constructor)]
+        fn new(&mut self) {}
+
+        #[ink(message)]
+        fn do_something(&self) {}
+    }
+}
+
+fn main() {}

--- a/lang2/macro/tests/ui/fail/15-multiple-storage-structs.stderr
+++ b/lang2/macro/tests/ui/fail/15-multiple-storage-structs.stderr
@@ -1,10 +1,16 @@
-error: 2 conflicting storage struct found
+error: encountered 2 conflicting storage structs
+ --> $DIR/15-multiple-storage-structs.rs:5:1
+  |
+5 | #[ink::contract(version = "0.1.0")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: conflicting storage struct
  --> $DIR/15-multiple-storage-structs.rs:8:12
   |
 8 |     struct FirstStorage {}
   |            ^^^^^^^^^^^^
 
-error: 2 conflicting storage struct found
+error: conflicting storage struct
   --> $DIR/15-multiple-storage-structs.rs:12:12
    |
 12 |     struct SecondStorage {}

--- a/lang2/macro/tests/ui/fail/15-multiple-storage-structs.stderr
+++ b/lang2/macro/tests/ui/fail/15-multiple-storage-structs.stderr
@@ -1,0 +1,11 @@
+error: 2 conflicting storage struct found
+ --> $DIR/15-multiple-storage-structs.rs:8:12
+  |
+8 |     struct FirstStorage {}
+  |            ^^^^^^^^^^^^
+
+error: 2 conflicting storage struct found
+  --> $DIR/15-multiple-storage-structs.rs:12:12
+   |
+12 |     struct SecondStorage {}
+   |            ^^^^^^^^^^^^^

--- a/lang2/macro/tests/ui/fail/16-storage-impl-ident-conflict.rs
+++ b/lang2/macro/tests/ui/fail/16-storage-impl-ident-conflict.rs
@@ -1,0 +1,37 @@
+#![feature(proc_macro_hygiene)]
+
+use ink_lang2 as ink;
+
+#[ink::contract(version = "0.1.0")]
+mod noop {
+    // This test ensures that ink! impl blocks are always
+    // implemented on the only storage struct definition.
+
+    #[ink(storage)]
+    struct StorageStruct {}
+
+    // This ink! impl block is okay.
+    impl StorageStruct {
+        #[ink(constructor)]
+        fn new1(&mut self) {}
+
+        #[ink(message)]
+        fn do_something1(&self) {}
+    }
+
+    // Missing the #[ink(storage)] attribute on purpose.
+    struct NonStorageStruct {}
+
+    // This ink! impl block is invalid in that it implement
+    // the messages and constructors for a non-existing ink!
+    // storage struct. We expect a failure here.
+    impl NonStorageStruct {
+        #[ink(constructor)]
+        fn new2(&mut self) {}
+
+        #[ink(message)]
+        fn do_something2(&self) {}
+    }
+}
+
+fn main() {}

--- a/lang2/macro/tests/ui/fail/16-storage-impl-ident-conflict.rs
+++ b/lang2/macro/tests/ui/fail/16-storage-impl-ident-conflict.rs
@@ -22,7 +22,7 @@ mod noop {
     // Missing the #[ink(storage)] attribute on purpose.
     struct NonStorageStruct {}
 
-    // This ink! impl block is invalid in that it implement
+    // This ink! impl block is invalid in that it implements
     // the messages and constructors for a non-existing ink!
     // storage struct. We expect a failure here.
     impl NonStorageStruct {

--- a/lang2/macro/tests/ui/fail/16-storage-impl-ident-conflict.stderr
+++ b/lang2/macro/tests/ui/fail/16-storage-impl-ident-conflict.stderr
@@ -1,0 +1,5 @@
+error: ink! impl blocks need to be implemented for the #[ink(storage)] struct
+  --> $DIR/16-storage-impl-ident-conflict.rs:28:10
+   |
+28 |     impl NonStorageStruct {
+   |          ^^^^^^^^^^^^^^^^

--- a/lang2/macro/tests/ui/fail/17-conflicting-ink-markers.rs
+++ b/lang2/macro/tests/ui/fail/17-conflicting-ink-markers.rs
@@ -1,0 +1,20 @@
+#![feature(proc_macro_hygiene)]
+
+use ink_lang2 as ink;
+
+#[ink::contract(version = "0.1.0")]
+mod noop {
+    #[ink(storage)]
+    #[ink(event)] // We cannot have #[ink(event)] if we already have #[ink(storage)]
+    struct Noop {}
+
+    impl Noop {
+        #[ink(constructor)]
+        fn new(&mut self) {}
+
+        #[ink(message)]
+        fn noop(&self) {}
+    }
+}
+
+fn main() {}

--- a/lang2/macro/tests/ui/fail/17-conflicting-ink-markers.stderr
+++ b/lang2/macro/tests/ui/fail/17-conflicting-ink-markers.stderr
@@ -1,0 +1,5 @@
+error: invalid ink! attribute found for `#[ink(storage)]` struct
+ --> $DIR/17-conflicting-ink-markers.rs:8:10
+  |
+8 |     #[ink(event)] // We cannot have #[ink(event)] if we already have #[ink(storage)]
+  |          ^^^^^^^

--- a/lang2/macro/tests/ui/fail/18-conflicting-ink-markers-2.rs
+++ b/lang2/macro/tests/ui/fail/18-conflicting-ink-markers-2.rs
@@ -8,7 +8,7 @@ mod noop {
     struct Noop {}
 
     #[ink(event)]
-    #[ink(storage)] // We cannot have #[ink(event)] if we already have #[ink(storage)]
+    #[ink(storage)] // We cannot have #[ink(storage)] if we already have #[ink(event)]
     struct Event {}
 
     impl Noop {

--- a/lang2/macro/tests/ui/fail/18-conflicting-ink-markers-2.rs
+++ b/lang2/macro/tests/ui/fail/18-conflicting-ink-markers-2.rs
@@ -1,0 +1,23 @@
+#![feature(proc_macro_hygiene)]
+
+use ink_lang2 as ink;
+
+#[ink::contract(version = "0.1.0")]
+mod noop {
+    #[ink(storage)]
+    struct Noop {}
+
+    #[ink(event)]
+    #[ink(storage)] // We cannot have #[ink(event)] if we already have #[ink(storage)]
+    struct Event {}
+
+    impl Noop {
+        #[ink(constructor)]
+        fn new(&mut self) {}
+
+        #[ink(message)]
+        fn noop(&self) {}
+    }
+}
+
+fn main() {}

--- a/lang2/macro/tests/ui/fail/18-conflicting-ink-markers-2.stderr
+++ b/lang2/macro/tests/ui/fail/18-conflicting-ink-markers-2.stderr
@@ -1,0 +1,5 @@
+error: invalid ink! attribute found for `#[ink(event)]` struct
+  --> $DIR/18-conflicting-ink-markers-2.rs:11:10
+   |
+11 |     #[ink(storage)] // We cannot have #[ink(event)] if we already have #[ink(storage)]
+   |          ^^^^^^^^^

--- a/lang2/macro/tests/ui/fail/18-conflicting-ink-markers-2.stderr
+++ b/lang2/macro/tests/ui/fail/18-conflicting-ink-markers-2.stderr
@@ -1,5 +1,5 @@
 error: invalid ink! attribute found for `#[ink(event)]` struct
   --> $DIR/18-conflicting-ink-markers-2.rs:11:10
    |
-11 |     #[ink(storage)] // We cannot have #[ink(event)] if we already have #[ink(storage)]
+11 |     #[ink(storage)] // We cannot have #[ink(storage)] if we already have #[ink(event)]
    |          ^^^^^^^^^

--- a/lang2/macro/tests/ui/fail/19-unknown-struct-ink-marker.rs
+++ b/lang2/macro/tests/ui/fail/19-unknown-struct-ink-marker.rs
@@ -1,0 +1,22 @@
+#![feature(proc_macro_hygiene)]
+
+use ink_lang2 as ink;
+
+#[ink::contract(version = "0.1.0")]
+mod noop {
+    #[ink(storage)]
+    struct Noop {}
+
+    #[ink(unknown_or_unsupported)]
+    struct HasUnknownMarker {}
+
+    impl Noop {
+        #[ink(constructor)]
+        fn new(&mut self) {}
+
+        #[ink(message)]
+        fn noop(&self) {}
+    }
+}
+
+fn main() {}

--- a/lang2/macro/tests/ui/fail/19-unknown-struct-ink-marker.stderr
+++ b/lang2/macro/tests/ui/fail/19-unknown-struct-ink-marker.stderr
@@ -1,0 +1,12 @@
+error: encountered unsupported ink! markers for struct
+  --> $DIR/19-unknown-struct-ink-marker.rs:10:5
+   |
+10 | /     #[ink(unknown_or_unsupported)]
+11 | |     struct HasUnknownMarker {}
+   | |______________________________^
+
+error: unsupported ink! marker for struct
+  --> $DIR/19-unknown-struct-ink-marker.rs:10:10
+   |
+10 |     #[ink(unknown_or_unsupported)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lang2/macro/tests/ui/fail/20-unknown-method-marker.rs
+++ b/lang2/macro/tests/ui/fail/20-unknown-method-marker.rs
@@ -1,0 +1,25 @@
+#![feature(proc_macro_hygiene)]
+
+use ink_lang2 as ink;
+
+#[ink::contract(version = "0.1.0")]
+mod noop {
+    #[ink(storage)]
+    struct Noop {}
+
+    impl Noop {
+        #[ink(constructor)]
+        fn new(&mut self) {}
+
+        #[ink(message)]
+        fn noop(&self) {}
+
+        #[ink(unknown_marker)]
+        fn has_unknown_marker(&self) {}
+
+        #[ink(unknown_marker_2)]
+        fn has_unknown_marker_too(&mut self) {}
+    }
+}
+
+fn main() {}

--- a/lang2/macro/tests/ui/fail/20-unknown-method-marker.stderr
+++ b/lang2/macro/tests/ui/fail/20-unknown-method-marker.stderr
@@ -1,0 +1,5 @@
+error: unknown ink! marker
+  --> $DIR/20-unknown-method-marker.rs:17:14
+   |
+17 |         #[ink(unknown_marker)]
+   |              ^^^^^^^^^^^^^^^^

--- a/lang2/macro/tests/ui/pass/03-incrementer-contract.rs
+++ b/lang2/macro/tests/ui/pass/03-incrementer-contract.rs
@@ -18,7 +18,7 @@ mod incrementer {
         by: i32,
     }
 
-    impl Flipper {
+    impl Incrementer {
         #[ink(constructor)]
         fn new(&mut self, init_value: i32) {
             self.value.set(init_value as i64);

--- a/lang2/macro/tests/ui/pass/04-erc20-contract.rs
+++ b/lang2/macro/tests/ui/pass/04-erc20-contract.rs
@@ -32,7 +32,7 @@ mod erc20 {
         amount: Balance,
     }
 
-    impl Flipper {
+    impl Erc20 {
         #[ink(constructor)]
         fn new(&mut self, initial_supply: Balance) {
             let caller = self.env().caller();


### PR DESCRIPTION
## Improved or added diagnostics

- [x] New diagnostics: missing `#[ink(storage)] struct` definition + tests
- [x] New test: multiple conflicting `#[ink(storage)] struct` definitions
- [x] New diagnostics: invalid ink! impl block non-#[ink(storage)] implementer
- [x] New diagnostics: unsupported ink! markers on structs
- [x] A struct is now treated as either storage or event depending on the order in which both `#[ink(storage)]` and `#[ink(event)]` has been provided if both have been provided. Old behaviour was to always default to storage.
- [x] New test: conflicting ink! event and storage markers.
- [x] Fixed some success tests: Incrementer, Erc20
- [x] Improved diagnostics with multiple conflicting `#[ink(storage)]` markers
- [x] New diagnostics: unknown `#[ink(..)]` marker on `struct`s
- [x] New diagnostics: unknown `#[ink(..)]` marker on `impl` block methods