### PR TITLE
[core] export test::env::EmittedEvent

### DIFF
--- a/core/src/env/engine/off_chain/mod.rs
+++ b/core/src/env/engine/off_chain/mod.rs
@@ -29,6 +29,7 @@ pub use self::{
     call_data::CallData,
     db::{
         AccountError,
+        EmittedEvent,
         PastPrints,
     },
     typed_encoded::TypedEncodedError,
@@ -40,7 +41,6 @@ use self::{
         Block,
         ChainSpec,
         Console,
-        EmittedEvent,
         EmittedEventsRecorder,
         ExecContext,
     },

--- a/core/src/env/engine/off_chain/test_api.rs
+++ b/core/src/env/engine/off_chain/test_api.rs
@@ -14,11 +14,13 @@
 
 //! Operations on the off-chain testing environment.
 
-pub use super::CallData;
+pub use super::{
+    CallData,
+    EmittedEvent,
+};
 use super::{
     db::ExecContext,
     AccountError,
-    EmittedEvent,
     EnvInstance,
     OnInstance,
 };

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -179,8 +179,13 @@ mod erc20 {
                 // Constructor works.
                 let _erc20 = Erc20::new(100);
 
-                // Transfer event triggered during initial contruction.
-                let emitted_events = env::test::recorded_events().collect::<Vec<_>>();
+                use env::test::{
+                    recorded_events,
+                    EmittedEvent,
+                };
+
+                // Transfer event triggered during initial construction.
+                let emitted_events = recorded_events().collect::<Vec<EmittedEvent>>();
                 assert_eq!(1, emitted_events.len());
                 let raw_event = emitted_events.first().unwrap();
                 let event = <Event as scale::Decode>::decode(&mut &raw_event.data[..])
@@ -199,7 +204,7 @@ mod erc20 {
             run_test(|| {
                 // Constructor works.
                 let erc20 = Erc20::new(100);
-                // Transfer event triggered during initial contruction.
+                // Transfer event triggered during initial construction.
                 assert_eq!(env::test::recorded_events().count(), 1);
                 // Get the token total supply.
                 assert_eq!(erc20.total_supply(), 100);
@@ -212,7 +217,7 @@ mod erc20 {
             run_test(|| {
                 // Constructor works
                 let erc20 = Erc20::new(100);
-                // Transfer event triggered during initial contruction
+                // Transfer event triggered during initial construction
                 assert_eq!(env::test::recorded_events().count(), 1);
                 let accounts = env::test::default_accounts::<env::DefaultEnvTypes>()
                     .expect("Cannot get accounts");
@@ -228,7 +233,7 @@ mod erc20 {
             run_test(|| {
                 // Constructor works.
                 let mut erc20 = Erc20::new(100);
-                // Transfer event triggered during initial contruction.
+                // Transfer event triggered during initial construction.
                 assert_eq!(1, env::test::recorded_events().count());
                 let accounts = env::test::default_accounts::<env::DefaultEnvTypes>()
                     .expect("Cannot get accounts");
@@ -248,7 +253,7 @@ mod erc20 {
             run_test(|| {
                 // Constructor works.
                 let mut erc20 = Erc20::new(100);
-                // Transfer event triggered during initial contruction.
+                // Transfer event triggered during initial construction.
                 assert_eq!(env::test::recorded_events().count(), 1);
                 let accounts = env::test::default_accounts::<env::DefaultEnvTypes>()
                     .expect("Cannot get accounts");
@@ -287,7 +292,7 @@ mod erc20 {
             run_test(|| {
                 // Constructor works.
                 let mut erc20 = Erc20::new(100);
-                // Transfer event triggered during initial contruction.
+                // Transfer event triggered during initial construction.
                 assert_eq!(env::test::recorded_events().count(), 1);
                 let accounts = env::test::default_accounts::<env::DefaultEnvTypes>()
                     .expect("Cannot get accounts");

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -172,11 +172,16 @@ mod erc20 {
             .unwrap()
         }
 
-        fn assert_transfer_event<I>(raw_events: I, transfer_index: usize, expected_value: u128)
-        where
-            I: IntoIterator<Item = env::test::EmittedEvent>
+        fn assert_transfer_event<I>(
+            raw_events: I,
+            transfer_index: usize,
+            expected_value: u128,
+        ) where
+            I: IntoIterator<Item = env::test::EmittedEvent>,
         {
-            let raw_event = raw_events.into_iter().nth(transfer_index)
+            let raw_event = raw_events
+                .into_iter()
+                .nth(transfer_index)
                 .expect(&format!("No event at index {}", transfer_index));
             let event = <Event as scale::Decode>::decode(&mut &raw_event.data[..])
                 .expect("Invalid contract Event");


### PR DESCRIPTION
Fixes #468.

Updates the `erc20` tests to use the type explicitly, to prove it works.