### PR TITLE
Add miri to CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,6 +103,17 @@ test:
   script:
     - cargo test --verbose --all-features --no-fail-fast --workspace
 
+miri:
+  stage:                           workspace
+  <<:                              *docker-env
+  needs:
+    - test
+  script:
+    - cargo miri --version;
+      pushd core;
+      cargo miri test --verbose -- -- storage2;
+      popd
+
 codecov:
   stage:                           workspace
   <<:                              *docker-env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@
 stages:
   - check
   - workspace
-  - workspace-extra
+  - extra
   - examples
   - publish
 
@@ -131,7 +131,7 @@ fmt:
     - cargo fmt --verbose --all -- --check
 
 miri:
-  stage:                           workspace-extra
+  stage:                           extra
   <<:                              *docker-env
   needs:
     - test
@@ -142,7 +142,7 @@ miri:
       popd
 
 codecov:
-  stage:                           workspace-extra
+  stage:                           extra
   <<:                              *docker-env
   needs:
     - test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -185,7 +185,7 @@ examples-test:
   stage:                           examples
   <<:                              *docker-env
   needs:
-    - clippy-std
+    - test
   script:
     - for example in examples/*/; do
         cargo test --verbose --manifest-path ${example}/Cargo.toml;
@@ -194,6 +194,8 @@ examples-test:
 examples-fmt:
   stage:                           examples
   <<:                              *docker-env
+  needs:
+    - fmt
   script:
     - for example in examples/*/; do
         cargo fmt --verbose --manifest-path ${example}/Cargo.toml -- --check;
@@ -212,6 +214,8 @@ examples-clippy-std:
 examples-clippy-wasm:
   stage:                           examples
   <<:                              *docker-env
+  needs:
+    - clippy-wasm
   script:
     - for example in examples/*/; do
         cargo clippy --verbose --manifest-path ${example}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
@@ -220,6 +224,8 @@ examples-clippy-wasm:
 examples-contract-build:
   stage:                           examples
   <<:                              *docker-env
+  needs:
+    - build-wasm
   script:
     - *update-cargo-contract
     - for example in examples/*/; do
@@ -232,7 +238,7 @@ examples-generate-metadata:
   stage:                           examples
   <<:                              *docker-env
   needs:
-    - build-wasm
+    - test
   script:
     - *update-cargo-contract
     - for example in examples/*/; do

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ codecov:
   stage:                           workspace
   <<:                              *docker-env
   needs:
-    - check-std
+    - test
   variables:
     # Variables partly came from https://github.com/mozilla/grcov/blob/master/README.md
     CARGO_INCREMENTAL:             0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,6 +137,7 @@ miri:
     - test
   script:
     - cargo miri --version;
+      rustup add component rust-src;
       pushd core;
       cargo miri test --verbose -- -- storage2;
       popd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@
 stages:
   - check
   - workspace
+  - workspace-extra
   - examples
   - publish
 
@@ -103,8 +104,34 @@ test:
   script:
     - cargo test --verbose --all-features --no-fail-fast --workspace
 
-miri:
+clippy-std:
   stage:                           workspace
+  <<:                              *docker-env
+  needs:
+    - check-std
+  script:
+    - for crate in ${ALL_CRATES}; do
+        cargo clippy --verbose --all-features --manifest-path ${crate}/Cargo.toml -- -D warnings;
+      done
+
+clippy-wasm:
+  stage:                           workspace
+  <<:                              *docker-env
+  needs:
+    - check-wasm
+  script:
+    - for crate in ${ALL_CRATES}; do
+        cargo clippy --verbose --no-default-features --manifest-path ${crate}/Cargo.toml --target wasm32-unknown-unknown -- -D warnings;
+      done
+
+fmt:
+  stage:                           workspace
+  <<:                              *docker-env
+  script:
+    - cargo fmt --verbose --all -- --check
+
+miri:
+  stage:                           workspace-extra
   <<:                              *docker-env
   needs:
     - test
@@ -115,7 +142,7 @@ miri:
       popd
 
 codecov:
-  stage:                           workspace
+  stage:                           workspace-extra
   <<:                              *docker-env
   needs:
     - test
@@ -146,33 +173,6 @@ codecov:
     - grcov ./target -s . -t lcov --llvm --ignore-not-existing --ignore "/*" --ignore "tests/*" -o lcov-lines.info
     - rust-covfix -o lcov-lines.info lcov-lines.info
     - bash <(curl -s https://codecov.io/bash) -f lcov-lines.info
-
-clippy-std:
-  stage:                           workspace
-  <<:                              *docker-env
-  needs:
-    - check-std
-  script:
-    - for crate in ${ALL_CRATES}; do
-        cargo clippy --verbose --all-features --manifest-path ${crate}/Cargo.toml -- -D warnings;
-      done
-
-clippy-wasm:
-  stage:                           workspace
-  <<:                              *docker-env
-  needs:
-    - check-wasm
-  script:
-    - for crate in ${ALL_CRATES}; do
-        cargo clippy --verbose --no-default-features --manifest-path ${crate}/Cargo.toml --target wasm32-unknown-unknown -- -D warnings;
-      done
-
-fmt:
-  stage:                           workspace
-  <<:                              *docker-env
-  script:
-    - cargo fmt --verbose --all -- --check
-
 
 #### stage:                        examples
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -137,7 +137,7 @@ miri:
     - test
   script:
     - cargo miri --version;
-      rustup add component rust-src;
+      rustup component add rust-src;
       pushd core;
       cargo miri test --verbose -- -- storage2;
       popd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -138,6 +138,7 @@ miri:
   script:
     - cargo miri --version;
       rustup component add rust-src;
+      cargo install --force xargo;
       pushd core;
       cargo miri test --verbose -- -- storage2;
       popd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,13 +139,11 @@ miri:
     # miri uses xargo hence can't be used with RUSTC_WRAPPER=sccache
     # miri setup is needed because by default is demands interaction asking for dependencies
     - unset RUSTC_WRAPPER;
-      cargo miri --version;
-      rustup component add rust-src;
-      cargo install --force xargo;
-      pushd core;
-      cargo miri setup;
-      cargo miri test --verbose -- -- storage2;
-      popd
+    - cargo miri --version;
+    - pushd core;
+    - time cargo miri setup;
+    - time cargo miri test --verbose -- -- storage2;
+    - popd
 
 codecov:
   stage:                           extra

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,10 +136,14 @@ miri:
   needs:
     - test
   script:
-    - cargo miri --version;
+    # miri uses xargo hence can't be used with RUSTC_WRAPPER=sccache
+    # miri setup is needed because by default is demands interaction asking for dependencies
+    - unset RUSTC_WRAPPER;
+      cargo miri --version;
       rustup component add rust-src;
       cargo install --force xargo;
       pushd core;
+      cargo miri setup;
       cargo miri test --verbose -- -- storage2;
       popd
 


### PR DESCRIPTION
We only test `ink_core/storage2` so far.

The `miri` tool requires `rust-src` and `xargo` tools to be installed.
This has been done in a separate PR already.

So far `miri` runs kind of successfully but it doesn't play well with `RUST_WRAPPER` and `TARGET_DIR` so we have to implement some `miri` specific work arounds here and there to avoid crashing other jobs as can be seen often with the `clippy` and `test` jobs.

Links: https://github.com/paritytech/ink/pull/401#issuecomment-631622841