### PR TITLE
Fix single threaded tests in off-chain environment

### DIFF
--- a/core/src/env/engine/off_chain/db/accounts.rs
+++ b/core/src/env/engine/off_chain/db/accounts.rs
@@ -78,6 +78,11 @@ impl AccountsDb {
         }
     }
 
+    /// Resets the account DB to uninitialized state.
+    pub fn reset(&mut self) {
+        self.accounts.clear()
+    }
+
     /// Returns the account at the given account ID or creates it.
     pub fn get_or_create_account<T>(&mut self, at: &T::AccountId) -> &mut Account
     where

--- a/core/src/env/engine/off_chain/db/chain_spec.rs
+++ b/core/src/env/engine/off_chain/db/chain_spec.rs
@@ -42,6 +42,14 @@ impl ChainSpec {
         }
     }
 
+    /// Resets the chain spec to uninitialized state.
+    pub fn reset(&mut self) {
+        self.gas_price = OffBalance::uninitialized();
+        self.minimum_balance = OffBalance::uninitialized();
+        self.tombstone_deposit = OffBalance::uninitialized();
+        self.block_time = OffTimestamp::uninitialized();
+    }
+
     /// Default initialization for the off-chain specification.
     pub fn initialize_as_default<T>(&mut self) -> crate::env::Result<()>
     where

--- a/core/src/env/engine/off_chain/db/console.rs
+++ b/core/src/env/engine/off_chain/db/console.rs
@@ -28,6 +28,11 @@ impl Console {
         }
     }
 
+    /// Resets the console to uninitialized state.
+    pub fn reset(&mut self) {
+        self.past_prints.clear();
+    }
+
     /// Prints the contents to the actual console and stores them.
     pub fn println(&mut self, contents: &str) {
         self.past_prints.push(contents.to_string());

--- a/core/src/env/engine/off_chain/db/events.rs
+++ b/core/src/env/engine/off_chain/db/events.rs
@@ -58,6 +58,11 @@ impl EmittedEventsRecorder {
         }
     }
 
+    /// Resets the emitted events to none.
+    pub fn reset(&mut self) {
+        self.emitted_events.clear();
+    }
+
     /// Records a new emitted event.
     pub fn record<T, E>(&mut self, new_event: E)
     where

--- a/core/src/env/engine/off_chain/mod.rs
+++ b/core/src/env/engine/off_chain/mod.rs
@@ -110,6 +110,36 @@ impl EnvInstance {
         }
     }
 
+    /// Returns `true` if the off-chain environment is uninitialized.
+    pub fn is_initialized(&self) -> bool {
+        !self.exec_context.is_empty()
+    }
+
+    /// Either resets or initializes the off-chain environment to default values.
+    pub fn initialize_or_reset_as_default<T>(&mut self) -> crate::env::Result<()>
+    where
+        T: EnvTypes,
+        <T as EnvTypes>::AccountId: From<[u8; 32]>,
+    {
+        if self.is_initialized() {
+            self.reset()
+        }
+        self.initialize_as_default::<T>()?;
+        Ok(())
+    }
+
+    /// Resets the off-chain environment to unintialized state.
+    pub fn reset(&mut self) {
+        self.accounts.reset();
+        self.exec_context.clear();
+        self.chain_spec.reset();
+        self.blocks.clear();
+        self.console.reset();
+        self.runtime_storage.reset();
+        self.runtime_call_handler.reset();
+        self.emitted_events.reset();
+    }
+
     /// Initializes the whole off-chain environment.
     ///
     /// # Note

--- a/core/src/env/engine/off_chain/runtime_calls.rs
+++ b/core/src/env/engine/off_chain/runtime_calls.rs
@@ -37,6 +37,11 @@ impl RuntimeCallHandler {
         Self { registered: None }
     }
 
+    /// Resets the runtime call handler to uninitialized state.
+    pub fn reset(&mut self) {
+        self.registered = None;
+    }
+
     /// Register a runtime call handler.
     pub fn register<T, F>(&mut self, mut f: F)
     where

--- a/core/src/env/engine/off_chain/runtime_storage.rs
+++ b/core/src/env/engine/off_chain/runtime_storage.rs
@@ -34,6 +34,11 @@ impl RuntimeStorage {
         }
     }
 
+    /// Resets the runtime storage to uninitialized state.
+    pub fn reset(&mut self) {
+        self.entries.clear();
+    }
+
     /// Stores the value under the given key.
     pub fn store<T>(&mut self, key: Vec<u8>, value: T)
     where

--- a/core/src/env/engine/off_chain/test_api.rs
+++ b/core/src/env/engine/off_chain/test_api.rs
@@ -288,14 +288,13 @@ where
 ///
 /// - Initializes the off-chain environment with default values that fit most
 /// uses cases.
-/// - The off-chain environment _must_ be initialized before use.
-pub fn initialize_as_default<T>() -> Result<()>
+pub fn initialize_or_reset_as_default<T>() -> Result<()>
 where
     T: EnvTypes,
     <T as EnvTypes>::AccountId: From<[u8; 32]>,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance.initialize_as_default::<T>()
+        instance.initialize_or_reset_as_default::<T>()
     })
 }
 
@@ -307,7 +306,7 @@ where
     F: FnOnce(DefaultAccounts<T>) -> Result<()>,
     <T as EnvTypes>::AccountId: From<[u8; 32]>,
 {
-    initialize_as_default::<T>()?;
+    initialize_or_reset_as_default::<T>()?;
     let default_accounts = default_accounts::<T>()?;
     f(default_accounts)
 }

--- a/lang/macro/src/codegen/testable.rs
+++ b/lang/macro/src/codegen/testable.rs
@@ -56,7 +56,7 @@ impl GenerateCode for TestWrapper<'_> {
                     type Wrapped = TestableStorage;
 
                     fn instantiate() -> Self::Wrapped {
-                        ink_core::env::test::initialize_as_default::<ink_core::env::DefaultEnvTypes>()
+                        ink_core::env::test::initialize_or_reset_as_default::<ink_core::env::DefaultEnvTypes>()
                             .expect("encountered already initialized off-chain environment");
                         let mut contract: Self = unsafe {
                             let mut alloc =


### PR DESCRIPTION
Currently some tests that rely on interaction with the off-chain test environment share some state when run in a single thread. This PR resolves these conflicts by conditionally resetting the off-chain test environment for every test incarnation if the off-chain test environment has already been initialized at that time.

Tests are normally run in parallel each in their own thread, however, some tools such as `miri` run all tests single threaded.

Tests that have been run using:
`cargo test -- --test-threads=1`