### PR TITLE
Improve benchmarks for new storage vector operations

### DIFF
--- a/core/benches/bench.rs
+++ b/core/benches/bench.rs
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 use criterion::{
+    black_box,
     criterion_group,
     criterion_main,
     BenchmarkId,
     Criterion,
 };
-
-use core::mem::ManuallyDrop;
 use ink_core::{
     env,
     storage2::{
@@ -31,186 +30,164 @@ use ink_core::{
     },
 };
 use ink_primitives::Key;
-use criterion::black_box;
 
-criterion_group!(benches_clear_cached, bench_clear_cached);
-criterion_group!(benches_clear_lazy, bench_clear_lazy);
-criterion_group!(benches_put_cached, bench_put_cached);
-criterion_group!(benches_put_lazy, bench_put_lazy);
-criterion_main!(
-    benches_clear_cached,
-    benches_clear_lazy,
-    benches_put_cached,
-    benches_put_lazy
+criterion_group!(
+    populated_cache,
+    bench_clear_populated_cache,
+    bench_put_populated_cache,
 );
+criterion_group!(empty_cache, bench_clear_empty_cache, bench_put_empty_cache,);
+criterion_main!(populated_cache, empty_cache,);
 
-/// Asserts that the the given ordered storage vector elements are equal to the
-/// ordered elements of the given slice.
-fn assert_eq_slice(vec: &StorageVec<u8>, slice: &[u8]) {
-    assert_eq!(vec.len() as usize, slice.len());
-    assert!(vec.iter().zip(slice.iter()).all(|(lhs, rhs)| *lhs == *rhs))
+/// Returns some test values for use in benchmarks.
+#[rustfmt::skip]
+fn test_values() -> &'static [u8] {
+    &[
+        b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9',
+        b'A', b'B', b'C', b'D', b'E', b'F'
+    ]
 }
 
 /// Creates a storage vector from the given slice.
-fn vec_from_slice(slice: &[u8]) -> StorageVec<u8> {
+fn storage_vec_from_slice(slice: &[u8]) -> StorageVec<u8> {
     slice.iter().copied().collect::<StorageVec<u8>>()
 }
 
-fn clear(test_values: &[u8]) {
-    let mut vec = vec_from_slice(&test_values);
-    black_box(vec.clear());
-    assert!(vec.is_empty());
-}
-
-fn pop_all(test_values: &[u8]) {
-    let mut vec = vec_from_slice(&test_values);
-    while let Some(_) = black_box(vec.pop()) {}
-    assert!(vec.is_empty());
-}
-
-fn put_cached(test_values: &[u8]) {
-    let mut vec = vec_from_slice(&test_values);
-    for (index, _value) in test_values.iter().enumerate() {
-        vec.set(index as u32, b'X');
-    }
-    assert_eq_slice(&vec, &[b'X', b'X', b'X', b'X', b'X', b'X']);
-}
-
-fn deref_cached(test_values: &[u8]) {
-    let mut vec = vec_from_slice(&test_values);
-    for (index, _value) in test_values.iter().enumerate() {
-        *vec.get_mut(index as u32).unwrap() = b'X';
-    }
-    assert_eq_slice(&vec, &[b'X', b'X', b'X', b'X', b'X', b'X']);
-}
-
-fn bench_put_cached(c: &mut Criterion) {
-    let mut group = c.benchmark_group("PutMustOutperformDerefInCachedCase");
-    let test_values = [b'A', b'B', b'C', b'D', b'E', b'F'];
-    group.bench_with_input(BenchmarkId::new("Put", 0), &test_values, |b, i| {
-        b.iter(|| put_cached(i))
-    });
-    group.bench_with_input(BenchmarkId::new("Deref", 0), &test_values, |b, i| {
-        b.iter(|| deref_cached(i))
-    });
-    group.finish();
-}
-
-fn bench_clear_cached(c: &mut Criterion) {
-    let mut group = c.benchmark_group("ClearMustOutperformPopInCachedCase");
-    let test_values = [b'A', b'B', b'C', b'D', b'E', b'F'];
-    group.bench_with_input(BenchmarkId::new("Clear", 0), &test_values, |b, i| {
-        b.iter(|| clear(i))
-    });
-    group.bench_with_input(BenchmarkId::new("PopAll", 0), &test_values, |b, i| {
-        b.iter(|| pop_all(i))
-    });
-    group.finish();
-}
-
-/// The manual drop is used to prevent the `vec` from being written back to storage.
-/// This is so that it can be reused in the next benchmark instance, without the
-/// storage flush overhead.
-fn manual_drop(vec: StorageVec<u8>) {
-    ManuallyDrop::new(vec);
-}
-
-/// In this case we lazily load the vec from storage using `pull_spread`.
-/// This will just load lazily and won't pull anything from the storage.
-fn clear_lazy() {
-    let root_key = Key::from([0x00; 32]);
-    let mut vec =
-        <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
-    black_box(vec.clear());
-    assert!(vec.is_empty());
-    manual_drop(vec);
-}
-
-/// In this case we lazily load the vec from storage using `pull_spread`.
-/// This will just load lazily and won't pull anything from the storage.
-/// `pop` will then result in loading from storage.
-fn pop_all_lazy() {
-    let root_key = Key::from([0x00; 32]);
-    let mut vec =
-        <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
-    while let Some(_) = black_box(vec.pop()) {}
-    assert!(vec.is_empty());
-    manual_drop(vec);
-}
-
-/// In this case we lazily load the vec from storage using `pull_spread`.
-/// This will just load lazily and won't pull anything from the storage.
-/// The `deref` will then load from storage.
-fn deref_lazy() {
-    let root_key = Key::from([0x00; 32]);
-    let mut vec =
-        <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
-    for index in 0..vec.len() {
-        *vec.get_mut(index).unwrap() = b'X';
-    }
-    assert_eq_slice(&vec, &[b'X', b'X', b'X', b'X', b'X', b'X']);
-    manual_drop(vec);
-}
-
-/// In this case we lazily load the vec from storage using `pull_spread`.
-/// This will just load lazily and won't pull anything from the storage.
-/// The `vec.set()` will not load anything from storage.
-fn put_lazy() {
-    let root_key = Key::from([0x00; 32]);
-    let mut vec =
-        <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
-    for index in 0..vec.len() {
-        vec.set(index, b'X');
-    }
-    assert_eq_slice(&vec, &[b'X', b'X', b'X', b'X', b'X', b'X']);
-    manual_drop(vec);
-}
-
-/// Create a vec and push it to storage.
-fn create_and_store() {
-    let test_values = [b'A', b'B', b'C', b'D', b'E', b'F'];
-    let vec = vec_from_slice(&test_values);
+/// Creates a storage vector and pushes it to the contract storage.
+fn push_storage_vec() {
+    let vec = storage_vec_from_slice(test_values());
     let root_key = Key::from([0x00; 32]);
     SpreadLayout::push_spread(&vec, &mut KeyPtr::from(root_key));
 }
 
-/// In this case we lazily instantiate a `StorageVec` by first `create_and_store`-ing
-/// into the contract storage. We then load the vec from storage lazily in each
-/// benchmark iteration.
-fn bench_clear_lazy(c: &mut Criterion) {
-    let mut group = c.benchmark_group("ClearMustOutperformPopInLazyCase");
-    let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
-        create_and_store();
-        group.bench_function(BenchmarkId::new("Clear", 0), |b| b.iter(|| clear_lazy()));
-        Ok(())
-    })
-    .unwrap();
-    let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
-        create_and_store();
-        group
-            .bench_function(BenchmarkId::new("PopAll", 0), |b| b.iter(|| pop_all_lazy()));
-        Ok(())
-    })
-    .unwrap();
+/// Pulls a lazily loading storage vector instance from the contract storage.
+fn pull_storage_vec() -> StorageVec<u8> {
+    let root_key = Key::from([0x00; 32]);
+    <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key))
+}
+
+mod populated_cache {
+    use super::*;
+
+    pub fn clear(test_values: &[u8]) {
+        let mut vec = storage_vec_from_slice(&test_values);
+        black_box(vec.clear());
+    }
+
+    pub fn pop_all(test_values: &[u8]) {
+        let mut vec = storage_vec_from_slice(&test_values);
+        while let Some(ignored) = black_box(vec.pop()) {
+            black_box(ignored);
+        }
+    }
+
+    pub fn put(test_values: &[u8]) {
+        let mut vec = storage_vec_from_slice(&test_values);
+        for (index, _value) in test_values.iter().enumerate() {
+            vec.set(index as u32, b'X');
+        }
+    }
+
+    pub fn get_mut(test_values: &[u8]) {
+        let mut vec = storage_vec_from_slice(&test_values);
+        for (index, _value) in test_values.iter().enumerate() {
+            *vec.get_mut(index as u32).unwrap() = b'X';
+        }
+    }
+}
+
+fn bench_put_populated_cache(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Compare: `put` and `get_mu` (populated cache)");
+    group.bench_with_input(BenchmarkId::new("put", 0), test_values(), |b, i| {
+        b.iter(|| populated_cache::put(i))
+    });
+    group.bench_with_input(BenchmarkId::new("get_mut", 0), test_values(), |b, i| {
+        b.iter(|| populated_cache::get_mut(i))
+    });
     group.finish();
+}
+
+fn bench_clear_populated_cache(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Compare: `clear` and `pop_all` (populated cache)");
+    let test_values = [b'A', b'B', b'C', b'D', b'E', b'F'];
+    group.bench_with_input("clear", &test_values, |b, i| {
+        b.iter(|| populated_cache::clear(i))
+    });
+    group.bench_with_input("pop_all", &test_values, |b, i| {
+        b.iter(|| populated_cache::pop_all(i))
+    });
+    group.finish();
+}
+
+mod empty_cache {
+    use super::*;
+
+    /// In this case we lazily load the vec from storage using `pull_spread`.
+    /// This will just load lazily and won't pull anything from the storage.
+    pub fn clear() {
+        push_storage_vec();
+        let mut vec = pull_storage_vec();
+        black_box(vec.clear());
+    }
+
+    /// In this case we lazily load the vec from storage using `pull_spread`.
+    /// This will just load lazily and won't pull anything from the storage.
+    /// `pop` will then result in loading from storage.
+    pub fn pop_all() {
+        push_storage_vec();
+        let mut vec = pull_storage_vec();
+        while let Some(ignored) = black_box(vec.pop()) {
+            black_box(ignored);
+        }
+    }
+
+    /// In this case we lazily load the vec from storage using `pull_spread`.
+    /// This will just load lazily and won't pull anything from the storage.
+    /// The `deref` will then load from storage.
+    pub fn get_mut() {
+        push_storage_vec();
+        let mut vec = pull_storage_vec();
+        for index in 0..vec.len() {
+            let _ = black_box(*vec.get_mut(index).unwrap() = b'X');
+        }
+    }
+
+    /// In this case we lazily load the vec from storage using `pull_spread`.
+    /// This will just load lazily and won't pull anything from the storage.
+    /// The `vec.set()` will not load anything from storage.
+    pub fn put() {
+        push_storage_vec();
+        let mut vec = pull_storage_vec();
+        for index in 0..vec.len() {
+            black_box(vec.set(index, b'X'));
+        }
+    }
 }
 
 /// In this case we lazily instantiate a `StorageVec` by first `create_and_store`-ing
 /// into the contract storage. We then load the vec from storage lazily in each
 /// benchmark iteration.
