### PR TITLE
Add plain multisig wallet example

### DIFF
--- a/examples/multisig_plain/.cargo/config
+++ b/examples/multisig_plain/.cargo/config
@@ -1,4 +1,0 @@
-[target.wasm32-unknown-unknown]
-rustflags = [
-	"-C", "link-args=-z stack-size=65536 --import-memory"
-]

--- a/examples/multisig_plain/.cargo/config
+++ b/examples/multisig_plain/.cargo/config
@@ -1,0 +1,4 @@
+[target.wasm32-unknown-unknown]
+rustflags = [
+	"-C", "link-args=-z stack-size=65536 --import-memory"
+]

--- a/examples/multisig_plain/.gitignore
+++ b/examples/multisig_plain/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/examples/multisig_plain/.ink/abi_gen/Cargo.toml
+++ b/examples/multisig_plain/.ink/abi_gen/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "abi-gen"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+publish = false
+
+[[bin]]
+name = "abi-gen"
+path = "main.rs"
+
+[dependencies]
+contract = { path = "../..", package = "multisig_plain", default-features = false, features = ["ink-generate-abi"] }
+ink_lang = { git = "https://github.com/paritytech/ink", package = "ink_lang", default-features = false, features = ["ink-generate-abi"] }
+serde = "1.0"
+serde_json = "1.0"

--- a/examples/multisig_plain/.ink/abi_gen/Cargo.toml
+++ b/examples/multisig_plain/.ink/abi_gen/Cargo.toml
@@ -11,6 +11,6 @@ path = "main.rs"
 
 [dependencies]
 contract = { path = "../..", package = "multisig_plain", default-features = false, features = ["ink-generate-abi"] }
