### PR TITLE
Implement Debug for storage::BTreeMap

### DIFF
--- a/core/src/storage/collections/btree_map/impls.rs
+++ b/core/src/storage/collections/btree_map/impls.rs
@@ -122,6 +122,7 @@ enum UnderflowResult {
 /// `BTreeMap` standard library implementation. The Rust implementation
 /// is in-memory, whereas this implementation uses the ink! storage
 /// primitives (`SyncChunk`, etc.).
+#[derive(Debug)]
 #[cfg_attr(feature = "ink-generate-abi", derive(Metadata))]
 pub struct BTreeMap<K, V> {
     /// Stores densely packed general BTreeMap information.
@@ -148,7 +149,7 @@ pub struct BTreeMap<K, V> {
 /// for performance reasons so that they all reside in the same
 /// storage entity. This allows implementations to perform less reads
 /// and writes to the underlying contract storage.
-#[derive(Encode, Decode)]
+#[derive(Debug, Encode, Decode)]
 #[cfg_attr(feature = "ink-generate-abi", derive(Metadata))]
 struct BTreeMapHeader {
     /// The latest vacant node index.
@@ -1673,7 +1674,7 @@ enum InsertResult {
 ///     `.entry()` API. It contains a key/value pair.
 ///   - `InternalEntry` is used internally in our implementation. It is a storage
 ///     entity and contains a tree node with many key/value pair storage indices.
-#[derive(Encode, Decode)]
+#[derive(Debug, Encode, Decode)]
 #[cfg_attr(feature = "ink-generate-abi", derive(Metadata))]
 enum InternalEntry<K, V> {
     /// A vacant entry pointing to the next vacant index.
@@ -1708,7 +1709,7 @@ where
 ///     `.entry()` API. It contains a key/value pair.
 ///   - `InternalEntry` is used internally in our implementation. It is a storage
 ///     entity and contains a tree node with many key/value pairs.
-#[derive(Encode, Decode)]
+#[derive(Debug, Encode, Decode)]
 #[cfg_attr(feature = "ink-generate-abi", derive(Metadata))]
 enum InternalKVEntry<K, V> {
     /// A vacant entry pointing to the next vacant index.

--- a/core/src/storage/collections/btree_map/node.rs
+++ b/core/src/storage/collections/btree_map/node.rs
@@ -38,7 +38,7 @@ use type_metadata::Metadata;
 const EDGES: usize = 2 * B;
 
 /// Reference to a key/value pair in the tree.
-#[derive(Encode, Decode)]
+#[derive(Debug, Encode, Decode)]
 #[cfg_attr(feature = "ink-generate-abi", derive(Metadata))]
 pub(super) struct KVPair<K, V> {
     /// A key.
@@ -128,7 +128,7 @@ impl<'a, K, V> KVRef<'a, K, V> {
 /// Each node is stored as one storage entity. This reduces storage access,
 /// since with each fetch the entire content of a node (all its elements, etc.)
 /// are fetched.
-#[derive(PartialEq, Eq, Encode, Decode)]
+#[derive(Debug, PartialEq, Eq, Encode, Decode)]
 #[cfg_attr(feature = "ink-generate-abi", derive(Metadata))]
 pub(super) struct Node<K, V> {
     /// A reference to this node's parent node.
@@ -324,7 +324,7 @@ impl<K, V> Node<K, V> {
 }
 
 /// Points to a node in the tree.
-#[derive(Clone, Copy, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Encode, Decode, PartialEq, Eq)]
 #[cfg_attr(feature = "ink-generate-abi", derive(Metadata))]
 pub(super) struct NodeHandle {
     node: u32,


### PR DESCRIPTION
Simply an oversight that this is missing. It is needed for std builds (off chain tests + metadata generation).

fixes #334 