-fn bench_put_lazy(c: &mut Criterion) {
-    let mut group = c.benchmark_group("PutMustOutperformDerefInLazyCase");
+fn bench_clear_empty_cache(c: &mut Criterion) {
     let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
-        create_and_store();
-        group.bench_function(BenchmarkId::new("Put", 0), |b| b.iter(|| put_lazy()));
+        let mut group = c.benchmark_group("Compare: `clear` and `pop_all` (empty cache)");
+        group.bench_function("clear", |b| b.iter(|| empty_cache::clear()));
+        group.bench_function("pop_all", |b| b.iter(|| empty_cache::pop_all()));
+        group.finish();
         Ok(())
     })
     .unwrap();
+}
+
+/// In this case we lazily instantiate a `StorageVec` by first `create_and_store`-ing
+/// into the contract storage. We then load the vec from storage lazily in each
+/// benchmark iteration.
+fn bench_put_empty_cache(c: &mut Criterion) {
     let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
-        create_and_store();
-        group.bench_function(BenchmarkId::new("Deref", 0), |b| b.iter(|| deref_lazy()));
+        let mut group = c.benchmark_group("Compare: `put` and `get_mut` (empty cache)");
+        group.bench_function("put", |b| b.iter(|| empty_cache::put()));
+        group.bench_function("get_mut", |b| b.iter(|| empty_cache::get_mut()));
+        group.finish();
         Ok(())
     })
     .unwrap();
