### PR TITLE
Fix metadata generation for multisig example

### DIFF
--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -107,6 +107,7 @@ mod multisig_plain {
 
     /// Indicates whether a transaction is already confirmed or needs further confirmations.
     #[derive(scale::Encode, scale::Decode, Clone, Copy)]
+    #[cfg_attr(feature = "ink-generate-abi", derive(type_metadata::Metadata))]
     pub enum ConfirmationStatus {
         /// The transaction is already confirmed.
         Confirmed,


### PR DESCRIPTION
I noticed that the metadata generation of the multisig contract broke. Didn't know when and why it happened but this fixes it by adding
```
#[cfg_attr(feature = "ink-generate-abi", derive(type_metadata::Metadata))]
```

to the proper type.