### PR TITLE
[core] Add Entry API for storage2::HashMap

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -89,3 +89,7 @@ harness = false
 [[bench]]
 name = "bench_bitstash"
 harness = false
+
+[[bench]]
+name = "bench_hashmap"
+harness = false

--- a/core/benches/bench_hashmap.rs
+++ b/core/benches/bench_hashmap.rs
@@ -1,0 +1,160 @@
+// Copyright 2019-2020 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{
+    black_box,
+    criterion_group,
+    criterion_main,
+    Criterion,
+};
+
+use ink_core::{
+    env,
+    storage2::{
+        collections::HashMap as StorageHashMap,
+        traits::{
+            KeyPtr,
+            SpreadLayout,
+        },
+    },
+};
+use ink_primitives::Key;
+
+criterion_group!(populated_cache, bench_insert_populated_cache,);
+criterion_group!(empty_cache, bench_insert,);
+criterion_main!(populated_cache, empty_cache,);
+
+/// Returns some test values for use in benchmarks.
+fn test_values() -> Vec<(i32, i32)> {
+    let mut v = Vec::new();
+    for index in 0..500 {
+        v.push((index, index));
+    }
+    v
+}
+
+/// Creates a storage stash from the given slice.
+fn hashmap_from_slice(slice: &[(i32, i32)]) -> StorageHashMap<i32, i32> {
+    slice.iter().copied().collect::<StorageHashMap<i32, i32>>()
+}
+
+/// Returns always the same `KeyPtr`.
+fn key_ptr() -> KeyPtr {
+    let root_key = Key::from([0x42; 32]);
+    KeyPtr::from(root_key)
+}
+
+/// Creates a storage stash and pushes it to the contract storage.
+fn push_storage_hashmap() {
+    let test_values = test_values();
+    let stash = hashmap_from_slice(&test_values[..]);
+    SpreadLayout::push_spread(&stash, &mut key_ptr());
+}
+
+/// Pulls a lazily loading storage stash instance from the contract storage.
+fn pull_storage_hashmap() -> StorageHashMap<i32, i32> {
+    <StorageHashMap<i32, i32> as SpreadLayout>::pull_spread(&mut key_ptr())
+}
+
+mod populated_cache {
+    use super::*;
+
+    pub fn insert_if_nonexistent() {
+        let test_values = test_values();
+        let mut hmap = hashmap_from_slice(&test_values[..]);
+        for key in 0..1000 {
+            black_box({
+                if !hmap.contains_key(&key) {
+                    hmap.insert(key, key);
+                }
+                *hmap.get_mut(&key).unwrap() += 1;
+            });
+        }
+    }
+
+    pub fn insert_if_nonexistent_entry_api() {
+        let test_values = test_values();
+        let mut hmap = hashmap_from_slice(&test_values[..]);
+        for key in 0..1000 {
+            black_box({
+                let v = hmap.entry(key).or_insert(key);
+                *v += 1;
+            });
+        }
+    }
+}
+
+fn bench_insert_populated_cache(c: &mut Criterion) {
+    let mut group =
+        c.benchmark_group("Compare: `insert` and `insert_entry_api` (populated cache)");
+    group.bench_function("insert_if_nonexistent", |b| {
+        b.iter(|| populated_cache::insert_if_nonexistent())
+    });
+    group.bench_function("insert_if_nonexistent_entry_api", |b| {
+        b.iter(|| populated_cache::insert_if_nonexistent_entry_api())
+    });
+    group.finish();
+}
+
+mod empty_cache {
+    use super::*;
+
+    /// In this case we lazily load the stash from storage using `pull_spread`.
+    /// This will just load lazily and won't pull anything from the storage.
+    pub fn insert_if_nonexistent() {
+        push_storage_hashmap();
+        let mut hmap = pull_storage_hashmap();
+        for key in 0..1000 {
+            black_box({
+                if !hmap.contains_key(&key) {
+                    hmap.insert(key, key);
+                }
+                *hmap.get_mut(&key).unwrap() += 1;
+            });
+        }
+    }
+
+    /// In this case we lazily load the stash from storage using `pull_spread`.
+    /// This will just load lazily and won't pull anything from the storage.
+    /// `take` will then result in loading from storage.
+    pub fn insert_if_nonexistent_entry_api() {
+        push_storage_hashmap();
+        let mut hmap = pull_storage_hashmap();
+        for key in 0..1000 {
+            black_box({
+                let v = hmap.entry(key).or_insert(key);
+                *v += 1;
+            });
+        }
+    }
+}
+
+/// In this case we lazily instantiate a `StorageStash` by first `create_and_store`-ing
+/// into the contract storage. We then load the stash from storage lazily in each
+/// benchmark iteration.
+fn bench_insert(c: &mut Criterion) {
+    let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
+        let mut group =
+            c.benchmark_group("Compare: `insert` and `insert_entry_api` (empty cache)");
+        group.bench_function("insert_if_nonexistent", |b| {
+            b.iter(|| empty_cache::insert_if_nonexistent())
+        });
+        group.bench_function("insert_if_nonexistent_entry_api", |b| {
+            b.iter(|| empty_cache::insert_if_nonexistent_entry_api())
+        });
+        group.finish();
+        Ok(())
+    })
+    .unwrap();
+}