-    group.finish();
 }


### PR DESCRIPTION
Improves the benchmarks for the storage vector operations.
Benchmarks now work and measure more precisely what they should measure.
The results for my local machine are:
```
     Running /home/robrob/projects/ink/target/release/deps/bench-e2ae0735144a5a49
Compare: `clear` and `pop_all` (populated cache)/clear                                                                            
                        time:   [429.59 ns 431.50 ns 433.60 ns]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
Compare: `clear` and `pop_all` (populated cache)/pop_all                                                                            
                        time:   [412.40 ns 413.94 ns 415.49 ns]
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

Compare: `put` and `get_mu` (populated cache)/put/0                                                                             
                        time:   [1.4774 us 1.4837 us 1.4903 us]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
Compare: `put` and `get_mu` (populated cache)/get_mut/0                                                                             
                        time:   [1.2821 us 1.2890 us 1.2965 us]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

Compare: `clear` and `pop_all` (empty cache)/clear                                                                             
                        time:   [4.2537 us 4.2716 us 4.2914 us]
                        change: [+7.0020% +7.7651% +8.5642%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
Compare: `clear` and `pop_all` (empty cache)/pop_all                                                                             
                        time:   [6.2049 us 6.2333 us 6.2637 us]
                        change: [-2.3157% -0.9645% +0.1005%] (p = 0.13 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild

Compare: `put` and `get_mut` (empty cache)/put                                                                             
                        time:   [6.7460 us 6.7774 us 6.8106 us]
                        change: [+0.3127% +1.1322% +1.9703%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
Compare: `put` and `get_mut` (empty cache)/get_mut                                                                             
                        time:   [9.1091 us 9.1604 us 9.2166 us]
                        change: [+9.8465% +10.985% +12.138%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```
So it can be seen that for the `empty cache` scenarios (which are common) the new operations improve the situation significantly (also very likely in terms of gas costs that we cannot measure) and for the other cases they do not significantly change the performance.