### PR TITLE
change (CI): `CARGO_HOME`, `RUST_INCREMENTAL`, no artifacts for `needs`, `only` changed to `rules`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,9 +14,9 @@ stages:
 variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
+  CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_JOB_NAME}"
+  CARGO_INCREMENTAL:               0
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
-  CI_SERVER_NAME:                  "GitLab CI"
-  REGISTRY:                        "paritytech"
   ALL_CRATES:                      "core core/derive alloc prelude primitives lang lang/macro lang/ir"
 
 .collect-artifacts:                &collect-artifacts
@@ -28,7 +28,7 @@ variables:
       - artifacts/
 
 .docker-env:                       &docker-env
-  image:                           ${REGISTRY}/ink-ci-linux:latest
+  image:                           paritytech/ink-ci-linux:latest
   before_script:
     - cargo -vV
     - rustc -vV
@@ -36,13 +36,12 @@ variables:
     - bash --version
     - ./scripts/pre_cache.sh
     - sccache -s
-  only:
-    - master
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-    - schedules
-    - web
-    - branches
-  dependencies:                    []
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   interruptible:                   true
   retry:
     max: 2
@@ -79,7 +78,8 @@ build-std:
   stage:                           workspace
   <<:                              *docker-env
   needs:
-    - check-std
+    - job:                         check-std
+      artifacts:                   false
   script:
     - for crate in ${ALL_CRATES}; do
         cargo build --verbose --all-features --release --manifest-path ${crate}/Cargo.toml;
@@ -89,7 +89,8 @@ build-wasm:
   stage:                           workspace
   <<:                              *docker-env
   needs:
-    - check-wasm
+    - job:                         check-wasm
+      artifacts:                   false
   script:
     - for crate in ${ALL_CRATES}; do
         cargo build --verbose --no-default-features --release --target wasm32-unknown-unknown --manifest-path ${crate}/Cargo.toml;
@@ -99,7 +100,8 @@ test:
   stage:                           workspace
   <<:                              *docker-env
   needs:
-    - check-std
+    - job:                         check-std
+      artifacts:                   false
   script:
     - cargo test --verbose --all-features --no-fail-fast --workspace
 
@@ -107,7 +109,8 @@ codecov:
   stage:                           workspace
   <<:                              *docker-env
   needs:
-    - check-std
+    - job:                         check-std
+      artifacts:                   false
   variables:
     # Variables partly came from https://github.com/mozilla/grcov/blob/master/README.md
     CARGO_INCREMENTAL:             0
@@ -140,7 +143,8 @@ clippy-std:
   stage:                           workspace
   <<:                              *docker-env
   needs:
-    - check-std
+    - job:                         check-std
+      artifacts:                   false
   script:
     - for crate in ${ALL_CRATES}; do
         cargo clippy --verbose --all-features --manifest-path ${crate}/Cargo.toml -- -D warnings;
@@ -150,7 +154,8 @@ clippy-wasm:
   stage:                           workspace
   <<:                              *docker-env
   needs:
-    - check-wasm
+    - job:                         check-wasm
+      artifacts:                   false
   script:
     - for crate in ${ALL_CRATES}; do
         cargo clippy --verbose --no-default-features --manifest-path ${crate}/Cargo.toml --target wasm32-unknown-unknown -- -D warnings;
@@ -176,7 +181,8 @@ examples-test:
   stage:                           examples
   <<:                              *docker-env
   needs:
-    - clippy-std
+    - job:                         clippy-std
+      artifacts:                   false
   script:
     - for example in examples/*/; do
         cargo test --verbose --manifest-path ${example}/Cargo.toml;
@@ -194,7 +200,8 @@ examples-clippy-std:
   stage:                           examples
   <<:                              *docker-env
   needs:
-    - clippy-std
+    - job:                         clippy-std
+      artifacts:                   false
   script:
     - for example in examples/*/; do
         cargo clippy --verbose --manifest-path ${example}/Cargo.toml -- -D warnings;
@@ -223,7 +230,8 @@ examples-generate-metadata:
   stage:                           examples
   <<:                              *docker-env
   needs:
-    - build-wasm
+    - job:                         build-wasm
+      artifacts:                   false
   script:
     - *update-cargo-contract
     - for example in examples/*/; do
@@ -239,10 +247,11 @@ publish-docs:
   <<:                              *docker-env
   variables:
     GIT_DEPTH:                     0
-  only:
-    - master
-    - schedules
-    - tags
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
   script:
     - rm -rf /tmp/*
     - unset CARGO_TARGET_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,8 +14,8 @@ stages:
 variables:
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
-  CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_JOB_NAME}"
   CARGO_INCREMENTAL:               0
+  CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_JOB_NAME}"
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   ALL_CRATES:                      "core core/derive alloc prelude primitives lang lang/macro lang/ir"
 


### PR DESCRIPTION
- returns `CARGO_HOME`, cc https://github.com/paritytech/ink/pull/386 https://github.com/rust-lang/cargo/issues/8120 and potential fix of it here: https://github.com/rust-lang/cargo/issues/4007 
- with `RUST_INCREMENTAL=0` CI has to work faster allowing `sccache` to cache more artifacts, on the other side incremental compilation is a pretty flaky thing on CIs.
- `needs` do not actually require uploading artifacts from the mentioned jobs, this is done solely for the sakes of speed, leveraging DAG in GitLab
- soon to be™ deprecated `only` changed to `rules`