### PR TITLE
Update subxt to 0.2

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,7 +28,7 @@ pwasm-utils = "0.11.0"
 parity-wasm = "0.40.2"
 cargo_metadata = "0.8.2"
 substrate-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-primitives" }
-subxt = { git = "https://github.com/paritytech/substrate-subxt/", branch = "v0.1", package = "substrate-subxt" }
+subxt = { git = "https://github.com/paritytech/substrate-subxt/", branch = "v0.2", package = "substrate-subxt" }
 tokio = "0.1.21"
 url = "1.7"
 


### PR DESCRIPTION
Fixes #241, subxt 0.2 is updated to match the latest substrate master