### PR TITLE
[lang] remove EnvAccess inherent emit_event to avoid override

### DIFF
--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -155,8 +155,18 @@ mod erc20 {
         fn new_works() {
             // Constructor works.
             let _erc20 = Erc20::new(100);
+
             // Transfer event triggered during initial contruction.
-            assert_eq!(1, env::test::recorded_events().count());
+            let emitted_events = env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(1, emitted_events.len());
+            let raw_event = emitted_events.first().unwrap();
+            let event = <Event as scale::Decode>::decode(&mut &raw_event.data[..])
+                .expect("Invalid contract Event");
+            if let Event::Transfer(transfer) = event {
+                assert_eq!(100, transfer.value);
+            } else {
+                panic!("Expected a Transfer Event")
+            }
         }
 
         /// The total supply was applied.

--- a/lang/macro/src/codegen/contract.rs
+++ b/lang/macro/src/codegen/contract.rs
@@ -75,7 +75,7 @@ impl GenerateCode for ContractModule<'_> {
                 pub type Event = self::__ink_private::Event;
             }
         } else {
-            quote! { }
+            quote! {}
         };
 
         quote! {

--- a/lang/macro/src/codegen/contract.rs
+++ b/lang/macro/src/codegen/contract.rs
@@ -96,6 +96,9 @@ impl GenerateCode for ContractModule<'_> {
                 #[cfg(feature = "ink-as-dependency")]
                 pub type #storage_ident = self::__ink_private::StorageAsDependency;
 
+                #[cfg(all(test, feature = "test-env"))]
+                pub type Event = self::__ink_private::Event;
+
                 #event_structs
 
                 #(

--- a/lang/macro/src/codegen/contract.rs
+++ b/lang/macro/src/codegen/contract.rs
@@ -69,6 +69,15 @@ impl GenerateCode for ContractModule<'_> {
         let cross_calling = self.generate_code_using::<CrossCalling>();
         let non_ink_items = &self.contract.non_ink_items;
 
+        let test_event_alias = if !self.contract.events.is_empty() {
+            quote! {
+                #[cfg(all(test, feature = "test-env"))]
+                pub type Event = self::__ink_private::Event;
+            }
+        } else {
+            quote! { }
+        };
+
         quote! {
             mod #ident {
                 #env_types
@@ -96,8 +105,7 @@ impl GenerateCode for ContractModule<'_> {
                 #[cfg(feature = "ink-as-dependency")]
                 pub type #storage_ident = self::__ink_private::StorageAsDependency;
 
-                #[cfg(all(test, feature = "test-env"))]
-                pub type Event = self::__ink_private::Event;
+                #test_event_alias
 
                 #event_structs
 

--- a/lang/macro/src/codegen/events.rs
+++ b/lang/macro/src/codegen/events.rs
@@ -119,7 +119,7 @@ impl EventHelpers<'_> {
                     where
                         E: Into<Self::Event>,
                     {
-                        ink_lang::EnvAccess::<EnvTypes>::emit_event(self, event.into())
+                        ink_lang::EnvAccess::<EnvTypes>::emit_event_inner(self, event.into())
                     }
                 }
             };

--- a/lang/macro/src/codegen/events.rs
+++ b/lang/macro/src/codegen/events.rs
@@ -119,7 +119,7 @@ impl EventHelpers<'_> {
                     where
                         E: Into<Self::Event>,
                     {
-                        ink_lang::EnvAccess::<EnvTypes>::emit_event_generic(self, event.into())
+                        ink_lang::EnvAccess::<EnvTypes>::emit_event_generic::<Self::Event>(self, event.into())
                     }
                 }
             };

--- a/lang/macro/src/codegen/events.rs
+++ b/lang/macro/src/codegen/events.rs
@@ -135,7 +135,7 @@ impl EventHelpers<'_> {
             .collect::<Vec<_>>();
 
         quote! {
-            #[derive(scale::Encode)]
+            #[derive(scale::Encode, scale::Decode)]
             pub enum Event {
                 #( #event_idents(#event_idents), )*
             }
@@ -182,7 +182,7 @@ impl EventHelpers<'_> {
 ///
 /// - making all fields `pub`
 /// - strip `#[ink(..)]` attributes
-/// - add `#[derive(scale::Encode)]`
+/// - add `#[derive(scale::Encode, scale::Decode)]`
 ///
 /// # Note
 ///
@@ -223,7 +223,7 @@ impl EventStructs<'_> {
             quote_spanned!(span =>
                 #conflic_depedency_cfg
                 #(#attrs)*
-                #[derive(scale::Encode)]
+                #[derive(scale::Encode, scale::Decode)]
                 pub struct #ident
                     #fields
             )

--- a/lang/macro/src/codegen/events.rs
+++ b/lang/macro/src/codegen/events.rs
@@ -119,7 +119,7 @@ impl EventHelpers<'_> {
                     where
                         E: Into<Self::Event>,
                     {
-                        ink_lang::EnvAccess::<EnvTypes>::emit_event_generic::<Self::Event>(self, event.into())
+                        ink_lang::EnvAccess::<EnvTypes>::emit_generic_event::<Self::Event>(self, event.into())
                     }
                 }
             };