-ink_lang = { git = "https://github.com/paritytech/ink", package = "ink_lang", default-features = false, features = ["ink-generate-abi"] }
+ink_lang = { path = "../../../../lang", package = "ink_lang", default-features = false, features = ["ink-generate-abi"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/examples/multisig_plain/.ink/abi_gen/main.rs
+++ b/examples/multisig_plain/.ink/abi_gen/main.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), std::io::Error> {
+    let abi = <contract::MultisigPlain as ink_lang::GenerateAbi>::generate_abi();
+    let contents = serde_json::to_string_pretty(&abi)?;
+    std::fs::create_dir("target").ok();
+    std::fs::write("target/metadata.json", contents)?;
+    Ok(())
+}

--- a/examples/multisig_plain/Cargo.toml
+++ b/examples/multisig_plain/Cargo.toml
@@ -1,0 +1,62 @@
+[package]
+name = "multisig_plain"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2018"
+
+[dependencies]
+ink_abi = { path = "../../abi", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { path = "../../primitives", default-features = false }
+ink_core = { path = "../../core", default-features = false }
+ink_lang = { path = "../../lang", default-features = false }
+ink_prelude = { path = "../../prelude", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
+type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }
+
+[lib]
+name = "multisig_plain"
+path = "lib.rs"
+crate-type = [
+	# Used for normal contract Wasm blobs.
+	"cdylib",
+	# Used for ABI generation.
+	"rlib",
+]
+
+[features]
+default = ["test-env"]
+std = [
+    "ink_abi/std",
+    "ink_core/std",
+    "ink_primitives/std",
+    "ink_prelude/std",
+    "scale/std",
+    "type-metadata/std",
+]
+test-env = [
+    "std",
+    "ink_lang/test-env",
+]
+ink-generate-abi = [
+    "std",
+    "ink_abi",
+    "type-metadata",
+    "ink_core/ink-generate-abi",
+    "ink_lang/ink-generate-abi",
+]
+ink-as-dependency = []
+
+[profile.release]
+panic = "abort"
+lto = true
+opt-level = "z"
+overflow-checks = true
+
+[workspace]
+members = [
+	".ink/abi_gen"
+]
+exclude = [
+	".ink"
+]

--- a/examples/multisig_plain/Cargo.toml
+++ b/examples/multisig_plain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "multisig_plain"
 version = "0.1.0"
-authors = ["[your_name] <[your_email]>"]
+authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -184,7 +184,11 @@ mod multisig_plain {
                 .map_err(|_| ())
         }
 
-        fn confirm_by_caller(&mut self, confirmer: AccountId, transaction: TransactionId) {
+        fn confirm_by_caller(
+            &mut self,
+            confirmer: AccountId,
+            transaction: TransactionId,
+        ) {
             if self
                 .confirmations
                 .insert((transaction, confirmer), ())

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -66,7 +66,7 @@
 
 use ink_lang as ink;
 
-#[ink::contract(version = "0.1.0", env = MyEnv)]
+#[ink::contract(version = "0.1.0", env = ink_core::env::DefaultEnvTypes)]
 mod multisig_plain {
     use ink_core::{
         env,
@@ -75,8 +75,6 @@ mod multisig_plain {
     use ink_prelude::vec::Vec;
     use scale::Output;
 
-    /// When using custom types in your runtime. Here is the place to declare them.
-    type MyEnv = env::DefaultEnvTypes;
     /// Tune this to your liking but be that many owners will not perform well.
     const MAX_OWNERS: u32 = 50;
 
@@ -252,7 +250,7 @@ mod multisig_plain {
         fn execute_transaction(&mut self, trans_id: TransactionId) -> Result<(), ()> {
             self.ensure_confirmed(trans_id);
             let t = self.take_transaction(trans_id).expect(WRONG_TRANSACTION_ID);
-            env::call::CallParams::<MyEnv, ()>::invoke(t.callee, t.selector.into())
+            env::call::CallParams::<EnvTypes, ()>::invoke(t.callee, t.selector.into())
                 .gas_limit(t.gas_limit)
                 .transferred_value(t.transferred_value)
                 .push_arg(&CallInput(&t.input))
@@ -363,7 +361,7 @@ mod multisig_plain {
     mod tests {
         use super::*;
         use ink_core::env::test;
-        type Accounts = test::DefaultAccounts<MyEnv>;
+        type Accounts = test::DefaultAccounts<EnvTypes>;
 
         fn default_accounts() -> Accounts {
             test::default_accounts()

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -194,26 +194,17 @@ mod multisig_plain {
         transaction: TransactionId,
     }
 
-    /// Emitted when a transaction was executed without evaluating its output.
+    /// Emitted when a transaction was executed.
     #[ink(event)]
-    struct Invokation {
+    struct Execution {
         /// The transaction that was executed.
         #[ink(topic)]
         transaction: TransactionId,
-        /// Indicates whether the transaction executed successfully.
+        /// Indicates whether the transaction executed successfully. If so the `Ok` value holds
+        /// the output in bytes. The Option is `None` when the transaction was executed through
+        /// `invoke_transaction` rather than `evaluate_transaction`.
         #[ink(topic)]
-        result: Result<(), ()>,
-    }
-
-    /// Emitted when a transaction was executed and its output is evaluated.
-    #[ink(event)]
-    struct Evaluation {
-        /// The transaction that was executed.
-        #[ink(topic)]
-        transaction: TransactionId,
-        /// The output of the transaction as bytes.
-        #[ink(topic)]
-        result: Result<Vec<u8>, ()>,
+        result: Result<Option<Vec<u8>>, ()>,
     }
 
     /// Emitted when an owner is added to the wallet.
@@ -442,9 +433,9 @@ mod multisig_plain {
             )
             .fire()
             .map_err(|_| ());
-            self.env().emit_event(Invokation {
+            self.env().emit_event(Execution {
                 transaction: trans_id,
-                result,
+                result: result.map(|_| None),
             });
             result
         }
@@ -464,9 +455,9 @@ mod multisig_plain {
             )
             .fire()
             .map_err(|_| ());
-            self.env().emit_event(Evaluation {
+            self.env().emit_event(Execution {
                 transaction: trans_id,
-                result: result.clone(),
+                result: result.clone().map(|val| Some(val)),
             });
             result
         }

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -467,11 +467,17 @@ mod multisig_plain {
                 .expect("Test environment is expected to be initialized.")
         }
 
+        fn build_contract() -> MultisigPlain {
+            let accounts = default_accounts();
+            let owners = ink_prelude::vec![accounts.alice, accounts.bob, accounts.eve];
+            MultisigPlain::new(owners, 2)
+        }
+
         #[test]
         fn construction_works() {
             let accounts = default_accounts();
             let owners = ink_prelude::vec![accounts.alice, accounts.bob, accounts.eve];
-            let contract = MultisigPlain::new(owners.clone(), 2);
+            let contract = build_contract();
 
             assert_eq!(contract.owners.len(), 3);
             assert_eq!(*contract.requirement.get(), 2);
@@ -485,6 +491,36 @@ mod multisig_plain {
             assert_eq!(contract.confirmations.len(), 0);
             assert_eq!(contract.confirmation_count.len(), 0);
             assert_eq!(contract.transactions.len(), 0);
+        }
+
+        #[test]
+        #[should_panic]
+        fn empty_owner_construction_fails() {
+            MultisigPlain::new(vec![], 0);
+        }
+
+        #[test]
+        #[should_panic]
+        fn zero_requirement_construction_fails() {
+            let accounts = default_accounts();
+            MultisigPlain::new(vec![accounts.alice, accounts.bob], 0);
+        }
+
+        #[test]
+        #[should_panic]
+        fn too_large_requirement_construction_fails() {
+            let accounts = default_accounts();
+            MultisigPlain::new(vec![accounts.alice, accounts.bob], 3);
+        }
+
+        #[test]
+        fn add_owner_works() {
+            let accounts = default_accounts();
+            let mut contract = build_contract();
+            let owners = contract.owners.len();
+            contract.add_owner(accounts.frank);
+            assert_eq!(contract.owners.len(), owners + 1);
+            assert!(contract.is_owner.get(&accounts.frank).is_some());
         }
     }
 }

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -108,7 +108,7 @@ mod multisig_plain {
         callee: AccountId,
         /// The selector bytes that identifies the function of the callee that should be called.
         selector: [u8; 4],
-        /// The raw parameters that are passed to the called function.
+        /// The SCALE encoded parameters that are passed to the called function.
         input: Vec<u8>,
         /// The amount of chain balance that is transferred to the callee.
         transferred_value: Balance,

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -399,6 +399,7 @@ mod multisig_plain {
         /// This can be called by any owner.
         ///
         /// # Panics
+        ///
         /// If `trans_id` is no valid transaction id.
         #[ink(message)]
         fn confirm_transaction(&mut self, trans_id: TransactionId) -> ConfirmationStatus {

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -80,7 +80,7 @@ mod multisig_plain {
     use ink_prelude::vec::Vec;
     use scale::Output;
 
-    /// Tune this to your liking but be wary that many owners will not perform well.
+    /// Tune this to your liking but be wary that allowing too many owners will not perform well.
     const MAX_OWNERS: u32 = 50;
 
     type TransactionId = u32;

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -87,7 +87,9 @@ mod multisig_plain {
     const WRONG_TRANSACTION_ID: &str =
         "The user specified an invalid transaction id. Abort.";
 
-    /// A wrapper that allows us to pass untyped parameters as blob to a `CallBuilder`
+    /// A wrapper that allows us to encode a blob of bytes.
+    ///
+    /// We use this to pass the set of untyped (bytes) parameters to the `CallBuilder`.
     struct CallInput<'a>(&'a [u8]);
 
     impl<'a> scale::Encode for CallInput<'a> {

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -361,8 +361,8 @@ mod multisig_plain {
             self.ensure_confirmed(trans_id);
             let t = self.take_transaction(trans_id).expect(WRONG_TRANSACTION_ID);
             let result = parameterize_call(
+                &t,
                 CallParams::<EnvTypes, ()>::invoke(t.callee, t.selector.into()),
-                t,
             )
             .fire()
             .map_err(|_| ());
@@ -381,8 +381,8 @@ mod multisig_plain {
             self.ensure_confirmed(trans_id);
             let t = self.take_transaction(trans_id).expect(WRONG_TRANSACTION_ID);
             let result = parameterize_call(
+                &t,
                 CallParams::<EnvTypes, Vec<u8>>::eval(t.callee, t.selector.into()),
-                t,
             )
             .fire()
             .map_err(|_| ());
@@ -490,8 +490,8 @@ mod multisig_plain {
 
     /// Parameterize a call with the arguments stored inside a transaction.
     fn parameterize_call<R>(
+        t: &Transaction,
         builder: CallBuilder<EnvTypes, R, Unsealed>,
-        t: Transaction,
     ) -> CallBuilder<EnvTypes, R, Sealed> {
         builder
             .gas_limit(t.gas_limit)

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -96,6 +96,7 @@ mod multisig_plain {
     /// A Transaction is what every `owner` can submit for confirmation by other owners.
     /// If enough owners agree it will be executed by the contract.
     #[derive(scale::Encode, scale::Decode, storage::Flush)]
+    #[cfg_attr(feature = "ink-generate-abi", derive(type_metadata::Metadata))]
     #[cfg_attr(feature = "std", derive(Debug))]
     pub struct Transaction {
         /// The AccountId of the contract that is called in this transaction.

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -106,7 +106,7 @@ mod multisig_plain {
     pub struct Transaction {
         /// The AccountId of the contract that is called in this transaction.
         callee: AccountId,
-        /// The raw selector which is the function name of the `callee`that is called.
+        /// The selector bytes that identifies the function of the callee that should be called.
         selector: [u8; 4],
         /// The raw parameters that are passed to the called function.
         input: Vec<u8>,

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -230,7 +230,7 @@ mod multisig_plain {
             self.transactions.get(id).unwrap();
         }
 
-        fn ensure_from_owner(&self) {
+        fn ensure_caller_is_owner(&self) {
             assert!(self.is_owner.contains_key(&self.env().caller()));
         }
 

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -75,7 +75,7 @@ mod multisig_plain {
     use ink_prelude::vec::Vec;
     use scale::Output;
 
-    /// Tune this to your liking but be that many owners will not perform well.
+    /// Tune this to your liking but be wary that many owners will not perform well.
     const MAX_OWNERS: u32 = 50;
 
     type TransactionId = u32;

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -119,7 +119,7 @@ mod multisig_plain {
         }
 
         #[ink(message)]
-        fn replace_owner(&mut self, owner: AccountId, new_owner: AccountId) {
+        fn replace_owner(&mut self, old_owner: AccountId, new_owner: AccountId) {
             self.ensure_from_wallet();
             self.ensure_owner(&owner);
             self.ensure_no_owner(&new_owner);

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -97,7 +97,7 @@ mod multisig_plain {
         }
 
         #[ink(message)]
-        fn add_owner(&mut self, owner: AccountId) {
+        fn add_owner(&mut self, new_owner: AccountId) {
             self.ensure_from_wallet();
             self.ensure_no_owner(&owner);
             ensure_requirement(self.owners.len() + 1, *self.requirement);

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -113,7 +113,7 @@ mod multisig_plain {
         /// The amount of chain balance that is transferred to the callee.
         transferred_value: Balance,
         /// Gas limit for the execution of the call.
-        gas_limit: Balance,
+        gas_limit: u64,
     }
 
     #[ink(storage)]

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -205,7 +205,7 @@ mod multisig_plain {
     impl MultisigPlain {
         /// The only constructor of the contract.
         /// A list of owners must be supplied and a number of how many of them must
-        ///confirm a transaction. Duplicate owners are silently dropped.
+        /// confirm a transaction. Duplicate owners are silently dropped.
         #[ink(constructor)]
         fn new(&mut self, owners: Vec<AccountId>, requirement: u32) {
             for owner in &owners {
@@ -470,10 +470,21 @@ mod multisig_plain {
         #[test]
         fn construction_works() {
             let accounts = default_accounts();
-            MultisigPlain::new(
-                ink_prelude::vec![accounts.alice, accounts.bob, accounts.eve],
-                2,
-            );
+            let owners = ink_prelude::vec![accounts.alice, accounts.bob, accounts.eve];
+            let contract = MultisigPlain::new(owners.clone(), 2);
+
+            assert_eq!(contract.owners.len(), 3);
+            assert_eq!(*contract.requirement.get(), 2);
+            assert!(contract.owners.iter().eq(owners.iter()));
+            assert!(contract.is_owner.get(&accounts.alice).is_some());
+            assert!(contract.is_owner.get(&accounts.bob).is_some());
+            assert!(contract.is_owner.get(&accounts.eve).is_some());
+            assert!(contract.is_owner.get(&accounts.charlie).is_none());
+            assert!(contract.is_owner.get(&accounts.django).is_none());
+            assert!(contract.is_owner.get(&accounts.frank).is_none());
+            assert_eq!(contract.confirmations.len(), 0);
+            assert_eq!(contract.confirmation_count.len(), 0);
+            assert_eq!(contract.transactions.len(), 0);
         }
     }
 }

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -319,7 +319,6 @@ mod multisig_plain {
         fn submit_transaction(&mut self, transaction: Transaction) -> ConfirmationStatus {
             self.ensure_caller_is_owner();
             let trans_id = self.transactions.put(transaction);
-            self.confirmation_count.insert(trans_id, 0);
             self.env().emit_event(Submission {
                 transaction: trans_id,
             });

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -91,7 +91,7 @@ mod multisig_plain {
                 self.is_owner.insert(*owner, ());
                 self.owners.push(*owner);
             }
-            ensure_requirement(self.owners.len(), requirement);
+            ensure_requirement_is_valid(self.owners.len(), requirement);
             assert!(self.is_owner.len() == self.owners.len());
             self.requirement.set(requirement);
         }
@@ -100,7 +100,7 @@ mod multisig_plain {
         fn add_owner(&mut self, new_owner: AccountId) {
             self.ensure_from_wallet();
             self.ensure_no_owner(&new_owner);
-            ensure_requirement(self.owners.len() + 1, *self.requirement);
+            ensure_requirement_is_valid(self.owners.len() + 1, *self.requirement);
             self.is_owner.insert(new_owner, ());
             self.owners.push(new_owner);
         }
@@ -111,7 +111,7 @@ mod multisig_plain {
             self.ensure_owner(&owner);
             let len = self.owners.len() - 1;
             let requirement = u32::min(len, *self.requirement.get());
-            ensure_requirement(len, requirement);
+            ensure_requirement_is_valid(len, requirement);
             self.owners.swap_remove(self.owner_index(&owner));
             self.is_owner.remove(&owner);
             self.requirement.set(requirement);
@@ -133,7 +133,7 @@ mod multisig_plain {
         #[ink(message)]
         fn change_requirement(&mut self, new_requirement: u32) {
             self.ensure_from_wallet();
-            ensure_requirement(self.owners.len(), new_requirement);
+            ensure_requirement_is_valid(self.owners.len(), new_requirement);
             self.requirement.set(new_requirement);
         }
 
@@ -250,7 +250,7 @@ mod multisig_plain {
         }
     }
 
-    fn ensure_requirement(owners: u32, requirement: u32) {
+    fn ensure_requirement_is_valid(owners: u32, requirement: u32) {
         assert!(0 < requirement && requirement <= owners && owners <= MAX_OWNERS);
     }
 

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -131,7 +131,7 @@ mod multisig_plain {
         /// The list is a vector because iterating over it is necessary when cleaning
         /// up the confirmation set.
         owners: storage::Vec<AccountId>,
-        /// Redundent information to speed up the check whether a caller is an owner.
+        /// Redundant information to speed up the check whether a caller is an owner.
         is_owner: storage::BTreeMap<AccountId, ()>,
         /// Minimum number of owners that have to confirm a transaction to be executed.
         requirement: storage::Value<u32>,

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -1,0 +1,231 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use ink_lang as ink;
+
+#[ink::contract(version = "0.1.0", env = MyEnv)]
+mod multisig_plain {
+    use ink_core::{
+        env,
+        storage,
+    };
+    use ink_prelude::vec::Vec;
+    use scale::Output;
+
+    type TransactionId = u32;
+    type MyEnv = env::DefaultEnvTypes;
+    const MAX_OWNERS: u32 = 50;
+
+    struct CallInput<'a>(&'a [u8]);
+
+    impl<'a> scale::Encode for CallInput<'a> {
+        fn encode_to<T: Output>(&self, dest: &mut T) {
+            dest.write(self.0);
+        }
+    }
+
+    #[derive(scale::Encode, scale::Decode, storage::Flush)]
+    #[cfg_attr(feature = "std", derive(Debug))]
+    pub struct Transaction {
+        callee: AccountId,
+        selector: [u8; 4],
+        input: Vec<u8>,
+        transferred_value: Balance,
+        gas_limit: u64,
+    }
+
+    #[ink(storage)]
+    struct MultisigPlain {
+        confirmations: storage::HashMap<(TransactionId, AccountId), ()>,
+        confirmation_count: storage::HashMap<TransactionId, u32>,
+        transactions: storage::Stash<Transaction>,
+        owners: storage::Vec<AccountId>,
+        is_owner: storage::HashMap<AccountId, ()>,
+        required: storage::Value<u32>,
+    }
+
+    impl MultisigPlain {
+        #[ink(constructor)]
+        fn new(&mut self, owners: Vec<AccountId>, required: u32) {
+            for owner in owners.iter() {
+                self.is_owner.insert(*owner, ());
+                self.owners.push(*owner);
+            }
+            ensure_requirement(self.owners.len(), required);
+            assert!(self.is_owner.len() == self.owners.len());
+            self.required.set(required);
+        }
+
+        #[ink(message)]
+        fn add_owner(&mut self, owner: AccountId) {
+            self.ensure_from_wallet();
+            self.ensure_no_owner(&owner);
+            ensure_requirement(self.owners.len() + 1, *self.required);
+            self.is_owner.insert(owner, ());
+            self.owners.push(owner);
+        }
+
+        #[ink(message)]
+        fn remove_owner(&mut self, owner: AccountId) {
+            self.ensure_from_wallet();
+            self.ensure_owner(&owner);
+            let len = self.owners.len() - 1;
+            let required = u32::min(len, *self.required.get());
+            ensure_requirement(len, required);
+            self.owners.swap_remove(self.owner_index(&owner));
+            self.is_owner.remove(&owner);
+            self.required.set(required);
+            self.clean_owner_confirmations(&owner);
+        }
+
+        #[ink(message)]
+        fn replace_owner(&mut self, owner: AccountId, new_owner: AccountId) {
+            self.ensure_from_wallet();
+            self.ensure_owner(&owner);
+            self.ensure_no_owner(&new_owner);
+            self.owners.replace(self.owner_index(&owner), || new_owner);
+            self.is_owner.remove(&owner);
+            self.is_owner.insert(new_owner, ());
+            self.clean_owner_confirmations(&owner);
+        }
+
+        #[ink(message)]
+        fn change_requirement(&mut self, requirement: u32) {
+            self.ensure_from_wallet();
+            ensure_requirement(self.owners.len(), requirement);
+            self.required.set(requirement);
+        }
+
+        #[ink(message)]
+        fn submit_transaction(&mut self, transaction: Transaction) {
+            self.ensure_from_owner();
+            let id = self.transactions.put(transaction);
+            self.confirmation_count.insert(id, 0);
+            self.internal_confirm(id);
+        }
+
+        #[ink(message)]
+        fn cancel_transaction(&mut self, id: TransactionId) {
+            self.ensure_from_wallet();
+            self.take_transaction(id);
+        }
+
+        #[ink(message)]
+        fn confirm_transaction(&mut self, id: TransactionId) {
+            self.ensure_from_owner();
+            self.ensure_transaction_exists(id);
+            self.internal_confirm(id);
+        }
+
+        #[ink(message)]
+        fn revoke_confirmation(&mut self, id: TransactionId) {
+            self.ensure_from_owner();
+            if self
+                .confirmations
+                .remove(&(id, self.env().caller()))
+                .is_some()
+            {
+                self.confirmation_count
+                    .mutate_with(&id, |count| *count -= 1);
+            }
+        }
+
+        #[ink(message)]
+        fn execute_transaction(&mut self, id: TransactionId) -> Result<(), ()> {
+            self.ensure_confirmed(id);
+            let t = self.take_transaction(id).unwrap();
+            env::call::CallParams::<MyEnv, ()>::invoke(t.callee, t.selector.into())
+                .gas_limit(t.gas_limit)
+                .transferred_value(t.transferred_value)
+                .push_arg(&CallInput(&t.input))
+                .fire()
+                .map(|_| ())
+                .map_err(|_| ())
+        }
+
+        fn internal_confirm(&mut self, id: TransactionId) {
+            if self
+                .confirmations
+                .insert((id, self.env().caller()), ())
+                .is_none()
+            {
+                self.confirmation_count
+                    .mutate_with(&id, |count| *count += 1);
+            }
+        }
+
+        fn owner_index(&self, owner: &AccountId) -> u32 {
+            self.owners.iter().position(|x| *x == *owner).unwrap() as u32
+        }
+
+        fn take_transaction(&mut self, id: TransactionId) -> Option<Transaction> {
+            let transaction = self.transactions.take(id);
+            if transaction.is_some() {
+                self.clean_transaction_confirmations(id);
+            }
+            transaction
+        }
+
+        fn clean_owner_confirmations(&mut self, owner: &AccountId) {
+            for (id, _) in self.transactions.iter() {
+                if self.confirmations.remove(&(id, *owner)).is_some() {
+                    self.confirmation_count
+                        .mutate_with(&id, |count| *count -= 1);
+                }
+            }
+        }
+
+        fn clean_transaction_confirmations(&mut self, transaction: TransactionId) {
+            for owner in self.owners.iter() {
+                self.confirmations.remove(&(transaction, *owner));
+            }
+            self.confirmation_count.remove(&transaction);
+        }
+
+        fn ensure_confirmed(&self, id: TransactionId) {
+            assert!(self.confirmation_count.get(&id).unwrap() >= self.required.get());
+        }
+
+        fn ensure_transaction_exists(&self, id: TransactionId) {
+            self.transactions.get(id).unwrap();
+        }
+
+        fn ensure_from_owner(&self) {
+            assert!(self.is_owner.contains_key(&self.env().caller()));
+        }
+
+        fn ensure_from_wallet(&self) {
+            assert!(self.env().caller() == self.env().account_id());
+        }
+
+        fn ensure_owner(&self, owner: &AccountId) {
+            assert!(self.is_owner.contains_key(owner));
+        }
+
+        fn ensure_no_owner(&self, owner: &AccountId) {
+            assert!(!self.is_owner.contains_key(owner));
+        }
+    }
+
+    fn ensure_requirement(owners: u32, required: u32) {
+        assert!(0 < required && required <= owners && owners <= MAX_OWNERS);
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use ink_core::env::test;
+        type Accounts = test::DefaultAccounts<MyEnv>;
+
+        #[test]
+        fn construction_works() {
+            test::run_test(|accounts: Accounts| {
+                MultisigPlain::new(
+                    ink_prelude::vec![accounts.alice, accounts.bob, accounts.eve],
+                    2,
+                );
+                Ok(())
+            })
+            .unwrap();
+        }
+    }
+}

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -142,7 +142,7 @@ mod multisig_plain {
             self.ensure_caller_is_owner();
             let trans_id = self.transactions.put(transaction);
             self.confirmation_count.insert(trans_id, 0);
-            self.add_confirmer(self.env().caller(), trans_id);
+            self.confirm_by_caller(self.env().caller(), trans_id);
         }
 
         #[ink(message)]
@@ -155,7 +155,7 @@ mod multisig_plain {
         fn confirm_transaction(&mut self, trans_id: TransactionId) {
             self.ensure_caller_is_owner();
             self.ensure_transaction_exists(trans_id);
-            self.add_confirmer(self.env().caller(), trans_id);
+            self.confirm_by_caller(self.env().caller(), trans_id);
         }
 
         #[ink(message)]
@@ -184,7 +184,7 @@ mod multisig_plain {
                 .map_err(|_| ())
         }
 
-        fn add_confirmer(&mut self, confirmer: AccountId, transaction: TransactionId) {
+        fn confirm_by_caller(&mut self, confirmer: AccountId, transaction: TransactionId) {
             if self
                 .confirmations
                 .insert((transaction, confirmer), ())

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -71,7 +71,7 @@
 
 use ink_lang as ink;
 
-#[ink::contract(version = "0.1.0", env = ink_core::env::DefaultEnvTypes)]
+#[ink::contract(version = "0.1.0")]
 mod multisig_plain {
     use ink_core::{
         env,
@@ -112,8 +112,8 @@ mod multisig_plain {
         input: Vec<u8>,
         /// The amount of chain balance that is transferred to the callee.
         transferred_value: Balance,
-        /// Gas limit for the transation.
-        gas_limit: u64,
+        /// Gas limit for the execution of the call.
+        gas_limit: Balance,
     }
 
     #[ink(storage)]
@@ -122,7 +122,7 @@ mod multisig_plain {
         /// transaction. This is effecively a set rather than a map.
         confirmations: storage::BTreeMap<(TransactionId, AccountId), ()>,
         /// The amount of confirmations for every transaction. This is a redundant
-        /// information this kept in order to prevent iterating through the
+        /// information and is kept in order to prevent iterating through the
         /// confirmation set to check if a transaction is confirmed.
         confirmation_count: storage::BTreeMap<TransactionId, u32>,
         /// Just the list of transactions. It is a stash as stable ids are necessary
@@ -246,7 +246,7 @@ mod multisig_plain {
             self.ensure_from_wallet();
             self.ensure_owner(&owner);
             let len = self.owners.len() - 1;
-            let requirement = u32::min(len, *self.requirement.get());
+            let requirement = u32::min(len, *self.requirement);
             self.ensure_requirement_is_valid(len, requirement);
             self.owners.swap_remove(self.owner_index(&owner));
             self.is_owner.remove(&owner);
@@ -387,7 +387,7 @@ mod multisig_plain {
         fn owner_index(&self, owner: &AccountId) -> u32 {
             self.owners.iter().position(|x| *x == *owner).expect(
                 "This is only called after it was already verified that the id is
-                actually an owner.",
+                 actually an owner.",
             ) as u32
         }
 
@@ -432,7 +432,7 @@ mod multisig_plain {
             );
         }
 
-        /// Panic of the transaction `trans_id` does not exit.
+        /// Panic if the transaction `trans_id` does not exit.
         fn ensure_transaction_exists(&self, trans_id: TransactionId) {
             self.transactions.get(trans_id).expect(WRONG_TRANSACTION_ID);
         }
@@ -607,7 +607,7 @@ mod multisig_plain {
 
         #[test]
         #[should_panic]
-        fn add_owner_existing_fails() {
+        fn add_existing_owner_fails() {
             let accounts = default_accounts();
             let mut contract = build_contract();
             set_from_wallet();

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -466,7 +466,7 @@ mod multisig_plain {
             .map_err(|_| ());
             self.env().emit_event(Execution {
                 transaction: trans_id,
-                result: result.clone().map(|val| Some(val)),
+                result: result.clone().map(Some),
             });
             result
         }

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -45,6 +45,11 @@
 //! will never trigger the execution of a `Transaction` even if the treshold is reached.
 //! A call of `execute_transaction` is always required. This can be called by anyone.
 //!
+//! All the messages that are declared as only callable by the wallet must go through
+//! the usual submit, confirm, execute cycle as any other transaction that should be
+//! called by the wallet. For example to add an owner you would submit a transaction
+//! that calls the wallets own `add_owner` message through `submit_transaction`.
+//!
 //! ### Owner Management
 //!
 //! The messages `add_owner`, `remove_owner`, and `replace_owner` can be used to manage

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -23,7 +23,9 @@
 //! Every owner can submit a transaction and when enough of the other owners confirm
 //! it will be able to be executed. The following invariant is enforced by the contract:
 //!
-//! ```0 < requirement && requirement <= owners && owners <= MAX_OWNERS```
+//! ```
+//! 0 < requirement && requirement <= owners && owners <= MAX_OWNERS
+//! ```
 //!
 //! ## Error Handling
 //!

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -87,7 +87,7 @@ mod multisig_plain {
     impl MultisigPlain {
         #[ink(constructor)]
         fn new(&mut self, owners: Vec<AccountId>, requirement: u32) {
-            for owner in owners.iter() {
+            for owner in &owners {
                 self.is_owner.insert(*owner, ());
                 self.owners.push(*owner);
             }

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -16,6 +16,11 @@
 //!
 //! This implements a plain multi owner wallet.
 //!
+//! ## Warning
+//!
+//! This contract is an *example*. It is neither audited nor endorsed for production use.
+//! Do **not** rely on it to keep anything of value secure.
+//!
 //! ## Overview
 //!
 //! Each instantiation of this contract has a set of `owners` and a `requirement` of
@@ -336,16 +341,19 @@ mod multisig_plain {
             assert!(self.env().caller() == self.env().account_id());
         }
 
-
+        /// Panic if `owner` is not an owner,
         fn ensure_owner(&self, owner: &AccountId) {
             assert!(self.is_owner.contains_key(owner));
         }
 
+        /// Panic if `owner` is an owner.
         fn ensure_no_owner(&self, owner: &AccountId) {
             assert!(!self.is_owner.contains_key(owner));
         }
     }
 
+    /// Panic if the number of `owners` under a `requirement` vialates our
+    /// requirement invariant.
     fn ensure_requirement_is_valid(owners: u32, requirement: u32) {
         assert!(0 < requirement && requirement <= owners && owners <= MAX_OWNERS);
     }

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -214,7 +214,7 @@ mod multisig_plain {
         /// A list of owners must be supplied and a number of how many of them must
         /// confirm a transaction. Duplicate owners are silently dropped.
         #[ink(constructor)]
-        fn new(&mut self, owners: Vec<AccountId>, requirement: u32) {
+        fn new(&mut self, requirement: u32, owners: Vec<AccountId>) {
             for owner in &owners {
                 self.is_owner.insert(*owner, ());
                 self.owners.push(*owner);
@@ -535,7 +535,7 @@ mod multisig_plain {
         fn build_contract() -> MultisigPlain {
             let accounts = default_accounts();
             let owners = ink_prelude::vec![accounts.alice, accounts.bob, accounts.eve];
-            MultisigPlain::new(owners, 2)
+            MultisigPlain::new(2, owners)
         }
 
         fn submit_transaction() -> MultisigPlain {
@@ -576,21 +576,21 @@ mod multisig_plain {
         #[test]
         #[should_panic]
         fn empty_owner_construction_fails() {
-            MultisigPlain::new(vec![], 0);
+            MultisigPlain::new(0, vec![]);
         }
 
         #[test]
         #[should_panic]
         fn zero_requirement_construction_fails() {
             let accounts = default_accounts();
-            MultisigPlain::new(vec![accounts.alice, accounts.bob], 0);
+            MultisigPlain::new(0, vec![accounts.alice, accounts.bob]);
         }
 
         #[test]
         #[should_panic]
         fn too_large_requirement_construction_fails() {
             let accounts = default_accounts();
-            MultisigPlain::new(vec![accounts.alice, accounts.bob], 3);
+            MultisigPlain::new(3, vec![accounts.alice, accounts.bob]);
         }
 
         #[test]

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -142,7 +142,7 @@ mod multisig_plain {
             self.ensure_caller_is_owner();
             let id = self.transactions.put(transaction);
             self.confirmation_count.insert(id, 0);
-            self.internal_confirm(id);
+            self.add_confirmer(self.env().caller(), id);
         }
 
         #[ink(message)]
@@ -155,7 +155,7 @@ mod multisig_plain {
         fn confirm_transaction(&mut self, id: TransactionId) {
             self.ensure_caller_is_owner();
             self.ensure_transaction_exists(id);
-            self.internal_confirm(id);
+            self.add_confirmer(self.env().caller(), id);
         }
 
         #[ink(message)]
@@ -184,14 +184,14 @@ mod multisig_plain {
                 .map_err(|_| ())
         }
 
-        fn internal_confirm(&mut self, id: TransactionId) {
+        fn add_confirmer(&mut self, confirmer: AccountId, transaction: TransactionId) {
             if self
                 .confirmations
-                .insert((id, self.env().caller()), ())
+                .insert((transaction, confirmer), ())
                 .is_none()
             {
                 self.confirmation_count
-                    .mutate_with(&id, |count| *count += 1);
+                    .mutate_with(&transaction, |count| *count += 1);
             }
         }
 

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2018-2019 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! # Plain Multisig Wallet
 //!
 //! This implements a plain multi owner wallet.

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -203,9 +203,9 @@ mod multisig_plain {
     }
 
     impl MultisigPlain {
-        /// The only constructor the the contract. A list of owners must be supplied
-        /// and a number of how many of them must confirm a transaction. Duplicate
-        /// owners are silently dropped.
+        /// The only constructor of the contract.
+        /// A list of owners must be supplied and a number of how many of them must
+        ///confirm a transaction. Duplicate owners are silently dropped.
         #[ink(constructor)]
         fn new(&mut self, owners: Vec<AccountId>, requirement: u32) {
             for owner in &owners {
@@ -217,7 +217,8 @@ mod multisig_plain {
             self.requirement.set(requirement);
         }
 
-        /// Add a new owner to the contract. Panics is the owner already exists.
+        /// Add a new owner to the contract.
+        /// Panics if the owner already exists.
         /// Only callable by the wallet itself.
         #[ink(message)]
         fn add_owner(&mut self, new_owner: AccountId) {
@@ -247,8 +248,8 @@ mod multisig_plain {
             self.env().emit_event(OwnerRemoval { owner });
         }
 
-        /// Replace an owner from the contract with a new one. Panics if `old_owner`
-        /// is no owner or if `new_owner` already is one.
+        /// Replace an owner from the contract with a new one.
+        /// Panics if `old_owner` is no owner or if `new_owner` already is one.
         /// Only callable by the wallet itself.
         #[ink(message)]
         fn replace_owner(&mut self, old_owner: AccountId, new_owner: AccountId) {
@@ -328,8 +329,8 @@ mod multisig_plain {
             }
         }
 
-        /// Execute a already confirmed execution. Its return type indicates whether
-        /// the called transaction was succesful.
+        /// Execute a confirmed execution.
+        /// Its return type indicates whether the called transaction was succesful.
         /// This can be called by anyone.
         #[ink(message)]
         fn execute_transaction(&mut self, trans_id: TransactionId) -> Result<(), ()> {
@@ -352,8 +353,9 @@ mod multisig_plain {
             result
         }
 
-        /// Set the `transaction` as confirmed by `confirmer`. Idempotent operation
-        /// regarding an already confirmed `transaction` by `confirmer`.
+        /// Set the `transaction` as confirmed by `confirmer`.
+        /// Idempotent operation regarding an already confirmed `transaction`
+        /// by `confirmer`.
         fn confirm_by_caller(
             &mut self,
             confirmer: AccountId,
@@ -373,8 +375,8 @@ mod multisig_plain {
             }
         }
 
-        /// Get the index of `owner` in `self.owners`. Panics if `owner` is not found
-        /// in `self.owners`.
+        /// Get the index of `owner` in `self.owners`.
+        /// Panics if `owner` is not found in `self.owners`.
         fn owner_index(&self, owner: &AccountId) -> u32 {
             self.owners.iter().position(|x| *x == *owner).expect(
                 "This is only called after it was already verified that the id is
@@ -382,8 +384,8 @@ mod multisig_plain {
             ) as u32
         }
 
-        /// Remove the transaction identified by `trans_id` from `self.transactions` and
-        /// removes all confirmation state associated with it.
+        /// Remove the transaction identified by `trans_id` from `self.transactions`.
+        /// Also removes all confirmation state associated with it.
         fn take_transaction(&mut self, trans_id: TransactionId) -> Option<Transaction> {
             let transaction = self.transactions.take(trans_id);
             if transaction.is_some() {
@@ -392,8 +394,8 @@ mod multisig_plain {
             transaction
         }
 
-        /// Remove all confirmation state associated with `owner` and adjust the
-        /// `self.confirmation_count` variable.
+        /// Remove all confirmation state associated with `owner`.
+        /// Also adjusts the `self.confirmation_count` variable.
         fn clean_owner_confirmations(&mut self, owner: &AccountId) {
             for (trans_id, _) in self.transactions.iter() {
                 if self.confirmations.remove(&(trans_id, *owner)).is_some() {

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -130,7 +130,7 @@ mod multisig_plain {
         }
 
         #[ink(message)]
-        fn change_requirement(&mut self, requirement: u32) {
+        fn change_requirement(&mut self, new_requirement: u32) {
             self.ensure_from_wallet();
             ensure_requirement(self.owners.len(), requirement);
             self.requirement.set(requirement);


### PR DESCRIPTION
This implements a plain multisig wallet with configurable owners and confirmation threshold. It is modeled after the popular [gnosis multisig wallet](https://github.com/gnosis/MultiSigWallet/blob/master/contracts/MultiSigWallet.sol). It allows executing arbitrary calls using the wallet origin to other contracts after receiving enough confirmations of the contract `owners`.

**Note**
The [polkadot-js/apps UI](https://polkadot.js.org/apps/) cannot be used to create the contract because of this issue: polkadot-js/api#1549. However, you need a dedicated DAPP for this contract anyways to have a good UX.

# Differences from the gnosis wallet

This contract stays close to the gnosis wallet. However, I took the liberty of changing some parts of the contract where I saw room for improvement. 

## State cleanup
The gnosis contract does not clean up historic state whatsoever. This mainly concerns the map that stores the confirmations for each owner and transaction. This seems reasonable when there is no state rent and the cleanup is expensive in computation.  My implementation does this somewhat expensive pruning in each call that obsoletes the state. So every call cleans up after itself.

## Execution is always a separate call
In the gnosis contract a confirmation triggers the execution when the confirmation threshold is reached. I opted for a more simpler approach where the execution must be triggered separately. This avoids cluttering the return type of the confirmation that otherwise had to return information about the possible execution.

## Avoid heavy `ensure_confirmed` computation
The gnosis contract needs to filter through the confirmations when determining if a transaction is confirmed. We avoid this singularity by adding a `confirmation_count` storage item that is kept synchronous with the current confirmations for each transaction. The trade off is the added complexity of doing this.

# TODO
This is a draft for a reason. There are some things left todo.

- [x] Documentation
- [x] State clearly that this contract is an example and not audited or ready for production
- [x] Fix `cargo contract generate-metadata`
- [x] Emit Events
- [x] Switch from `HashMap` to `BTreeMap`. ~Blocked by #334~
- [x] Tests