### PR TITLE
[core] Optimize dynamic storage allocator

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -85,3 +85,7 @@ harness = false
 [[bench]]
 name = "bench_stash"
 harness = false
+
+[[bench]]
+name = "bench_bitstash"
+harness = false

--- a/core/benches/bench_bitstash.rs
+++ b/core/benches/bench_bitstash.rs
@@ -89,9 +89,9 @@ fn bench_populated_cache(c: &mut Criterion) {
         b.iter(|| populated_cache::fill_bitstash())
     });
     group.bench_function("one_put", |b| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || create_large_stash(),
-            |mut stash| one_put(&mut stash),
+            |stash| black_box(one_put(stash)),
             BatchSize::SmallInput,
         )
     });

--- a/core/benches/bench_bitstash.rs
+++ b/core/benches/bench_bitstash.rs
@@ -84,7 +84,7 @@ mod populated_cache {
 }
 
 fn bench_populated_cache(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Bench: `fill_bitstash` (populated cache)");
+    let mut group = c.benchmark_group("Bench: populated cache");
     group.bench_function("fill_bitstash", |b| {
         b.iter(|| populated_cache::fill_bitstash())
     });
@@ -116,7 +116,7 @@ mod empty_cache {
 /// benchmark iteration.
 fn bench_empty_cache(c: &mut Criterion) {
     let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
-        let mut group = c.benchmark_group("Bench: `fill_bitstash` (empty cache)");
+        let mut group = c.benchmark_group("Bench: empty cache");
         group
             .bench_function("fill_bitstash", |b| b.iter(|| empty_cache::fill_bitstash()));
         group.bench_function("one_put", |b| {

--- a/core/benches/bench_bitstash.rs
+++ b/core/benches/bench_bitstash.rs
@@ -120,13 +120,13 @@ fn bench_empty_cache(c: &mut Criterion) {
         group
             .bench_function("fill_bitstash", |b| b.iter(|| empty_cache::fill_bitstash()));
         group.bench_function("one_put", |b| {
-            b.iter_batched(
+            b.iter_batched_ref(
                 || {
                     let stash = create_large_stash();
                     push_stash_by_ref(&stash);
                     pull_stash()
                 },
-                |mut stash| one_put(&mut stash),
+                |stash| one_put(stash),
                 BatchSize::SmallInput,
             )
         });

--- a/core/benches/bench_bitstash.rs
+++ b/core/benches/bench_bitstash.rs
@@ -91,7 +91,7 @@ fn bench_populated_cache(c: &mut Criterion) {
     group.bench_function("one_put", |b| {
         b.iter_batched_ref(
             || create_large_stash(),
-            |stash| black_box(one_put(stash)),
+            |stash| one_put(stash),
             BatchSize::SmallInput,
         )
     });

--- a/core/benches/bench_bitstash.rs
+++ b/core/benches/bench_bitstash.rs
@@ -55,7 +55,7 @@ mod populated_cache {
 
     pub fn fill_bitstash() {
         let mut stash = BitStash::default();
-        for i in 0..BENCH_ALLOCATIONS {
+        for _ in 0..BENCH_ALLOCATIONS {
             black_box(stash.put());
         }
     }
@@ -78,7 +78,7 @@ mod empty_cache {
     pub fn fill_bitstash() {
         push_stash();
         let mut stash = pull_stash();
-        for i in 0..BENCH_ALLOCATIONS {
+        for _ in 0..BENCH_ALLOCATIONS {
             black_box(stash.put());
         }
     }

--- a/core/benches/bench_bitstash.rs
+++ b/core/benches/bench_bitstash.rs
@@ -1,0 +1,99 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{
+    black_box,
+    criterion_group,
+    criterion_main,
+    Criterion,
+};
+
+use ink_core::{
+    env,
+    storage2::{
+        collections::BitStash,
+        traits::{
+            KeyPtr,
+            SpreadLayout,
+        },
+    },
+};
+use ink_primitives::Key;
+
+const BENCH_ALLOCATIONS: u32 = 100_000;
+
+criterion_group!(populated_cache, bench_populated_cache,);
+criterion_group!(empty_cache, bench_empty_cache,);
+criterion_main!(populated_cache, empty_cache,);
+
+/// Creates a `BitStash` and pushes it to the contract storage.
+fn push_stash() {
+    let stash = BitStash::default();
+    let root_key = Key::from([0x00; 32]);
+    SpreadLayout::push_spread(&stash, &mut KeyPtr::from(root_key));
+}
+
+/// Pulls a lazily loading `BitStash` instance from the contract storage.
+fn pull_stash() -> BitStash {
+    let root_key = Key::from([0x00; 32]);
+    <BitStash as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key))
+}
+
+mod populated_cache {
+    use super::*;
+
+    pub fn fill_bitstash() {
+        let mut stash = BitStash::default();
+        for i in 0..BENCH_ALLOCATIONS {
+            black_box(stash.put());
+        }
+    }
+}
+
+fn bench_populated_cache(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Bench: `fill_bitstash` (populated cache)");
+    group.bench_function("fill_bitstash", |b| {
+        b.iter(|| populated_cache::fill_bitstash())
+    });
+    group.finish();
+}
+
+mod empty_cache {
+    use super::*;
+
+    /// In this case we lazily load the stash from storage using `pull_spread`.
+    /// This will just load lazily and won't pull anything from the storage.
+    /// `take` will then result in loading from storage.
+    pub fn fill_bitstash() {
+        push_stash();
+        let mut stash = pull_stash();
+        for i in 0..BENCH_ALLOCATIONS {
+            black_box(stash.put());
+        }
+    }
+}
+
+/// In this case we lazily instantiate a `BitStash` by first creating and storing
+/// into the contract storage. We then load the stash from storage lazily in each
+/// benchmark iteration.
+fn bench_empty_cache(c: &mut Criterion) {
+    let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
+        let mut group = c.benchmark_group("Bench: `fill_bitstash` (empty cache)");
+        group
+            .bench_function("fill_bitstash", |b| b.iter(|| empty_cache::fill_bitstash()));
+        group.finish();
+        Ok(())
+    })
+    .unwrap();
+}

--- a/core/src/storage2/alloc/mod.rs
+++ b/core/src/storage2/alloc/mod.rs
@@ -32,7 +32,7 @@
 //! This way we can reduce the problem of finding another region in our storage
 //! that fits certain requirements (e.g. a minimum size) to the problem of
 //! finding another uniform slot. Since we are on 32-bit WebAssembly we have
-//! memory limitations that makes it impractical to have more than 2^32 dynamic
+//! memory limitations that make it impractical to have more than 2^32 dynamic
 //! allocated entities and so we can create another limitation for having a
 //! total of 2^32 dynamic allocations at any point in time.
 //! This enables us to have 32-bit keys instead of 256-bit keys.

--- a/core/src/storage2/collections/bitstash/counts.rs
+++ b/core/src/storage2/collections/bitstash/counts.rs
@@ -76,14 +76,6 @@ impl CountFree {
         }
 
         Some(i as u8)
-
-        // Old version
-        // for (i, count) in self.counts.iter_mut().enumerate() {
-        // if !self.full.is_full(i as u8) {
-        // return Some(i as u8)
-        // }
-        // }
-        // None
     }
 
     /// Increases the number of set bits for the given index.

--- a/core/src/storage2/collections/bitstash/counts.rs
+++ b/core/src/storage2/collections/bitstash/counts.rs
@@ -63,12 +63,6 @@ impl FullMask {
     pub fn reset_full(&mut self, index: u8) {
         self.0 &= !(1_u32 << (31 - index as u32));
     }
-
-    /// Returns `true` if there is no more space available at any of the indices
-    /// and hence all chunks are full.
-    pub fn is_completely_full(self) -> bool {
-        self.0 == u32::MAX
-    }
 }
 
 impl CountFree {
@@ -76,15 +70,9 @@ impl CountFree {
     ///
     /// Returns `None` if all counts are `0xFF`.
     pub fn position_first_zero(&mut self) -> Option<u8> {
-        if self.full.is_completely_full() {
-            return None
-        }
-
         let i = (!self.full.0).leading_zeros();
         if i == 32 {
-            unreachable!(
-                "if full we must already have exited right at the start of this function"
-            );
+            return None;
         }
 
         Some(i as u8)

--- a/core/src/storage2/collections/bitstash/counts.rs
+++ b/core/src/storage2/collections/bitstash/counts.rs
@@ -63,6 +63,12 @@ impl FullMask {
     pub fn reset_full(&mut self, index: u8) {
         self.0 &= !(1_u32 << (31 - index as u32));
     }
+
+    /// Returns `true` if there is no more space available at any of the indices
+    /// and hence all chunks are full.
+    pub fn is_completely_full(self) -> bool {
+        self.0 == u32::MAX
+    }
 }
 
 impl CountFree {

--- a/core/src/storage2/collections/bitstash/counts.rs
+++ b/core/src/storage2/collections/bitstash/counts.rs
@@ -72,7 +72,7 @@ impl CountFree {
     pub fn position_first_zero(&mut self) -> Option<u8> {
         let i = (!self.full.0).leading_zeros();
         if i == 32 {
-            return None;
+            return None
         }
 
         Some(i as u8)

--- a/core/src/storage2/collections/bitstash/counts.rs
+++ b/core/src/storage2/collections/bitstash/counts.rs
@@ -75,6 +75,14 @@ impl CountFree {
             return None
         }
         Some(i as u8)
+
+        // Old version
+        // for (i, count) in self.counts.iter_mut().enumerate() {
+        // if !self.full.is_full(i as u8) {
+        // return Some(i as u8)
+        // }
+        // }
+        // None
     }
 
     /// Increases the number of set bits for the given index.

--- a/core/src/storage2/collections/bitstash/counts.rs
+++ b/core/src/storage2/collections/bitstash/counts.rs
@@ -88,10 +88,7 @@ impl CountFree {
         if self.counts[index] == !0 {
             self.full.set_full(index as u8);
         } else {
-            let new_value = self.counts[index]
-                .checked_add(1)
-                .expect("set bits increment overflowed");
-            self.counts[index] = new_value;
+            self.counts[index] = self.counts[index] + 1;
         }
     }
 

--- a/core/src/storage2/collections/bitstash/counts.rs
+++ b/core/src/storage2/collections/bitstash/counts.rs
@@ -75,14 +75,6 @@ impl CountFree {
             return None
         }
         Some(i as u8)
-
-        // Old version
-        // for (i, count) in self.counts.iter_mut().enumerate() {
-        // if !self.full.is_full(i as u8) {
-        // return Some(i as u8)
-        // }
-        // }
-        // None
     }
 
     /// Increases the number of set bits for the given index.

--- a/core/src/storage2/collections/bitstash/counts.rs
+++ b/core/src/storage2/collections/bitstash/counts.rs
@@ -69,12 +69,11 @@ impl CountFree {
     /// Returns the position of the first free `u8` in the free counts.
     ///
     /// Returns `None` if all counts are `0xFF`.
-    pub fn position_first_zero(&mut self) -> Option<u8> {
+    pub fn position_first_zero(&self) -> Option<u8> {
         let i = (!self.full.0).leading_zeros();
         if i == 32 {
             return None
         }
-
         Some(i as u8)
     }
 

--- a/core/src/storage2/collections/bitstash/counts.rs
+++ b/core/src/storage2/collections/bitstash/counts.rs
@@ -76,17 +76,44 @@ impl CountFree {
     ///
     /// Returns `None` if all counts are `0xFF`.
     pub fn position_first_zero(&mut self) -> Option<u8> {
-        for (i, count) in self.counts.iter_mut().enumerate() {
-            if !self.full.is_full(i as u8) {
-                if *count == !0 {
-                    self.full.set_full(i as u8);
-                } else {
-                    *count += 1;
-                }
-                return Some(i as u8)
-            }
+        if self.full.is_completely_full() {
+            return None
         }
-        None
+
+        let i = (!self.full.0).leading_zeros();
+        if i == 32 {
+            unreachable!(
+                "if full we must already have exited right at the start of this function"
+            );
+        }
+
+        Some(i as u8)
+
+        // Old version
+        // for (i, count) in self.counts.iter_mut().enumerate() {
+        // if !self.full.is_full(i as u8) {
+        // return Some(i as u8)
+        // }
+        // }
+        // None
+    }
+
+    /// Increases the number of set bits for the given index.
+    ///
+    /// # Panics
+    ///
+    /// - If the given index is out of bounds.
+    /// - If the increment would cause an overflow.
+    pub fn inc(&mut self, index: usize) {
+        assert!(index < 32, "index is out of bounds");
+        if self.counts[index] == !0 {
+            self.full.set_full(index as u8);
+        } else {
+            let new_value = self.counts[index]
+                .checked_add(1)
+                .expect("set bits increment overflowed");
+            self.counts[index] = new_value;
+        }
     }
 
     /// Decreases the number of set bits for the given index.

--- a/core/src/storage2/collections/bitstash/counts.rs
+++ b/core/src/storage2/collections/bitstash/counts.rs
@@ -88,7 +88,7 @@ impl CountFree {
         if self.counts[index] == !0 {
             self.full.set_full(index as u8);
         } else {
-            self.counts[index] = self.counts[index] + 1;
+            self.counts[index] += 1;
         }
     }
 

--- a/core/src/storage2/collections/bitstash/mod.rs
+++ b/core/src/storage2/collections/bitstash/mod.rs
@@ -34,7 +34,7 @@ type Index = u32;
 
 /// A stash for bits operating on the contract storage.
 ///
-/// Allows to efficienty put and take bits and
+/// Allows to efficiently put and take bits and
 /// stores the underlying bits in an extremely compressed format.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct BitStash {

--- a/core/src/storage2/collections/bitstash/mod.rs
+++ b/core/src/storage2/collections/bitstash/mod.rs
@@ -76,6 +76,7 @@ impl BitStash {
         // The counts list consists of packs of 32 counts per element.
         for (n, counts) in self.counts.iter_mut().enumerate() {
             if let Some(i) = counts.position_first_zero() {
+                counts.inc(i as usize);
                 let n = n as u64;
                 let i = i as u64;
                 return Some(n * (32 * 256) + i * 256)


### PR DESCRIPTION
Closes #407.

## Benches for 100k `BitStash::put` ops (updated)

### New version (no more loop):

```
Bench: populated cache/fill_bitstash                                                                             
                        time:   [16.253 ms 16.922 ms 17.659 ms]                                                                                                
                        change: [-10.013% -3.6306% +3.2150%] (p = 0.29 > 0.05)                                                                                 
                        No change in performance detected.                     
Found 13 outliers among 100 measurements (13.00%)                              
  5 (5.00%) high mild                                                                                                                                          
  8 (8.00%) high severe                                                                                                                                        
Bench: populated cache/one_put                                                                             
                        time:   [465.78 ns 500.94 ns 538.52 ns]                
                        change: [-97.830% -97.481% -97.089%] (p = 0.00 < 0.05)                                                                                 
                        Performance has improved.                                                                                                              
Found 3 outliers among 100 measurements (3.00%)                                                                                                                
  3 (3.00%) high mild                                                                                                                                          
                                                                                                                                                               
Bench: empty cache/fill_bitstash                                                                                                                               
                        time:   [17.082 ms 17.946 ms 18.910 ms]                                                                                                
                        change: [-1.5820% +5.6911% +13.130%] (p = 0.11 > 0.05)                                                                                 
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe
Bench: empty cache/one_put                                                                             
                        time:   [7.7743 us 8.3617 us 9.0137 us]
                        change: [-5.6624% +3.8722% +14.787%] (p = 0.47 > 0.05)
                        No change in performance detected.
Found 18 outliers among 100 measurements (18.00%)
  5 (5.00%) high mild
  13 (13.00%) high severe
```

### Running the old version (loop) subsequently after the new version:
```
Bench: populated cache/fill_bitstash                                                                            
                        time:   [28.347 ms 29.501 ms 30.765 ms]
                        change: [+64.246% +74.338% +85.703%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) high mild
  11 (11.00%) high severe
Bench: populated cache/one_put                                                                            
                        time:   [757.24 ns 810.25 ns 867.63 ns]
                        change: [+46.578% +61.744% +77.221%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Bench: empty cache/fill_bitstash                                                                            
                        time:   [27.392 ms 28.532 ms 29.816 ms]
                        change: [+48.523% +58.986% +69.641%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe
Bench: empty cache/one_put                                                                            
                        time:   [8.2094 us 8.9335 us 9.7604 us]
                        change: [-4.1931% +6.8383% +21.234%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 19 outliers among 100 measurements (19.00%)
  1 (1.00%) high mild
  18 (18.00%) high severe
```