### PR TITLE
[core] Constrain invoke_runtime parameter

### DIFF
--- a/core/src/env2/srml/impls.rs
+++ b/core/src/env2/srml/impls.rs
@@ -349,13 +349,13 @@ where
         ext::deposit_event(topics, data);
     }
 
-    fn invoke_runtime<O, V>(buffer: &mut O, call_data: &V)
+    fn invoke_runtime<O, V>(buffer: &mut O, call_data: V)
     where
         O: scale::Output + AsRef<[u8]> + Reset,
-        V: scale::Encode,
+        V: Into<<Self as EnvTypes>::Call>,
     {
         buffer.reset();
-        call_data.encode_to(buffer);
+        call_data.into().encode_to(buffer);
         ext::dispatch_call(buffer.as_ref());
     }
 

--- a/core/src/env2/srml/impls.rs
+++ b/core/src/env2/srml/impls.rs
@@ -349,7 +349,7 @@ where
         ext::deposit_event(topics, data);
     }
 
-    fn invoke_runtime<O, V>(buffer: &mut O, call_data: &<Self as EnvTypes>::Call)
+    fn invoke_runtime<O>(buffer: &mut O, call_data: &<Self as EnvTypes>::Call)
     where
         O: scale::Output + AsRef<[u8]> + Reset,
     {

--- a/core/src/env2/srml/impls.rs
+++ b/core/src/env2/srml/impls.rs
@@ -349,13 +349,12 @@ where
         ext::deposit_event(topics, data);
     }
 
-    fn invoke_runtime<O, V>(buffer: &mut O, call_data: V)
+    fn invoke_runtime<O, V>(buffer: &mut O, call_data: &<Self as EnvTypes>::Call)
     where
         O: scale::Output + AsRef<[u8]> + Reset,
-        V: Into<<Self as EnvTypes>::Call>,
     {
         buffer.reset();
-        call_data.into().encode_to(buffer);
+        call_data.encode_to(buffer);
         ext::dispatch_call(buffer.as_ref());
     }
 

--- a/core/src/env2/test/accessor.rs
+++ b/core/src/env2/test/accessor.rs
@@ -421,10 +421,9 @@ where
         })
     }
 
-    fn invoke_runtime<O, V>(_buffer: &mut O, call_data: V)
+    fn invoke_runtime<O>(_buffer: &mut O, call_data: &<Self as EnvTypes>::Call)
     where
         O: scale::Output + AsRef<[u8]> + Reset,
-        V: Into<<Self as EnvTypes>::Call>,
     {
         // With the off-chain test environment we have no means
         // to emit an event on the chain since there is no chain.
@@ -436,9 +435,7 @@ where
             instance
                 .borrow_mut()
                 .records
-                .push(Record::from(InvokeRuntimeRecord::new(
-                    call_data.into().encode(),
-                )));
+                .push(Record::from(InvokeRuntimeRecord::new(call_data.encode())));
         })
     }
 

--- a/core/src/env2/test/accessor.rs
+++ b/core/src/env2/test/accessor.rs
@@ -65,6 +65,7 @@ use crate::{
     },
     storage::Key,
 };
+use scale::Encode;
 
 thread_local! {
     /// The single thread-local test environment instance.
@@ -420,10 +421,10 @@ where
         })
     }
 
-    fn invoke_runtime<O, V>(_buffer: &mut O, call_data: &V)
+    fn invoke_runtime<O, V>(_buffer: &mut O, call_data: V)
     where
         O: scale::Output + AsRef<[u8]> + Reset,
-        V: scale::Encode,
+        V: Into<<Self as EnvTypes>::Call>,
     {
         // With the off-chain test environment we have no means
         // to emit an event on the chain since there is no chain.
@@ -435,7 +436,9 @@ where
             instance
                 .borrow_mut()
                 .records
-                .push(Record::from(InvokeRuntimeRecord::new(call_data.encode())));
+                .push(Record::from(InvokeRuntimeRecord::new(
+                    call_data.into().encode(),
+                )));
         })
     }
 

--- a/core/src/env2/traits.rs
+++ b/core/src/env2/traits.rs
@@ -147,10 +147,10 @@ pub trait Env:
         Event: Topics<Self> + scale::Encode;
 
     /// Invokes a runtime dispatchable function with the given call data.
-    fn invoke_runtime<O, V>(buffer: &mut O, call_data: &V)
+    fn invoke_runtime<O, V>(buffer: &mut O, call_data: V)
     where
         O: scale::Output + AsRef<[u8]> + Reset,
-        V: scale::Encode;
+        V: Into<<Self as EnvTypes>::Call>;
 
     /// Restores the contract to the given address.
     ///

--- a/core/src/env2/traits.rs
+++ b/core/src/env2/traits.rs
@@ -147,10 +147,9 @@ pub trait Env:
         Event: Topics<Self> + scale::Encode;
 
     /// Invokes a runtime dispatchable function with the given call data.
-    fn invoke_runtime<O, V>(buffer: &mut O, call_data: V)
+    fn invoke_runtime<O>(buffer: &mut O, call_data: &<Self as EnvTypes>::Call)
     where
-        O: scale::Output + AsRef<[u8]> + Reset,
-        V: Into<<Self as EnvTypes>::Call>;
+        O: scale::Output + AsRef<[u8]> + Reset;
 
     /// Restores the contract to the given address.
     ///


### PR DESCRIPTION
As discussed in #297. Use the same constraint `Into<<Self as EnvTypes>::Call>` as in the first [env/api.rs#L84](https://github.com/paritytech/ink/blob/master/core/src/env/api.rs#L84).

This is also a prerequisite to exposing the `invoke_runtime` method as will be done from https://github.com/paritytech/ink-types-node-runtime/pull/7