--- a/core/benches/bench_hashmap.rs
+++ b/core/benches/bench_hashmap.rs
@@ -49,11 +49,10 @@ const ENTRIES: i32 = 500;
 
 /// Returns some test values for use in benchmarks.
 fn test_values() -> Vec<(i32, i32)> {
-    let mut v = Vec::new();
-    for index in 0..ENTRIES {
-        v.push((index, index));
-    }
-    v
+    (0..ENTRIES)
+        .into_iter()
+        .map(|index| (index, index))
+        .collect::<Vec<_>>()
 }
 
 /// Creates a `StorageHashMap` from the given slice.

--- a/core/benches/bench_hashmap.rs
+++ b/core/benches/bench_hashmap.rs
@@ -44,7 +44,7 @@ fn test_values() -> Vec<(i32, i32)> {
     v
 }
 
-/// Creates a storage stash from the given slice.
+/// Creates a `StorageHashMap` from the given slice.
 fn hashmap_from_slice(slice: &[(i32, i32)]) -> StorageHashMap<i32, i32> {
     slice.iter().copied().collect::<StorageHashMap<i32, i32>>()
 }
@@ -55,14 +55,14 @@ fn key_ptr() -> KeyPtr {
     KeyPtr::from(root_key)
 }
 
-/// Creates a storage stash and pushes it to the contract storage.
+/// Creates a `StorageHashMap` and pushes it to the contract storage.
 fn push_storage_hashmap() {
     let test_values = test_values();
-    let stash = hashmap_from_slice(&test_values[..]);
-    SpreadLayout::push_spread(&stash, &mut key_ptr());
+    let hmap = hashmap_from_slice(&test_values[..]);
+    SpreadLayout::push_spread(&hmap, &mut key_ptr());
 }
 
-/// Pulls a lazily loading storage stash instance from the contract storage.
+/// Pulls a lazily loading `StorageHashMap` instance from the contract storage.
 fn pull_storage_hashmap() -> StorageHashMap<i32, i32> {
     <StorageHashMap<i32, i32> as SpreadLayout>::pull_spread(&mut key_ptr())
 }
