### PR TITLE
Fix undeclared ink_prelude bug

### DIFF
--- a/examples/lang/delegator/Cargo.toml
+++ b/examples/lang/delegator/Cargo.toml
@@ -34,6 +34,7 @@ std = [
     "ink_core/std",
     "ink_model/std",
     "ink_lang/std",
+    "ink_prelude/std",
     "scale/std",
     "type-metadata/std",
 

--- a/examples/lang/delegator/Cargo.toml
+++ b/examples/lang/delegator/Cargo.toml
@@ -9,6 +9,7 @@ ink_abi = { path = "../../../abi", default-features = false, features = ["derive
 ink_core = { path = "../../../core", default-features = false }
 ink_model = { path = "../../../model", default-features = false }
 ink_lang = { path = "../../../lang", default-features = false }
+ink_prelude = { path = "../../../prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }

--- a/examples/lang/delegator/accumulator/Cargo.toml
+++ b/examples/lang/delegator/accumulator/Cargo.toml
@@ -9,6 +9,7 @@ ink_abi = { path = "../../../../abi", default-features = false, features = ["der
 ink_core = { path = "../../../../core", default-features = false }
 ink_model = { path = "../../../../model", default-features = false }
 ink_lang = { path = "../../../../lang", default-features = false }
+ink_prelude = { path = "../../../../prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }
@@ -29,6 +30,7 @@ std = [
     "ink_core/std",
     "ink_model/std",
     "ink_lang/std",
+    "ink_prelude/std",
     "scale/std",
     "type-metadata/std",
 ]

--- a/examples/lang/delegator/adder/Cargo.toml
+++ b/examples/lang/delegator/adder/Cargo.toml
@@ -9,6 +9,7 @@ ink_abi = { path = "../../../../abi", default-features = false, features = ["der
 ink_core = { path = "../../../../core", default-features = false }
 ink_model = { path = "../../../../model", default-features = false }
 ink_lang = { path = "../../../../lang", default-features = false }
+ink_prelude = { path = "../../../../prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }
@@ -31,6 +32,7 @@ std = [
     "ink_core/std",
     "ink_model/std",
     "ink_lang/std",
+    "ink_prelude/std",
     "scale/std",
     "type-metadata/std",
 

--- a/examples/lang/delegator/subber/Cargo.toml
+++ b/examples/lang/delegator/subber/Cargo.toml
@@ -9,6 +9,7 @@ ink_abi = { path = "../../../../abi", default-features = false, features = ["der
 ink_core = { path = "../../../../core", default-features = false }
 ink_model = { path = "../../../../model", default-features = false }
 ink_lang = { path = "../../../../lang", default-features = false }
+ink_prelude = { path = "../../../../prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }
@@ -31,6 +32,7 @@ std = [
     "ink_core/std",
     "ink_model/std",
     "ink_lang/std",
+    "ink_prelude/std",
     "scale/std",
     "type-metadata/std",
 ]

--- a/examples/lang/erc20/Cargo.toml
+++ b/examples/lang/erc20/Cargo.toml
@@ -30,6 +30,7 @@ std = [
     "ink_core/std",
     "ink_model/std",
     "ink_lang/std",
+    "ink_prelude/std",
     "type-metadata/std",
     "scale/std",
 ]

--- a/examples/lang/erc20/Cargo.toml
+++ b/examples/lang/erc20/Cargo.toml
@@ -9,6 +9,7 @@ ink_abi = { path = "../../../abi", default-features = false, features = ["derive
 ink_core = { path = "../../../core", default-features = false }
 ink_model = { path = "../../../model", default-features = false }
 ink_lang = { path = "../../../lang", default-features = false }
+ink_prelude = { path = "../../../prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }

--- a/examples/lang/erc721/Cargo.toml
+++ b/examples/lang/erc721/Cargo.toml
@@ -30,6 +30,7 @@ std = [
     "ink_core/std",
     "ink_model/std",
     "ink_lang/std",
+    "ink_prelude/std",
     "type-metadata/std",
     "scale/std",
 ]

--- a/examples/lang/erc721/Cargo.toml
+++ b/examples/lang/erc721/Cargo.toml
@@ -9,6 +9,7 @@ ink_abi = { path = "../../../abi", default-features = false, features = ["derive
 ink_core = { path = "../../../core", default-features = false }
 ink_model = { path = "../../../model", default-features = false }
 ink_lang = { path = "../../../lang", default-features = false }
+ink_prelude = { path = "../../../prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }

--- a/examples/lang/flipper/Cargo.toml
+++ b/examples/lang/flipper/Cargo.toml
@@ -9,6 +9,7 @@ ink_abi = { path = "../../../abi", default-features = false, features = ["derive
 ink_core = { path = "../../../core", default-features = false }
 ink_model = { path = "../../../model", default-features = false }
 ink_lang = { path = "../../../lang", default-features = false }
+ink_prelude = { path = "../../../prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }

--- a/examples/lang/flipper/Cargo.toml
+++ b/examples/lang/flipper/Cargo.toml
@@ -30,6 +30,7 @@ std = [
     "ink_core/std",
     "ink_model/std",
     "ink_lang/std",
+    "ink_prelude/std",
     "scale/std",
     "type-metadata/std",
 ]

--- a/examples/lang/incrementer/Cargo.toml
+++ b/examples/lang/incrementer/Cargo.toml
@@ -9,6 +9,7 @@ ink_abi = { path = "../../../abi", default-features = false, features = ["derive
 ink_core = { path = "../../../core", default-features = false }
 ink_model = { path = "../../../model", default-features = false }
 ink_lang = { path = "../../../lang", default-features = false }
+ink_prelude = { path = "../../../prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }

--- a/examples/lang/incrementer/Cargo.toml
+++ b/examples/lang/incrementer/Cargo.toml
@@ -30,6 +30,7 @@ std = [
     "ink_core/std",
     "ink_model/std",
     "ink_lang/std",
+    "ink_prelude/std",
     "scale/std",
     "type-metadata/std",
 ]


### PR DESCRIPTION
All examples used `ink_prelude` crate in `lang` can not work, add 
`ink_prelude = { path = "../../../prelude", default-features = false }` in `Cargo.toml`