### PR TITLE
add bors to ink repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ variables:
     - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
     - schedules
     - web
-    - /^[0-9]+$/                   # PRs
+    - branches
   dependencies:                    []
   interruptible:                   true
   retry:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ cache: cargo
 dist: trusty
 sudo: true
 
+branches:
+  only:
+  - master
+
 rust:
   - nightly-2019-11-17
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,21 +1,7 @@
 status = [
-    "ci/gitlab/gitlab.parity.io",
-    "continuous-integration/gitlab-check-std",
-    "continuous-integration/gitlab-check-wasm",
-    "continuous-integration/gitlab-build-std",
-    "continuous-integration/gitlab-build-wasm",
-    "continuous-integration/gitlab-test",
-    "continuous-integration/gitlab-clippy-std",
-    "continuous-integration/gitlab-clippy-wasm",
-    "continuous-integration/gitlab-fmt",
-    "continuous-integration/gitlab-examples-test",
-    "continuous-integration/gitlab-examples-clippy-std",
-    "continuous-integration/gitlab-examples-clippy-wasm",
-    "continuous-integration/gitlab-examples-fmt",
-    "continuous-integration/gitlab-examples-contract-build",
-    "continuous-integration/gitlab-examples-generate-metadata"
+    "ci/gitlab/gitlab.parity.io"
 ]
-# The default is one hour.
-timeout_sec = 600
+# The default is one hour (3600 sec).
+timeout_sec = 1800
 use_squash_merge = true
 required_approvals = 1

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,21 @@
+status = [
+    "ci/gitlab/gitlab.parity.io",
+    "continuous-integration/gitlab-build-wasm",
+    "continuous-integration/gitlab-check-std",
+    "continuous-integration/gitlab-check-wasm",
+    "continuous-integration/gitlab-clippy-std",
+    "continuous-integration/gitlab-clippy-wasm",
+    "continuous-integration/gitlab-examples-clippy-std",
+    "continuous-integration/gitlab-examples-clippy-wasm",
+    "continuous-integration/gitlab-examples-contract-build",
+    "continuous-integration/gitlab-examples-fmt",
+    "continuous-integration/gitlab-examples-generate-metadata",
+    "continuous-integration/gitlab-examples-test",
+    "continuous-integration/gitlab-fmt",
+    "continuous-integration/gitlab-publish-docs",
+    "continuous-integration/gitlab-test"
+]
+# The default is one hour.
+timeout_sec = 600
+use_squash_merge = true
+required_approvals = 1

--- a/bors.toml
+++ b/bors.toml
@@ -1,19 +1,19 @@
 status = [
     "ci/gitlab/gitlab.parity.io",
-    "continuous-integration/gitlab-build-wasm",
     "continuous-integration/gitlab-check-std",
     "continuous-integration/gitlab-check-wasm",
+    "continuous-integration/gitlab-build-std",
+    "continuous-integration/gitlab-build-wasm",
+    "continuous-integration/gitlab-test",
     "continuous-integration/gitlab-clippy-std",
     "continuous-integration/gitlab-clippy-wasm",
+    "continuous-integration/gitlab-fmt",
+    "continuous-integration/gitlab-examples-test",
     "continuous-integration/gitlab-examples-clippy-std",
     "continuous-integration/gitlab-examples-clippy-wasm",
-    "continuous-integration/gitlab-examples-contract-build",
     "continuous-integration/gitlab-examples-fmt",
-    "continuous-integration/gitlab-examples-generate-metadata",
-    "continuous-integration/gitlab-examples-test",
-    "continuous-integration/gitlab-fmt",
-    "continuous-integration/gitlab-publish-docs",
-    "continuous-integration/gitlab-test"
+    "continuous-integration/gitlab-examples-contract-build",
+    "continuous-integration/gitlab-examples-generate-metadata"
 ]
 # The default is one hour.
 timeout_sec = 600


### PR DESCRIPTION
Adding `bors` to `ink!` repo.
From now on
- you shouldn't use the Big Green Button any more there, use `bors try` to run CI on `master` merged in your PR and run `bors r+` (as "LGTM, merge") instead of pushing the button.
- to avoid conflicts I had to remove `Require pull request reviews before merging` from GitHub settings, the same is now required in `bors.toml`.

Here's dashboard https://app.bors.tech/repositories/23801
And the manual https://bors.tech/documentation/

Please spread this between the project members.