### PR TITLE
Eliminate some unsafe in storage2 module

### DIFF
--- a/core/src/storage2/collections/stash/impls.rs
+++ b/core/src/storage2/collections/stash/impls.rs
@@ -49,7 +49,8 @@ where
 {
     fn assert_index_within_bounds(&self, index: u32) {
         if cfg!(debug_assertions) {
-            assert!(index < self.len(),
+            assert!(
+                index < self.len(),
                 "index out of bounds: the len is {} but the index is {}",
                 self.len(),
                 index

--- a/core/src/storage2/lazy/cache_cell.rs
+++ b/core/src/storage2/lazy/cache_cell.rs
@@ -1,0 +1,103 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    fmt::Debug,
+    ptr::NonNull,
+};
+
+/// A cache for a `T` that allow to mutate the inner `T` through `&self`.
+///
+/// Internally this is a thin wrapper around an `UnsafeCell<T>`.
+/// The main difference to `UnsafeCell` is that this type provides an out of the
+/// box API to safely access the inner `T` as well for single threaded contexts.
+pub struct CacheCell<T: ?Sized> {
+    /// The inner value that is allowed to be mutated in shared contexts.
+    inner: UnsafeCell<T>,
+}
+
+impl<T> CacheCell<T> {
+    /// Creates a new cache cell from the given value.
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: UnsafeCell::new(value),
+        }
+    }
+
+    /// Returns the inner value.
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner()
+    }
+}
+
+impl<T> Debug for CacheCell<T>
+where
+    T: ?Sized + Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <T as Debug>::fmt(self.as_inner(), f)
+    }
+}
+
+impl<T> From<T> for CacheCell<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T> Default for CacheCell<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self::new(<T as Default>::default())
+    }
+}
+
+impl<T> CacheCell<T>
+where
+    T: ?Sized,
+{
+    /// Returns a shared reference to the inner value.
+    pub fn as_inner(&self) -> &T {
+        // SAFETY: This is safe since we are returning a shared reference back
+        //         to the caller while this method itself accesses `self` as
+        //         shared reference.
+        unsafe { &*self.inner.get() }
+    }
+
+    /// Returns an exclusive reference to the inner value.
+    pub fn as_inner_mut(&mut self) -> &mut T {
+        // SAFETY: This is safe since we are returning the exclusive reference
+        //         of the inner value through the `get_mut` API which itself
+        //         requires exclusive reference access to the wrapping `self`
+        //         disallowing aliasing exclusive references.
+        unsafe { &mut *self.inner.get() }
+    }
+
+    /// Returns a mutable pointer to the inner value.
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe since it allows to mutably borrow the inner value through
+    /// a shared reference. The same rules apply here as with [`UnsafeCell::get`].
+    pub fn get_ptr(&self) -> NonNull<T> {
+        // SAFETY: The inner `T` of the internal `UnsafeCell` exists and thus
+        //         the pointer that we get returned to it via `UnsafeCell::get`
+        //         is never going to be `null`.
+        unsafe { NonNull::new_unchecked(self.inner.get()) }
+    }
+}

--- a/core/src/storage2/lazy/lazy_hmap.rs
+++ b/core/src/storage2/lazy/lazy_hmap.rs
@@ -93,9 +93,7 @@ where
     V: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_map()
-            .entries(self.0.as_inner().iter())
-            .finish()
+        f.debug_map().entries(self.0.as_inner().iter()).finish()
     }
 }
 

--- a/core/src/storage2/lazy/lazy_hmap.rs
+++ b/core/src/storage2/lazy/lazy_hmap.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::{
+    CacheCell,
     Entry,
     EntryState,
 };
