### PR TITLE
[core, lang] fix cargo test --workspace failures

### DIFF
--- a/core/derive/Cargo.toml
+++ b/core/derive/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../README.md"
 proc-macro = true
 
 [dependencies]
+ink_primitives = { path = "../../primitives", default-features = false }
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"
@@ -22,4 +23,6 @@ trybuild = "1.0"
 
 [features]
 default = ["std"]
-std = []
+std = [
+    "ink_primitives/std",
+]

--- a/lang/macro/tests/ui/fail/14-missing-storage-struct.stderr
+++ b/lang/macro/tests/ui/fail/14-missing-storage-struct.stderr
@@ -3,3 +3,5 @@ error: no #[ink(storage)] struct found but expected exactly 1
   |
 3 | #[ink::contract(version = "0.1.0")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/lang/macro/tests/ui/fail/15-multiple-storage-structs.stderr
+++ b/lang/macro/tests/ui/fail/15-multiple-storage-structs.stderr
@@ -3,6 +3,8 @@ error: encountered 2 conflicting storage structs
   |
 3 | #[ink::contract(version = "0.1.0")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: conflicting storage struct
  --> $DIR/15-multiple-storage-structs.rs:6:12


### PR DESCRIPTION
Fixes test failures with the new `cargo test --workspace` command.