--- a/lang/macro/src/codegen/events.rs
+++ b/lang/macro/src/codegen/events.rs
@@ -119,7 +119,7 @@ impl EventHelpers<'_> {
                     where
                         E: Into<Self::Event>,
                     {
-                        ink_lang::EnvAccess::<EnvTypes>::emit_event_inner(self, event.into())
+                        ink_lang::EnvAccess::<EnvTypes>::emit_event_generic(self, event.into())
                     }
                 }
             };

--- a/lang/macro/src/codegen/events.rs
+++ b/lang/macro/src/codegen/events.rs
@@ -119,7 +119,7 @@ impl EventHelpers<'_> {
                     where
                         E: Into<Self::Event>,
                     {
-                        ink_lang::EnvAccess::<EnvTypes>::emit_generic_event::<Self::Event>(self, event.into())
+                        ink_core::env::emit_event::<EnvTypes, Self::Event>(event.into());
                     }
                 }
             };

--- a/lang/macro/src/codegen/storage.rs
+++ b/lang/macro/src/codegen/storage.rs
@@ -54,13 +54,6 @@ impl GenerateCode for Storage<'_> {
         let message_impls = self.generate_message_impls();
         let storage_struct = self.generate_storage_struct();
 
-        let use_emit_event = if !self.contract.events.is_empty() {
-            // Required to allow for `self.env().emit_event(..)` in messages and constructors.
-            quote! { use __ink_private::EmitEvent as _; }
-        } else {
-            quote! {}
-        };
-
         quote_spanned!(storage_span =>
             #[doc(hidden)]
             #conflic_depedency_cfg
@@ -81,7 +74,6 @@ impl GenerateCode for Storage<'_> {
                 #[allow(unused_imports)]
                 use ink_lang::Env as _;
 
-                #use_emit_event
                 #message_impls
             };
         )

--- a/lang/macro/src/codegen/storage.rs
+++ b/lang/macro/src/codegen/storage.rs
@@ -54,6 +54,13 @@ impl GenerateCode for Storage<'_> {
         let message_impls = self.generate_message_impls();
         let storage_struct = self.generate_storage_struct();
 
+        let use_emit_event = if !self.contract.events.is_empty() {
+            // Required to allow for `self.env().emit_event(..)` in messages and constructors.
+            quote! { use __ink_private::EmitEvent as _; }
+        } else {
+            quote! {}
+        };
+
         quote_spanned!(storage_span =>
             #[doc(hidden)]
             #conflic_depedency_cfg
@@ -74,6 +81,7 @@ impl GenerateCode for Storage<'_> {
                 #[allow(unused_imports)]
                 use ink_lang::Env as _;
 
+                #use_emit_event
                 #message_impls
             };
         )

--- a/lang/src/env_access.rs
+++ b/lang/src/env_access.rs
@@ -190,7 +190,7 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_core::env::emit_event`]
-    pub fn emit_event_inner<Event>(self, event: Event)
+    pub fn emit_event_generic<Event>(self, event: Event)
     where
         Event: Topics<T> + scale::Encode,
     {

--- a/lang/src/env_access.rs
+++ b/lang/src/env_access.rs
@@ -23,7 +23,6 @@ use ink_core::{
         },
         EnvTypes,
         Result,
-        Topics,
     },
 };
 use ink_primitives::Key;
@@ -183,18 +182,6 @@ where
     /// For more details visit: [`ink_core::env::tombstone_deposit`]
     pub fn tombstone_deposit(self) -> T::Balance {
         env::tombstone_deposit::<T>().expect("couldn't decode tombstone deposits")
-    }
-
-    /// Emits an event with the given event data, for any event type.
-    ///
-    /// # Note
-    ///
-    /// For more details visit: [`ink_core::env::emit_event`]
-    pub fn emit_generic_event<Event>(self, event: Event)
-    where
-        Event: Topics<T> + scale::Encode,
-    {
-        env::emit_event::<T, Event>(event)
     }
 
     /// Sets the rent allowance of the executed contract to the new value.

--- a/lang/src/env_access.rs
+++ b/lang/src/env_access.rs
@@ -190,7 +190,7 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_core::env::emit_event`]
-    pub fn emit_event<Event>(self, event: Event)
+    pub fn emit_event_inner<Event>(self, event: Event)
     where
         Event: Topics<T> + scale::Encode,
     {

--- a/lang/src/env_access.rs
+++ b/lang/src/env_access.rs
@@ -185,9 +185,11 @@ where
         env::tombstone_deposit::<T>().expect("couldn't decode tombstone deposits")
     }
 
-    /// Emits an event with the given event data.
+    /// Emits an event with the given event data, for any event type.
     ///
     /// # Note
+    ///
+    /// Prefer using
     ///
     /// For more details visit: [`ink_core::env::emit_event`]
     pub fn emit_event_generic<Event>(self, event: Event)

--- a/lang/src/env_access.rs
+++ b/lang/src/env_access.rs
@@ -189,10 +189,8 @@ where
     ///
     /// # Note
     ///
-    /// Prefer using
-    ///
     /// For more details visit: [`ink_core::env::emit_event`]
-    pub fn emit_event_generic<Event>(self, event: Event)
+    pub fn emit_generic_event<Event>(self, event: Event)
     where
         Event: Topics<T> + scale::Encode,
     {


### PR DESCRIPTION
Fixes #377 

Renamed `EnvAccess::emit_events` inherent impl to `emit_events_inner` (please suggest a better name).

Previously it wasn't calling the `EmitEvent::emit_event` implementation because it was defaulting to the inherent definition of the same name.