### PR TITLE
Migrate examples to new APIs

### DIFF
--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -428,17 +428,8 @@ mod erc721 {
 
     /// Increase token counter from the `of` AccountId.
     fn increase_counter_of(entry: Entry<AccountId, u32>) -> Result<(), Error> {
-        match entry {
-            Entry::Occupied(mut occupied) => {
-                let count = occupied.get_mut();
-                *count += 1;
-                Ok(())
-            }
-            Entry::Vacant(vacant) => {
-                vacant.insert(1);
-                Ok(())
-            }
-        }
+        entry.and_modify(|v| *v += 1).or_insert(1);
+        Ok(())
     }
 
     /// Unit tests
@@ -756,8 +747,6 @@ mod erc721 {
         #[test]
         fn burn_fails_token_not_found() {
             run_test(|| {
-                let accounts = env::test::default_accounts::<env::DefaultEnvTypes>()
-                    .expect("Cannot get accounts");
                 // Create a new contract instance.
                 let mut erc721 = Erc721::new();
                 // Try burning a non existent token

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -418,10 +418,10 @@ mod erc721 {
     }
 
     fn decrease_counter_of(
-        foo: &mut StorageHashMap<AccountId, u32>,
+        hmap: &mut StorageHashMap<AccountId, u32>,
         of: &AccountId,
     ) -> Result<(), Error> {
-        let count = (*foo).get_mut(of).ok_or(Error::CannotFetchValue)?;
+        let count = (*hmap).get_mut(of).ok_or(Error::CannotFetchValue)?;
         *count -= 1;
         Ok(())
     }

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -69,7 +69,10 @@ use ink_lang as ink;
 #[ink::contract(version = "0.1.0")]
 mod erc721 {
     #[cfg(not(feature = "ink-as-dependency"))]
-    use ink_core::storage2::collections::HashMap as StorageHashMap;
+    use ink_core::storage2::collections::{
+        hashmap::Entry,
+        HashMap as StorageHashMap,
+    };
     use scale::{
         Decode,
         Encode,
@@ -230,10 +233,20 @@ mod erc721 {
         #[ink(message)]
         fn burn(&mut self, id: TokenId) -> Result<(), Error> {
             let caller = self.env().caller();
-            if self.token_owner.get(&id) != Some(&caller) {
+            let Self {
+                token_owner,
+                owned_tokens_count,
+                ..
+            } = self;
+            let occupied = match token_owner.entry(id) {
+                Entry::Vacant(_) => return Err(Error::TokenNotFound),
+                Entry::Occupied(occupied) => occupied,
+            };
+            if occupied.get() != &caller {
                 return Err(Error::NotOwner)
             };
-            self.remove_token_from(&caller, id)?;
+            decrease_counter_of(owned_tokens_count, &caller)?;
+            occupied.remove_entry();
             self.env().emit_event(Transfer {
                 from: Some(caller),
                 to: Some(AccountId::from([0x0; 32])),
@@ -273,26 +286,37 @@ mod erc721 {
             from: &AccountId,
             id: TokenId,
         ) -> Result<(), Error> {
-            if !self.exists(id) {
-                return Err(Error::TokenNotFound)
-            }
-            self.decrease_counter_of(from)?;
-            self.token_owner.take(&id).ok_or(Error::CannotRemove)?;
+            let Self {
+                token_owner,
+                owned_tokens_count,
+                ..
+            } = self;
+            let occupied = match token_owner.entry(id) {
+                Entry::Vacant(_) => return Err(Error::TokenNotFound),
+                Entry::Occupied(occupied) => occupied,
+            };
+            decrease_counter_of(owned_tokens_count, from)?;
+            occupied.remove_entry();
             Ok(())
         }
 
         /// Adds the token `id` to the `to` AccountID.
         fn add_token_to(&mut self, to: &AccountId, id: TokenId) -> Result<(), Error> {
-            if self.exists(id) {
-                return Err(Error::TokenExists)
+            let Self {
+                token_owner,
+                owned_tokens_count,
+                ..
+            } = self;
+            let vacant_token_owner = match token_owner.entry(id) {
+                Entry::Vacant(vacant) => vacant,
+                Entry::Occupied(_) => return Err(Error::TokenExists),
             };
             if *to == AccountId::from([0x0; 32]) {
                 return Err(Error::NotAllowed)
             };
-            self.increase_counter_of(to)?;
-            if self.token_owner.insert(id, *to).is_some() {
-                return Err(Error::CannotInsert)
-            }
+            let entry = owned_tokens_count.entry(*to);
+            increase_counter_of(entry)?;
+            vacant_token_owner.insert(*to);
             Ok(())
         }
 
@@ -350,33 +374,6 @@ mod erc721 {
             Ok(())
         }
 
-        /// Increase token counter from the `of` AccountId.
-        fn increase_counter_of(&mut self, of: &AccountId) -> Result<(), Error> {
-            if self.balance_of_or_zero(of) > 0 {
-                let count = self
-                    .owned_tokens_count
-                    .get_mut(of)
-                    .ok_or(Error::CannotFetchValue)?;
-                *count += 1;
-                Ok(())
-            } else {
-                match self.owned_tokens_count.insert(*of, 1) {
-                    Some(_) => Err(Error::CannotInsert),
-                    None => Ok(()),
-                }
-            }
-        }
-
-        /// Decrease token counter from the `of` AccountId.
-        fn decrease_counter_of(&mut self, of: &AccountId) -> Result<(), Error> {
-            let count = self
-                .owned_tokens_count
-                .get_mut(of)
-                .ok_or(Error::CannotFetchValue)?;
-            *count -= 1;
-            Ok(())
-        }
-
         /// Removes existing approval from token `id`.
         fn clear_approval(&mut self, id: TokenId) -> Result<(), Error> {
             if !self.token_approvals.contains_key(&id) {
@@ -417,6 +414,30 @@ mod erc721 {
         /// Returns true if token `id` exists or false if it does not.
         fn exists(&self, id: TokenId) -> bool {
             self.token_owner.get(&id).is_some() && self.token_owner.contains_key(&id)
+        }
+    }
+
+    fn decrease_counter_of(
+        foo: &mut StorageHashMap<AccountId, u32>,
+        of: &AccountId,
+    ) -> Result<(), Error> {
+        let count = (*foo).get_mut(of).ok_or(Error::CannotFetchValue)?;
+        *count -= 1;
+        Ok(())
+    }
+
+    /// Increase token counter from the `of` AccountId.
+    fn increase_counter_of(entry: Entry<AccountId, u32>) -> Result<(), Error> {
+        match entry {
+            Entry::Occupied(mut occupied) => {
+                let count = occupied.get_mut();
+                *count += 1;
+                Ok(())
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(1);
+                Ok(())
+            }
         }
     }
 

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -766,7 +766,7 @@ mod erc721 {
         }
 
         #[test]
-        fn burn_fails_token_not_found() {
+        fn burn_fails_not_owner() {
             run_test(|| {
                 let accounts = env::test::default_accounts::<env::DefaultEnvTypes>()
                     .expect("Cannot get accounts");

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -355,7 +355,7 @@ mod multisig_plain {
             ensure_requirement_is_valid(len, requirement);
             self.owners.swap_remove(self.owner_index(&owner));
             self.is_owner.take(&owner);
-            *self.requirement = requirement;
+            Lazy::set(&mut self.requirement, requirement);
             self.clean_owner_confirmations(&owner);
             self.env().emit_event(OwnerRemoval { owner });
         }
@@ -392,7 +392,7 @@ mod multisig_plain {
         fn change_requirement(&mut self, new_requirement: u32) {
             self.ensure_from_wallet();
             ensure_requirement_is_valid(self.owners.len(), new_requirement);
-            *self.requirement = new_requirement;
+            Lazy::set(&mut self.requirement, new_requirement);
             self.env().emit_event(RequirementChange { new_requirement });
         }
 

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -457,10 +457,14 @@ mod multisig_plain {
             self.ensure_caller_is_owner();
             let caller = self.env().caller();
             if self.confirmations.take(&(trans_id, caller)).is_some() {
-                let v_mut = self.confirmation_count.entry(trans_id).or_insert(1);
-                if *v_mut > 0 {
-                    *v_mut -= 1;
-                }
+                self.confirmation_count
+                    .entry(trans_id)
+                    .and_modify(|v| {
+                        if *v > 0 {
+                            *v -= 1;
+                        }
+                    })
+                    .or_insert(1);
                 self.env().emit_event(Revokation {
                     transaction: trans_id,
                     from: caller,

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -942,6 +942,28 @@ mod multisig_plain {
         }
 
         #[test]
+        fn revoke_confirmations() {
+            // given
+            let mut contract = submit_transaction();
+            let accounts = default_accounts();
+            // Confirm by Bob
+            set_sender(accounts.bob);
+            contract.confirm_transaction(0);
+            // Confirm by Eve
+            set_sender(accounts.eve);
+            contract.confirm_transaction(0);
+            assert_eq!(contract.confirmations.len(), 3);
+            assert_eq!(*contract.confirmation_count.get(&0).unwrap(), 3);
+            // Revoke from Eve
+            contract.revoke_confirmation(0);
+            assert_eq!(*contract.confirmation_count.get(&0).unwrap(), 2);
+            // Revoke from Bob
+            set_sender(accounts.bob);
+            contract.revoke_confirmation(0);
+            assert_eq!(*contract.confirmation_count.get(&0).unwrap(), 1);
+        }
+
+        #[test]
         fn confirm_transaction_already_confirmed() {
             let mut contract = submit_transaction();
             let accounts = default_accounts();


### PR DESCRIPTION
Closes #485 

Left these two ToDos out:
```
Migrate examples to use the ops which were introduced for storage2::Vec in #453
```
There are no examples which could use `Vec::set()` or `Vec::clear()` at the moment.

```
If possible, migrate examples to use storage2::Stash::remove_occupied(…) introduced in #440
```
The method is `unsafe` and we try to use only `unsafe` in examples when it's strictly necessary.


In terms of the new HashMap Entry API there are more places where we could use them ‒ at the cost of readability though.