### PR TITLE
Add Self::env() syntax to ink! lang to access environment

### DIFF
--- a/lang/macro/src/codegen/storage.rs
+++ b/lang/macro/src/codegen/storage.rs
@@ -79,7 +79,10 @@ impl GenerateCode for Storage<'_> {
             const _: () = {
                 // Used to make `self.env()` available in message code.
                 #[allow(unused_imports)]
-                use ink_lang::Env as _;
+                use ::ink_lang::{
+                    Env as _,
+                    StaticEnv as _,
+                };
 
                 #use_emit_event
                 #message_impls
@@ -95,6 +98,14 @@ impl Storage<'_> {
                 type EnvAccess = ink_lang::EnvAccess<'a, EnvTypes>;
 
                 fn env(self) -> Self::EnvAccess {
+                    Default::default()
+                }
+            }
+
+            impl<'a> ink_lang::StaticEnv for Storage {
+                type EnvAccess = ink_lang::EnvAccess<'static, EnvTypes>;
+
+                fn env() -> Self::EnvAccess {
                     Default::default()
                 }
             }

--- a/lang/macro/tests/compile_tests.rs
+++ b/lang/macro/tests/compile_tests.rs
@@ -22,6 +22,7 @@ fn compile_tests() {
     t.pass("tests/ui/pass/05-erc721-contract.rs");
     t.pass("tests/ui/pass/06-non-ink-items.rs");
     t.pass("tests/ui/pass/07-flipper-as-dependency.rs");
+    t.pass("tests/ui/pass/08-static-env.rs");
     t.compile_fail("tests/ui/fail/01-constructor-returns.rs");
     t.compile_fail("tests/ui/fail/02-missing-constructor.rs");
     t.compile_fail("tests/ui/fail/03-invalid-version.rs");

--- a/lang/macro/tests/ui/pass/08-static-env.rs
+++ b/lang/macro/tests/ui/pass/08-static-env.rs
@@ -1,0 +1,20 @@
+use ink_lang as ink;
+
+#[ink::contract(version = "0.1.0")]
+mod static_env {
+    #[ink(storage)]
+    struct StaticEnv {}
+
+    impl StaticEnv {
+        #[ink(constructor)]
+        fn new(&mut self) {
+        }
+
+        #[ink(message)]
+        fn gas_left(&mut self) -> Balance {
+            Self::env().gas_left()
+        }
+    }
+}
+
+fn main() {}

--- a/lang/src/env_access.rs
+++ b/lang/src/env_access.rs
@@ -27,7 +27,7 @@ use ink_core::{
 };
 use ink_primitives::Key;
 
-/// Allows to directly access the environment mutably.
+/// Simplifies interaction with the host environment via `self`.
 ///
 /// # Note
 ///
@@ -35,11 +35,26 @@ use ink_primitives::Key;
 /// their environment in order to allow the different dispatch functions
 /// to use it for returning the contract's output.
 pub trait Env {
-    /// The environmental types.
+    /// The access wrapper.
     type EnvAccess;
 
     /// Accesses the environment with predefined environmental types.
     fn env(self) -> Self::EnvAccess;
+}
+
+/// Simplifies interaction with the host environment via `Self`.
+///
+/// # Note
+///
+/// This is generally implemented for storage structs that include
+/// their environment in order to allow the different dispatch functions
+/// to use it for returning the contract's output.
+pub trait StaticEnv {
+    /// The access wrapper.
+    type EnvAccess;
+
+    /// Accesses the environment with predefined environmental types.
+    fn env() -> Self::EnvAccess;
 }
 
 /// A typed accessor to the environment.

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -57,6 +57,7 @@ pub use self::{
     env_access::{
         Env,
         EnvAccess,
+        StaticEnv,
     },
     error::{
         DispatchError,


### PR DESCRIPTION
This is required as a stepping stone for the integration of `storage2` module with `ink_lang`.
This allows to interact with the environment not only through e.g. `self.env().caller()` but additionally via e.g. `Self::env().caller()`.