@@ -110,7 +110,7 @@ fn bench_insert_populated_cache(c: &mut Criterion) {
 mod empty_cache {
     use super::*;
 
-    /// In this case we lazily load the stash from storage using `pull_spread`.
+    /// In this case we lazily load the map from storage using `pull_spread`.
     /// This will just load lazily and won't pull anything from the storage.
     pub fn insert_if_nonexistent() {
         push_storage_hashmap();
@@ -125,7 +125,7 @@ mod empty_cache {
         }
     }
 
-    /// In this case we lazily load the stash from storage using `pull_spread`.
+    /// In this case we lazily load the map from storage using `pull_spread`.
     /// This will just load lazily and won't pull anything from the storage.
     /// `take` will then result in loading from storage.
     pub fn insert_if_nonexistent_entry_api() {
@@ -140,9 +140,6 @@ mod empty_cache {
     }
 }
 
-/// In this case we lazily instantiate a `StorageStash` by first `create_and_store`-ing
-/// into the contract storage. We then load the stash from storage lazily in each
-/// benchmark iteration.
 fn bench_insert(c: &mut Criterion) {
     let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
         let mut group =

--- a/core/benches/bench_hashmap.rs
+++ b/core/benches/bench_hashmap.rs
@@ -85,41 +85,33 @@ fn pull_storage_hashmap() -> StorageHashMap<i32, i32> {
 
 fn bench_insert_and_inc(hmap: &mut StorageHashMap<i32, i32>) {
     for key in 0..ENTRIES * 2 {
-        black_box({
-            if !hmap.contains_key(&key) {
-                hmap.insert(key, key);
-            }
-            *hmap.get_mut(&key).unwrap() += 1;
-        });
+        if !black_box(hmap.contains_key(&key)) {
+            black_box(hmap.insert(key, key));
+        }
+        *black_box(hmap.get_mut(&key)).unwrap() += 1;
     }
 }
 
 fn bench_insert_and_inc_entry_api(hmap: &mut StorageHashMap<i32, i32>) {
     for key in 0..ENTRIES * 2 {
-        black_box({
-            let v = hmap.entry(key).or_insert(key);
-            *v += 1;
-        });
+        let v = black_box(hmap.entry(key).or_insert(key));
+        *v += 1;
     }
 }
 
 fn bench_removal(hmap: &mut StorageHashMap<i32, i32>) {
-        black_box({
-            if hmap.contains_key(&key) {
-                let _ = hmap.take(&key);
-            }
-        });
     for key in 0..ENTRIES * 2 {
+        if black_box(hmap.contains_key(&key)) {
+            let _ = black_box(hmap.take(&key));
+        }
     }
 }
 
 fn bench_removal_entry_api(hmap: &mut StorageHashMap<i32, i32>) {
     for key in 0..ENTRIES * 2 {
-        black_box({
-            if let Entry::Occupied(o) = hmap.entry(key) {
-                o.remove();
-            }
-        });
+        if let Entry::Occupied(o) = black_box(hmap.entry(key)) {
+            o.remove();
+        }
     }
 }
 

--- a/core/benches/bench_hashmap.rs
+++ b/core/benches/bench_hashmap.rs
@@ -104,12 +104,12 @@ fn bench_insert_and_inc_entry_api(hmap: &mut StorageHashMap<i32, i32>) {
 }
 
 fn bench_removal(hmap: &mut StorageHashMap<i32, i32>) {
-    for key in 0..ENTRIES {
         black_box({
             if hmap.contains_key(&key) {
                 let _ = hmap.take(&key);
             }
         });
+    for key in 0..ENTRIES * 2 {
     }
 }
 

--- a/core/benches/bench_hashmap.rs
+++ b/core/benches/bench_hashmap.rs
@@ -22,7 +22,10 @@ use criterion::{
 use ink_core::{
     env,
     storage2::{
-        collections::HashMap as StorageHashMap,
+        collections::{
+            hashmap::Entry,
+            HashMap as StorageHashMap,
+        },
         traits::{
             KeyPtr,
             SpreadLayout,
@@ -31,8 +34,12 @@ use ink_core::{
 };
 use ink_primitives::Key;
 
-criterion_group!(populated_cache, bench_insert_populated_cache,);
-criterion_group!(empty_cache, bench_insert,);
+criterion_group!(
+    populated_cache,
+    bench_insert_populated_cache,
+    bench_remove_populated_cache,
+);
+criterion_group!(empty_cache, bench_insert, bench_remove,);
 criterion_main!(populated_cache, empty_cache,);
 
 /// Returns some test values for use in benchmarks.
@@ -70,7 +77,7 @@ fn pull_storage_hashmap() -> StorageHashMap<i32, i32> {
 mod populated_cache {
     use super::*;
 
-    pub fn insert_if_nonexistent() {
+    pub fn insert_and_inc() {
         let test_values = test_values();
         let mut hmap = hashmap_from_slice(&test_values[..]);
         for key in 0..1000 {
@@ -83,7 +90,7 @@ mod populated_cache {
         }
     }
 
-    pub fn insert_if_nonexistent_entry_api() {
+    pub fn insert_and_inc_entry_api() {
         let test_values = test_values();
         let mut hmap = hashmap_from_slice(&test_values[..]);
         for key in 0..1000 {
@@ -93,18 +100,58 @@ mod populated_cache {
             });
         }
     }
+
+    pub fn remove() {
+        let test_values = test_values();
+        let mut hmap = hashmap_from_slice(&test_values[..]);
+        for key in 0..1000 {
+            black_box({
+                if hmap.contains_key(&key) {
+                    let _ = hmap.take(&key);
+                }
+            });
+        }
+    }
+
+    pub fn remove_entry_api() {
+        let test_values = test_values();
+        let mut hmap = hashmap_from_slice(&test_values[..]);
+        for key in 0..1000 {
+            black_box({
+                if let Entry::Occupied(o) = hmap.entry(key) {
+                    o.remove();
+                }
+            });
+        }
+    }
 }
 
 fn bench_insert_populated_cache(c: &mut Criterion) {
-    let mut group =
-        c.benchmark_group("Compare: `insert` and `insert_entry_api` (populated cache)");
-    group.bench_function("insert_if_nonexistent", |b| {
-        b.iter(|| populated_cache::insert_if_nonexistent())
+    let mut group = c.benchmark_group(
+        "Compare: `insert_and_inc` and `insert_and_inc_entry_api` (populated cache)",
+    );
+    group.bench_function("insert_and_inc", |b| {
+        b.iter(|| populated_cache::insert_and_inc())
     });
-    group.bench_function("insert_if_nonexistent_entry_api", |b| {
-        b.iter(|| populated_cache::insert_if_nonexistent_entry_api())
+    group.bench_function("insert_and_inc_entry_api", |b| {
+        b.iter(|| populated_cache::insert_and_inc_entry_api())
     });
     group.finish();
+}
+
+fn bench_remove_populated_cache(c: &mut Criterion) {
+    let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
+        let mut group = c.benchmark_group(
+            "Compare: `remove` and `remove_entry_api` (populated cache)",
+        );
+        group.bench_function("remove", |b| b.iter(|| populated_cache::remove()));
+        group.bench_function("remove_entry_api", |b| {
+            b.iter(|| populated_cache::remove_entry_api())
+        });
+        group.finish();
+        Ok(())
+    })
+    .unwrap();
 }
 
 mod empty_cache {
@@ -112,7 +159,7 @@ mod empty_cache {
 
     /// In this case we lazily load the map from storage using `pull_spread`.
     /// This will just load lazily and won't pull anything from the storage.
-    pub fn insert_if_nonexistent() {
+    pub fn insert_and_inc() {
         push_storage_hashmap();
         let mut hmap = pull_storage_hashmap();
         for key in 0..1000 {
@@ -128,7 +175,7 @@ mod empty_cache {
     /// In this case we lazily load the map from storage using `pull_spread`.
     /// This will just load lazily and won't pull anything from the storage.
     /// `take` will then result in loading from storage.
-    pub fn insert_if_nonexistent_entry_api() {
+    pub fn insert_and_inc_entry_api() {
         push_storage_hashmap();
         let mut hmap = pull_storage_hashmap();
         for key in 0..1000 {
@@ -138,17 +185,56 @@ mod empty_cache {
             });
         }
     }
+
+    pub fn remove() {
+        let test_values = test_values();
+        let mut hmap = hashmap_from_slice(&test_values[..]);
+        for key in 0..500 {
+            black_box({
+                if hmap.contains_key(&key) {
+                    let _ = hmap.take(&key);
+                }
+            });
+        }
+    }
+
+    pub fn remove_entry_api() {
+        let test_values = test_values();
+        let mut hmap = hashmap_from_slice(&test_values[..]);
+        for key in 0..500 {
+            black_box({
+                if let Entry::Occupied(o) = hmap.entry(key) {
+                    o.remove();
+                }
+            });
+        }
+    }
 }
 
 fn bench_insert(c: &mut Criterion) {
     let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
-        let mut group =
-            c.benchmark_group("Compare: `insert` and `insert_entry_api` (empty cache)");
-        group.bench_function("insert_if_nonexistent", |b| {
-            b.iter(|| empty_cache::insert_if_nonexistent())
+        let mut group = c.benchmark_group(
+            "Compare: `insert_and_inc` and `insert_and_inc_entry_api` (empty cache)",
+        );
+        group.bench_function("insert_and_inc", |b| {
+            b.iter(|| empty_cache::insert_and_inc())
         });
-        group.bench_function("insert_if_nonexistent_entry_api", |b| {
-            b.iter(|| empty_cache::insert_if_nonexistent_entry_api())
+        group.bench_function("insert_and_inc_entry_api", |b| {
+            b.iter(|| empty_cache::insert_and_inc_entry_api())
+        });
+        group.finish();
+        Ok(())
+    })
+    .unwrap();
+}
+
+fn bench_remove(c: &mut Criterion) {
+    let _ = env::test::run_test::<env::DefaultEnvTypes, _>(|_| {
+        let mut group =
+            c.benchmark_group("Compare: `remove` and `remove_entry_api` (empty cache)");
+        group.bench_function("remove", |b| b.iter(|| empty_cache::remove()));
+        group.bench_function("remove_entry_api", |b| {
+            b.iter(|| empty_cache::remove_entry_api())
         });
         group.finish();
         Ok(())

--- a/core/src/storage2/collections/hashmap/mod.rs
+++ b/core/src/storage2/collections/hashmap/mod.rs
@@ -481,10 +481,10 @@ where
     fn insert(value: V, entry: VacantEntry<'a, K, V, H>) -> &'a mut V {
         let old_value = entry.base.insert(entry.key.clone(), value);
         debug_assert!(old_value.is_none());
-        match entry.base.entry(entry.key) {
-            Entry::Vacant(_) => unreachable!("entry was just inserted; qed"),
-            Entry::Occupied(entry) => entry.into_mut(),
-        }
+        entry
+            .base
+            .get_mut(&entry.key)
+            .expect("encountered invalid vacant entry")
     }
 }
 

--- a/core/src/storage2/collections/hashmap/mod.rs
+++ b/core/src/storage2/collections/hashmap/mod.rs
@@ -549,7 +549,7 @@ where
         &self
             .base
             .get(&self.key)
-            .expect("OccupiedEntry must always exist")
+            .expect("entry behind `OccupiedEntry` must always exist")
     }
 
     /// Gets a mutable reference to the value in the entry.
@@ -559,7 +559,7 @@ where
     pub fn get_mut(&mut self) -> &mut V {
         self.base
             .get_mut(&self.key)
-            .expect("OccupiedEntry must always exist")
+            .expect("entry behind `OccupiedEntry` must always exist")
     }
 
     /// Sets the value of the entry, and returns the entry's old value.
@@ -568,7 +568,7 @@ where
             .base
             .values
             .get_mut(&self.key)
-            .expect("OccupiedEntry must always exist");
+            .expect("entry behind `OccupiedEntry` must always exist");
         core::mem::replace(&mut occupied.value, new_value)
     }
 
@@ -582,6 +582,6 @@ where
     pub fn into_mut(self) -> &'a mut V {
         self.base
             .get_mut(&self.key)
-            .expect("OccupiedEntry must always exist")
+            .expect("entry behind `OccupiedEntry` must always exist")
     }
 }

--- a/core/src/storage2/collections/hashmap/mod.rs
+++ b/core/src/storage2/collections/hashmap/mod.rs
@@ -386,7 +386,7 @@ where
     }
 
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
-    pub fn entry(&'_ mut self, key: K) -> Entry<'_, K, V, H> {
+    pub fn entry(&mut self, key: K) -> Entry<K, V, H> {
         let v = self.values.get(&key);
         match v {
             Some(entry) => {
@@ -409,7 +409,7 @@ where
     Key: From<<H as Hasher>::Output>,
 {
     /// Returns a reference to this entry's key.
-    pub fn key(&'a self) -> &'a K {
+    pub fn key(&self) -> &K {
         match self {
             Entry::Occupied(entry) => &entry.key,
             Entry::Vacant(entry) => &entry.key,

--- a/core/src/storage2/collections/hashmap/mod.rs
+++ b/core/src/storage2/collections/hashmap/mod.rs
@@ -392,12 +392,7 @@ where
                     base: self,
                 })
             }
-            None => {
-                Entry::Vacant(VacantEntry {
-                    key,
-                    base: self,
-                })
-            }
+            None => Entry::Vacant(VacantEntry { key, base: self }),
         }
     }
 }
@@ -455,7 +450,7 @@ where
     {
         match self {
             Entry::Occupied(entry) => entry.into_value(),
-            Entry::Vacant(entry) => Entry::insert(default(&entry.key), entry)
+            Entry::Vacant(entry) => Entry::insert(default(&entry.key), entry),
         }
     }
 
@@ -512,7 +507,9 @@ where
         self.base
             .values
             .put(self.key.clone(), Some(ValueEntry { value, key_index }));
-        self.base.get_mut(&self.key).unwrap()
+        self.base
+            .get_mut(&self.key)
+            .expect("put was just executed; qed")
     }
 }
 
@@ -530,14 +527,20 @@ where
 
     /// Take the ownership of the key and value from the map.
     pub fn remove_entry(self) -> (K, V) {
-        let v = self.base.take(&self.key).unwrap();
+        let v = self
+            .base
+            .take(&self.key)
+            .expect("OccupiedEntry must always exist");
         let k = self.key;
         (k, v)
     }
 
     /// Gets a reference to the value in the entry.
     pub fn get(&self) -> &V {
-        &self.base.get(&self.key).unwrap()
+        &self
+            .base
+            .get(&self.key)
+            .expect("OccupiedEntry must always exist")
     }
 
     /// Gets a mutable reference to the value in the entry.
@@ -545,29 +548,41 @@ where
     /// If you need a reference to the `OccupiedEntry` which may outlive the destruction of the
     /// `Entry` value, see `into_mut`.
     pub fn get_mut(&mut self) -> &mut V {
-        self.base.get_mut(&self.key).unwrap()
+        self.base
+            .get_mut(&self.key)
+            .expect("OccupiedEntry must always exist")
     }
 
     /// Sets the value of the entry, and returns the entry's old value.
     pub fn insert(&mut self, new_value: V) -> V {
-        let occupied = self.base.values.get_mut(&self.key).unwrap();
+        let occupied = self
+            .base
+            .values
+            .get_mut(&self.key)
+            .expect("OccupiedEntry must always exist");
         core::mem::replace(&mut occupied.value, new_value)
     }
 
     /// Takes the value out of the entry, and returns it.
     pub fn remove(self) -> V {
-        self.base.take(&self.key).unwrap()
+        self.base
+            .take(&self.key)
+            .expect("OccupiedEntry must always exist")
     }
 
     /// Converts the OccupiedEntry into a mutable reference to the value in the entry
     /// with a lifetime bound to the map itself.
     pub fn into_mut(self) -> &'a mut V {
-        self.base.get_mut(&self.key).unwrap()
+        self.base
+            .get_mut(&self.key)
+            .expect("OccupiedEntry must always exist")
     }
 
     /// Converts the OccupiedEntry into a mutable reference to the value in the entry
     /// with a lifetime bound to the map itself.
     pub fn into_value(self) -> &'a mut V {
-        self.base.get_mut(&self.key).unwrap()
+        self.base
+            .get_mut(&self.key)
+            .expect("OccupiedEntry must always exist")
     }
 }

--- a/core/src/storage2/collections/hashmap/mod.rs
+++ b/core/src/storage2/collections/hashmap/mod.rs
@@ -389,11 +389,10 @@ where
     pub fn entry(&'_ mut self, key: K) -> Entry<'_, K, V, H> {
         let v = self.values.get(&key);
         match v {
-            Some(_) => {
-                let occupied = self.values.get(&key).unwrap();
+            Some(entry) => {
                 Entry::Occupied(OccupiedEntry {
                     key,
-                    key_index: occupied.key_index,
+                    key_index: entry.key_index,
                     base: self,
                 })
             }

--- a/core/src/storage2/collections/hashmap/mod.rs
+++ b/core/src/storage2/collections/hashmap/mod.rs
@@ -417,7 +417,8 @@ where
         }
     }
 
-    /// Returns a reference to this entry's key.
+    /// Ensures a value is in the entry by inserting the default value if empty, and returns
+    /// a reference to the value in the entry.
     pub fn or_default(self) -> &'a V {
         match self {
             Entry::Occupied(entry) => entry.into_mut(),
@@ -480,7 +481,7 @@ where
     /// Inserts `value` into `entry`.
     fn insert(value: V, entry: VacantEntry<'a, K, V, H>) -> &'a mut V {
         let old_value = entry.base.insert(entry.key.clone(), value);
-        debug_assert_eq!(old_value, None);
+        debug_assert!(old_value.is_none());
         match entry.base.entry(entry.key) {
             Entry::Vacant(_) => unreachable!("entry was just inserted; qed"),
             Entry::Occupied(entry) => entry.into_mut(),

--- a/core/src/storage2/collections/hashmap/tests.rs
+++ b/core/src/storage2/collections/hashmap/tests.rs
@@ -358,7 +358,7 @@ fn spread_layout_clear_works() {
 }
 
 #[test]
-fn entry_api_works_with_empty() {
+fn entry_api_insert_inexistent_works_with_empty() {
     // given
     let mut hmap = <StorageHashMap<i32, bool>>::new();
     match hmap.entry(0) {
@@ -376,12 +376,20 @@ fn entry_api_works_with_empty() {
 }
 
 #[test]
-fn entry_api_works_with_filled() {
+fn entry_api_insert_existent_works() {
+    // given
     let mut hmap = prefilled_hmap();
     match hmap.entry(b'A') {
         Vacant(_) => panic!(),
-        Occupied(_) => {}
+        Occupied(o) => assert_eq!(o.get(), &13),
     }
+
+    // when
+    hmap.entry(b'A').or_insert(77);
+
+    // then
+    assert_eq!(hmap.get(&b'A'), Some(&13));
+    assert_eq!(hmap.len(), 2);
 }
 
 #[test]
@@ -404,58 +412,6 @@ fn entry_api_mutations_work_with_push_pull() -> env::Result<()> {
         assert_eq!(hmap3.get(&b'A'), Some(&14));
         Ok(())
     })
-}
-
-#[test]
-fn entry_api_insert_mutate_remove_ops_work() {
-    let test_values = [(1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60)];
-    let mut hmap = test_values
-        .iter()
-        .copied()
-        .collect::<StorageHashMap<u8, i32>>();
-
-    // Existing key (insert)
-    match hmap.entry(1) {
-        Vacant(_) => panic!(),
-        Occupied(mut view) => {
-            assert_eq!(view.get(), &10);
-            assert_eq!(view.insert(100), 10);
-        }
-    }
-    assert_eq!(hmap.get(&1).unwrap(), &100);
-    assert_eq!(hmap.len(), 6);
-
-    // Existing key (update)
-    match hmap.entry(2) {
-        Vacant(_) => panic!(),
-        Occupied(mut view) => {
-            let v = view.get_mut();
-            let new_v = (*v) * 10;
-            *v = new_v;
-        }
-    }
-    assert_eq!(hmap.get(&2).unwrap(), &200);
-    assert_eq!(hmap.len(), 6);
-
-    // Existing key (take)
-    match hmap.entry(3) {
-        Vacant(_) => panic!(),
-        Occupied(view) => {
-            assert_eq!(view.remove(), 30);
-        }
-    }
-    assert_eq!(hmap.get(&3), None);
-    assert_eq!(hmap.len(), 5);
-
-    // Inexistent key (insert)
-    match hmap.entry(10) {
-        Occupied(_) => panic!(),
-        Vacant(view) => {
-            assert_eq!(*view.insert(1000), 1000);
-        }
-    }
-    assert_eq!(hmap.get(&10).unwrap(), &1000);
-    assert_eq!(hmap.len(), 6);
 }
 
 #[test]

--- a/core/src/storage2/collections/hashmap/tests.rs
+++ b/core/src/storage2/collections/hashmap/tests.rs
@@ -30,6 +30,7 @@ use crate::{
 };
 use ink_primitives::Key;
 
+/// Returns a prefilled `HashMap` with `[('A', 13), ['B', 23])`.
 fn prefilled_hmap() -> StorageHashMap<u8, i32> {
     let test_values = [(b'A', 13), (b'B', 23)];
     test_values
@@ -38,15 +39,18 @@ fn prefilled_hmap() -> StorageHashMap<u8, i32> {
         .collect::<StorageHashMap<u8, i32>>()
 }
 
+/// Returns always the same `KeyPtr`.
 fn key_ptr() -> KeyPtr {
     let root_key = Key::from([0x42; 32]);
     KeyPtr::from(root_key)
 }
 
+/// Pushes a `HashMap` instance into the contract storage.
 fn push_hmap(hmap: &StorageHashMap<u8, i32>) {
     SpreadLayout::push_spread(hmap, &mut key_ptr());
 }
 
+/// Pulls a `HashMap` instance from the contract storage.
 fn pull_hmap() -> StorageHashMap<u8, i32> {
     <StorageHashMap<u8, i32> as SpreadLayout>::pull_spread(&mut key_ptr())
 }
@@ -466,6 +470,19 @@ fn entry_api_simple_insert_with_works() {
     assert_eq!(*v, 42);
     assert_eq!(hmap.get(&b'C').unwrap(), &42);
     assert_eq!(hmap.len(), 3);
+}
+
+#[test]
+fn entry_api_simple_default_insert_works() {
+    // given
+    let mut hmap = <StorageHashMap<i32, bool>>::new();
+
+    // when
+    let v = hmap.entry(1).or_default();
+
+    // then
+    assert_eq!(*v, false);
+    assert_eq!(hmap.get(&1).unwrap(), &false);
 }
 
 #[test]


### PR DESCRIPTION
Closes #427.

Benches:
```
$ cargo bench -- entry_api 2>&1 | egrep "^Compare|time" | grep -v Warning
Compare: `insert_and_inc` and `insert_and_inc_entry_api` (populated cache)/insert_and_inc
                        time:   [263.95 us 275.97 us 289.26 us]
Compare: `insert_and_inc` and `insert_and_inc_entry_api` (populated cache)/insert_and_inc_entry_api
                        time:   [271.81 us 283.34 us 295.88 us]

Compare: `remove` and `remove_entry_api` (populated cache)/remove
                        time:   [171.53 us 177.15 us 183.52 us]
Compare: `remove` and `remove_entry_api` (populated cache)/remove_entry_api
                        time:   [179.98 us 190.69 us 202.47 us]

Compare: `insert_and_inc` and `insert_and_inc_entry_api` (empty cache)/insert_and_inc
                        time:   [827.08 us 872.82 us 927.68 us]
Compare: `insert_and_inc` and `insert_and_inc_entry_api` (empty cache)/insert_and_inc_entry_api
                        time:   [825.21 us 861.89 us 901.10 us]

Compare: `remove` and `remove_entry_api` (empty cache)/remove
                        time:   [567.94 us 600.89 us 633.95 us]
Compare: `remove` and `remove_entry_api` (empty cache)/remove_entry_api
                        time:   [519.43 us 540.76 us 564.59 us]
```

I used [codecov on `storage2/HashMap/mod.rs`](https://codecov.io/gh/paritytech/ink/pull/477/src/core/src/storage2/collections/hashmap/mod.rs?before=core/src/storage2/collections/hashmap/mod.rs) to guide the unit tests which I wrote.