### PR TITLE
Add ink_core/derive to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   CI_SERVER_NAME:                  "GitLab CI"
   REGISTRY:                        "paritytech"
-  ALL_CRATES:                      "core alloc prelude primitives lang lang/macro"
+  ALL_CRATES:                      "core core/derive alloc prelude primitives lang lang/macro"
 
 .collect-artifacts:                &collect-artifacts
   artifacts:


### PR DESCRIPTION
Adds the `ink_core/derive` sub crate to the general CI routines such as has been done with `ink_lang/macro`.