@@ -31,10 +32,7 @@ use crate::{
 };
 use core::{
     borrow::Borrow,
-    cell::{
-        RefCell,
-        UnsafeCell,
-    },
+    cell::RefCell,
     cmp::{
         Eq,
         Ord,
@@ -82,12 +80,12 @@ pub struct LazyHashMap<K, V, H> {
     ///
     /// This normally only represents a subset of the total set of elements.
     /// An entry is cached as soon as it is loaded or written.
-    cached_entries: UnsafeCell<EntryMap<K, V>>,
+    cached_entries: CacheCell<EntryMap<K, V>>,
     /// The used hash builder.
     hash_builder: RefCell<HashBuilder<H, Vec<u8>>>,
 }
 
-struct DebugEntryMap<'a, K, V>(&'a UnsafeCell<EntryMap<K, V>>);
+struct DebugEntryMap<'a, K, V>(&'a CacheCell<EntryMap<K, V>>);
 
 impl<'a, K, V> Debug for DebugEntryMap<'a, K, V>
 where
@@ -96,7 +94,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map()
-            .entries(unsafe { &*self.0.get() }.iter())
+            .entries(self.0.as_inner().iter())
             .finish()
     }
 }
@@ -211,7 +209,7 @@ where
     pub fn new() -> Self {
         Self {
             key: None,
-            cached_entries: UnsafeCell::new(EntryMap::new()),
+            cached_entries: CacheCell::new(EntryMap::new()),
             hash_builder: RefCell::new(HashBuilder::from(Vec::new())),
         }
     }
@@ -227,7 +225,7 @@ where
     fn lazy(key: Key) -> Self {
         Self {
             key: Some(key),
-            cached_entries: UnsafeCell::new(EntryMap::new()),
+            cached_entries: CacheCell::new(EntryMap::new()),
             hash_builder: RefCell::new(HashBuilder::from(Vec::new())),
         }
     }
@@ -239,14 +237,12 @@ where
 
     /// Returns a shared reference to the underlying entries.
     fn entries(&self) -> &EntryMap<K, V> {
-        // SAFETY: It is safe to return a `&` reference from a `&self` receiver.
-        unsafe { &*self.cached_entries.get() }
+        self.cached_entries.as_inner()
     }
 
     /// Returns an exclusive reference to the underlying entries.
     fn entries_mut(&mut self) -> &mut EntryMap<K, V> {
-        // SAFETY: It is safe to return a `&mut` reference from a `&mut self` receiver.
-        unsafe { &mut *self.cached_entries.get() }
+        self.cached_entries.as_inner_mut()
     }
 
     /// Puts the new value under the given key.
@@ -350,7 +346,7 @@ where
         //         By returning a raw pointer we enforce an `unsafe` block at
         //         the caller site to underline that guarantees are given by the
         //         caller.
-        let cached_entries = &mut *self.cached_entries.get();
+        let cached_entries = &mut *self.cached_entries.get_ptr().as_ptr();
         use ink_prelude::collections::btree_map::Entry as BTreeMapEntry;
         // We have to clone the key here because we do not have access to the unsafe
         // raw entry API for Rust hash maps, yet since it is unstable. We can remove

--- a/core/src/storage2/lazy/mod.rs
+++ b/core/src/storage2/lazy/mod.rs
@@ -31,9 +31,12 @@ mod lazy_cell;
 mod lazy_hmap;
 mod lazy_imap;
 
-use self::entry::{
-    Entry,
-    EntryState,
+use self::{
+    cache_cell::CacheCell,
+    entry::{
+        Entry,
+        EntryState,
+    },
 };
 pub use self::{
     lazy_array::{

--- a/core/src/storage2/lazy/mod.rs
+++ b/core/src/storage2/lazy/mod.rs
@@ -24,6 +24,7 @@
 //! These low-level collections are not aware of the elements they manage thus
 //! extra care has to be taken when operating directly on them.
 
+mod cache_cell;
 mod entry;
 mod lazy_array;
 mod lazy_cell;


### PR DESCRIPTION
This PR introduces a new thin wrapper around `UnsafeCell` which allows us to safely drop some `unsafe` blocks here and there for the lazy storage abstractions. Besides that the new `CacheCell` abstractions has very similar characteristics compared to the `UnsafeCell` but its API is simply optimized for our use case.