### PR TITLE
CI fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -227,7 +227,7 @@ publish-docs:
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - git fetch origin gh-pages
     # Generating Docs
-    - time cargo doc --no-deps --all-features 
+    - time cargo +nightly doc --no-deps --all-features 
         -p type-metadata -p ink_abi -p ink_abi_derive -p ink_core -p ink_core_derive 
         -p ink_primitives -p ink_prelude -p ink_lang -p ink_lang_macro
     # saving README and docs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ stages:
 
 variables:
   GIT_STRATEGY:                    fetch
-  GIT_DEPTH:                       3
+  GIT_DEPTH:                       100
   CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_JOB_NAME}"
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   CI_SERVER_NAME:                  "GitLab CI"
@@ -212,10 +212,10 @@ publish-docs:
   <<:                              *docker-env
   variables:
     GIT_DEPTH:                     0
-  only:
-    - master
-    - schedules
-    - tags
+  # only:
+  #   - master
+  #   - schedules
+  #   - tags
   script:
     - rm -rf /tmp/*
     - unset CARGO_TARGET_DIR
@@ -227,7 +227,9 @@ publish-docs:
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - git fetch origin gh-pages
     # Generating Docs
-    - time cargo doc --release --no-deps --all --verbose
+    - time cargo doc --no-deps --all-features 
+        -p type-metadata -p ink_abi -p ink_abi_derive -p ink_core -p ink_core_derive 
+        -p ink_primitives -p ink_prelude -p ink_lang -p ink_lang_macro
     # saving README and docs
     - mv target/doc/ /tmp/
     - cp README.md /tmp/doc/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,10 +212,10 @@ publish-docs:
   <<:                              *docker-env
   variables:
     GIT_DEPTH:                     0
-  # only:
-  #   - master
-  #   - schedules
-  #   - tags
+  only:
+    - master
+    - schedules
+    - tags
   script:
     - rm -rf /tmp/*
     - unset CARGO_TARGET_DIR

--- a/abi/Cargo.toml
+++ b/abi/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
-derive_more = { version = "0.99.2", default-features = false, features = ["from"] }
+serde = { version = "1.0.104", default-features = false, features = ["derive", "alloc"] }
+derive_more = { version = "0.99.3", default-features = false, features = ["from"] }
 ink_abi_derive = { path = "derive", default-features = false, optional = true }
 ink_prelude = { path = "../prelude/", default-features = false }
 ink_primitives = { path = "../primitives/", default-features = false }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = "1.0.48"
 
 [features]
 default = [

--- a/abi/derive/Cargo.toml
+++ b/abi/derive/Cargo.toml
@@ -17,9 +17,9 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
-proc-macro2 = "1.0"
+quote = "1.0.3"
+syn = { version = "1.0.16", features = ["full"] }
+proc-macro2 = "1.0.9"
 
 [features]
 default = ["std"]

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-wee_alloc = { version = "0.4", default-features = false }
+wee_alloc = { version = "0.4.5", default-features = false }
 
 [features]
 default = ["std"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,19 +23,19 @@ ink_prelude = { path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.2", default-features = false, features = ["derive", "full"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }
-derive_more = { version = "0.99.2", default-features = false, features = ["from", "display"] }
-smallvec = { version = "1.0", default-features = false, features = ["union"] }
-cfg-if = "0.1"
-num-traits = { version = "0.2.1", default-features = false, features = ["i128"] }
+derive_more = { version = "0.99.3", default-features = false, features = ["from", "display"] }
+smallvec = { version = "1.2.0", default-features = false, features = ["union"] }
+cfg-if = "0.1.10"
+num-traits = { version = "0.2.11", default-features = false, features = ["i128"] }
 
 # Only used in the off-chain environment.
 #
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside of the off-chain environment!
-rand = { version = "0.7", default-features = false, features = ["alloc"], optional = true }
+rand = { version = "0.7.3", default-features = false, features = ["alloc"], optional = true }
 
 [dev-dependencies]
-itertools = "0.8.2"
+itertools = "0.9.0"
 
 [features]
 default = ["std"]

--- a/core/derive/Cargo.toml
+++ b/core/derive/Cargo.toml
@@ -12,14 +12,14 @@ proc-macro = true
 
 [dependencies]
 ink_primitives = { path = "../../primitives", default-features = false }
-quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
-proc-macro2 = "1.0"
-synstructure = "0.12"
+quote = "1.0.3"
+syn = { version = "1.0.16", features = ["full"] }
+proc-macro2 = "1.0.9"
+synstructure = "0.12.3"
 
 [dev-dependencies]
 ink_core = { path = ".." }
-trybuild = "1.0"
+trybuild = "1.0.23"
 
 [features]
 default = ["std"]

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -22,7 +22,7 @@ ink_prelude = { path = "../prelude/", default-features = false }
 ink_lang_macro = { path = "macro", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.2", default-features = false, features = ["derive", "full"] }
-derive_more = { version = "0.99.2", default-features = false, features = ["from"] }
+derive_more = { version = "0.99.3", default-features = false, features = ["from"] }
 
 [features]
 default = ["test-env"]

--- a/lang/macro/Cargo.toml
+++ b/lang/macro/Cargo.toml
@@ -18,16 +18,16 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 ink_primitives = { path = "../../primitives/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.2", default-features = false, features = ["derive"] }
-quote = "1"
-syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
-proc-macro2 = "1.0"
-heck = "0.3"
-itertools = { version = "0.8.1", default-features = false }
-either = { version = "1.5", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-serde_json = "1.0"
-derive_more = { version = "0.99.2", default-features = false, features = ["from"] }
-regex = "1.3"
+quote = "1.0.3"
+syn = { version = "1.0.16", features = ["parsing", "full", "extra-traits"] }
+proc-macro2 = "1.0.9"
+heck = "0.3.1"
+itertools = { version = "0.9.0", default-features = false }
+either = { version = "1.5.3", default-features = false }
+serde = { version = "1.0.104", default-features = false, features = ["derive"] }
+serde_json = "1.0.48"
+derive_more = { version = "0.99.3", default-features = false, features = ["from"] }
+regex = "1.3.4"
 
 [dev-dependencies]
 ink_abi = { path = "../../abi/" }
@@ -35,7 +35,7 @@ ink_core = { path = "../../core/" }
 ink_lang = { path = "..", default-features = false, features = ["ink-generate-abi"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"] }
 
-trybuild = "1.0"
+trybuild = "1.0.23"
 pretty_assertions = "0.6.1"
 
 [lib]

--- a/prelude/Cargo.toml
+++ b/prelude/Cargo.toml
@@ -22,7 +22,7 @@ name = "ink_prelude"
 path = "lib.rs"
 
 [dependencies]
-cfg-if = "0.1"
+cfg-if = "0.1.10"
 
 [features]
 default = ["std"]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -19,7 +19,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 ink_prelude = { path = "../prelude/", default-features = false }
-tiny-keccak = { version = "2.0", features = ["keccak"] }
+tiny-keccak = { version = "2.0.1", features = ["keccak"] }
 scale = { package = "parity-scale-codec", version = "1.2", default-features = false, features = ["derive", "full"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }
 


### PR DESCRIPTION
- running 
```
cargo doc --no-deps --all-features -p type-metadata -p ink_abi -p ink_abi_derive -p ink_core -p ink_core_derive -p ink_primitives -p ink_prelude -p ink_lang -p ink_lang_macro
```
to cover all packages.
- also set `GIT_DEPTH` to 100 to avoid some potential failures I've had with substrate, it will not affect CI speed more than on a second.
- had to `cargo upgrade` to satisfy `trybuild v1.0.23` which now expects everything to be up-to-date. (and [the pipeline](https://gitlab.parity.io/parity/ink/pipelines/82198) succeded)