### PR TITLE
Add scale::Output to Wrap (no_std) + minor improvements

### DIFF
--- a/core/src/hash/accumulator.rs
+++ b/core/src/hash/accumulator.rs
@@ -79,6 +79,23 @@ pub struct Wrap<'a> {
     len: usize,
 }
 
+impl Wrap<'_> {
+    /// Returns the capacity of the underlying buffer.
+    fn capacity(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Returns the length of the underlying buffer.
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the underlying buffer is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
 #[cfg(feature = "std")]
 impl<'a> Write for Wrap<'a> {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
@@ -103,6 +120,7 @@ impl<'a> Accumulator for Wrap<'a> {
     }
 
     fn write(&mut self, bytes: &[u8]) {
+        assert!(self.len() + bytes.len() <= self.capacity());
         let len = self.len;
         let bytes_len = bytes.len();
         self.buffer[len..(len + bytes_len)].copy_from_slice(bytes);
@@ -111,5 +129,18 @@ impl<'a> Accumulator for Wrap<'a> {
 
     fn as_slice(&self) -> &[u8] {
         &self.buffer[..self.len]
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<'a> scale::Output for Wrap<'a> {
+    fn write(&mut self, bytes: &[u8]) {
+        <Self as Accumulator>::write(self, bytes)
+    }
+
+    fn push_byte(&mut self, byte: u8) {
+        assert!(self.len() < self.capacity());
+        self.buffer[self.len] = byte;
+        self.len += 1;
     }
 }

--- a/core/src/hash/accumulator.rs
+++ b/core/src/hash/accumulator.rs
@@ -120,7 +120,7 @@ impl<'a> Accumulator for Wrap<'a> {
     }
 
     fn write(&mut self, bytes: &[u8]) {
-        assert!(self.len() + bytes.len() <= self.capacity());
+        debug_assert!(self.len() + bytes.len() <= self.capacity());
         let len = self.len;
         let bytes_len = bytes.len();
         self.buffer[len..(len + bytes_len)].copy_from_slice(bytes);
@@ -139,7 +139,7 @@ impl<'a> scale::Output for Wrap<'a> {
     }
 
     fn push_byte(&mut self, byte: u8) {
-        assert!(self.len() < self.capacity());
+        debug_assert!(self.len() < self.capacity());
         self.buffer[self.len] = byte;
         self.len += 1;
     }

--- a/core/src/hash/accumulator.rs
+++ b/core/src/hash/accumulator.rs
@@ -89,11 +89,6 @@ impl Wrap<'_> {
     fn len(&self) -> usize {
         self.len
     }
-
-    /// Returns `true` if the underlying buffer is empty.
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
- Add `scale::Output` impl to `Wrap` in `no_std`
- Minor improvements