### PR TITLE
[core] Constrain `invoke_runtime` type

### DIFF
--- a/core/src/env2/srml/impls.rs
+++ b/core/src/env2/srml/impls.rs
@@ -22,6 +22,7 @@ use scale::{
 use crate::{
     env2::{
         call::{
+            CallData,
             CallParams,
             CreateParams,
             ReturnType,
@@ -349,10 +350,9 @@ where
         ext::deposit_event(topics, data);
     }
 
-    fn invoke_runtime<O, V>(buffer: &mut O, call_data: &V)
+    fn invoke_runtime<O>(buffer: &mut O, call_data: &CallData)
     where
         O: scale::Output + AsRef<[u8]> + Reset,
-        V: scale::Encode,
     {
         buffer.reset();
         call_data.encode_to(buffer);

--- a/core/src/env2/test/accessor.rs
+++ b/core/src/env2/test/accessor.rs
@@ -31,6 +31,7 @@ use core::{
 use crate::{
     env2::{
         call::{
+            CallData,
             CallParams,
             CreateParams,
             ReturnType,
@@ -420,10 +421,9 @@ where
         })
     }
 
-    fn invoke_runtime<O, V>(_buffer: &mut O, call_data: &V)
+    fn invoke_runtime<O>(_buffer: &mut O, call_data: &CallData)
     where
         O: scale::Output + AsRef<[u8]> + Reset,
-        V: scale::Encode,
     {
         // With the off-chain test environment we have no means
         // to emit an event on the chain since there is no chain.
@@ -435,7 +435,7 @@ where
             instance
                 .borrow_mut()
                 .records
-                .push(Record::from(InvokeRuntimeRecord::new(call_data.encode())));
+                .push(Record::from(InvokeRuntimeRecord::new(call_data.to_bytes())));
         })
     }
 

--- a/core/src/env2/traits.rs
+++ b/core/src/env2/traits.rs
@@ -17,6 +17,7 @@ use scale::Codec;
 use crate::{
     env2::{
         call::{
+            CallData,
             CallParams,
             CreateParams,
             ReturnType,
@@ -147,10 +148,9 @@ pub trait Env:
         Event: Topics<Self> + scale::Encode;
 
     /// Invokes a runtime dispatchable function with the given call data.
-    fn invoke_runtime<O, V>(buffer: &mut O, call_data: &V)
+    fn invoke_runtime<O>(buffer: &mut O, call_data: &CallData)
     where
-        O: scale::Output + AsRef<[u8]> + Reset,
-        V: scale::Encode;
+        O: scale::Output + AsRef<[u8]> + Reset;
 
     /// Restores the contract to the given address.
     ///


### PR DESCRIPTION
These are the changes to constrain the call data parameter of `invoke_runtime` as mentioned in issue #297