### PR TITLE
Add proc. macro documentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -270,8 +270,10 @@ publish-docs:
     - git fetch origin gh-pages
     # Generating Docs
     - time cargo doc --no-deps --all-features
-        -p scale-info -p ink_metadata -p ink_env -p ink_storage -p ink_storage_derive
-        -p ink_primitives -p ink_prelude -p ink_lang -p ink_lang_macro
+        -p scale-info -p ink_metadata
+        -p ink_env -p ink_storage -p ink_storage_derive
+        -p ink_primitives -p ink_prelude
+        -p ink_lang -p ink_lang_macro -p ink_lang_ir -p ink_lang_codegen
     # saving README and docs
     - mv target/doc/ /tmp/
     - cp README.md /tmp/doc/

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -216,6 +216,16 @@ pub trait Clear {
     fn clear() -> Self;
 }
 
+impl Clear for [u8; 32] {
+    fn is_clear(&self) -> bool {
+        self.as_ref().iter().all(|&byte| byte == 0x00)
+    }
+
+    fn clear() -> Self {
+        [0x00; 32]
+    }
+}
+
 impl Clear for Hash {
     fn is_clear(&self) -> bool {
         self.as_ref().iter().all(|&byte| byte == 0x00)

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -228,10 +228,10 @@ impl Clear for [u8; 32] {
 
 impl Clear for Hash {
     fn is_clear(&self) -> bool {
-        self.as_ref().iter().all(|&byte| byte == 0x00)
+        <[u8; 32] as Clear>::is_clear(&self.0)
     }
 
     fn clear() -> Self {
-        Self([0x00; 32])
+        Self(<[u8; 32] as Clear>::clear())
     }
 }

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -284,6 +284,9 @@ use proc_macro::TokenStream;
 ///     Authors of ink! smart contracts can make an ink! message payable by adding the `payable`
 ///     flag to it. An example below:
 ///
+///     Note that ink! constructors are always implicitely payable and thus cannot be flagged
+///     as such.
+///
 ///     ```
 ///     # use ink_lang as ink;
 ///     # #[ink::contract]

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -298,7 +298,7 @@ use proc_macro::TokenStream;
 ///     Authors of ink! smart contracts can make an ink! message payable by adding the `payable`
 ///     flag to it. An example below:
 ///
-///     Note that ink! constructors are always implicitely payable and thus cannot be flagged
+///     Note that ink! constructors are always implicitly payable and thus cannot be flagged
 ///     as such.
 ///
 ///     ```

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -353,6 +353,54 @@ use proc_macro::TokenStream;
 ///     # }
 ///     ```
 ///
+/// ## Events
+///
+/// An ink! smart contract may define events that it can emit during contract execution.
+/// Emitting events can be used by third party tools to query information about a contract's
+/// execution and state.
+///
+/// The following example ink! contract shows how an event `Transferred` is defined and
+/// emitted in the `#[ink(constructor)]`.
+///
+/// ```
+/// # use ink_lang as ink;
+/// #
+/// #[ink::contract]
+/// mod erc20 {
+///     /// Defines an event that is emitted every time value is transferred.
+///     #[ink(event)]
+///     pub struct Transferred {
+///         from: Option<AccountId>,
+///         to: Option<AccountId>,
+///         value: Balance,
+///     }
+///
+///     #[ink(storage)]
+///     pub struct Erc20 {
+///         total_supply: Balance,
+///         // more fields ...
+///     }
+///
+///     impl Erc20 {
+///         #[ink(constructor)]
+///         pub fn new(initial_supply: Balance) -> Self {
+///             let caller = Self::env().caller();
+///             Self::env().emit_event(Transferred {
+///                 from: None,
+///                 to: Some(caller),
+///                 value: initial_supply,
+///             });
+///             Self { total_supply: initial_supply }
+///         }
+///
+///         #[ink(message)]
+///         pub fn total_supply(&self) -> Balance {
+///             self.total_supply
+///         }
+///     }
+/// }
+/// ```
+///
 /// ## Example: Flipper
 ///
 /// The below code shows the complete implementation of the so-called Flipper

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -240,6 +240,11 @@ use proc_macro::TokenStream;
 ///
 ///     An ink! smart contract can have multiple such ink! messages defined.
 ///
+///     **Note:**
+///
+///     - An ink! message with a `&self` receiver may only read state whereas an ink! message
+///       with a `&mut self` receiver may mutate the contract's storage.
+///
 ///     **Example:**
 ///
 ///     Given the `Flipper` contract definition above we add some `#[ink(message)]` definitions
@@ -266,6 +271,41 @@ use proc_macro::TokenStream;
 ///
 ///         /// Returns the current value.
 ///         #[ink(message)]
+///         pub fn get(&self) -> bool {
+///             self.value
+///         }
+///     }
+///     # }
+///     ```
+///
+///     **Payable Messages:**
+///
+///     An ink! message by default will reject calls that additional fund the smart contract.
+///     Authors of ink! smart contracts can make an ink! message payable by adding the `payable`
+///     flag to it. An example below:
+///
+///     ```
+///     # use ink_lang as ink;
+///     # #[ink::contract]
+///     # mod flipper {
+///         # #[ink(storage)]
+///         # pub struct Flipper {
+///         #     value: bool,
+///         # }
+///     impl Flipper {
+///         # #[ink(constructor)]
+///         # pub fn new(initial_value: bool) -> Self {
+///         #     Flipper { value: false }
+///         # }
+///         /// Flips the current value.
+///         #[ink(message)]
+///         #[ink(payable)] // You can either specify payable out-of-line.
+///         pub fn flip(&mut self) {
+///             self.value = !self.value;
+///         }
+///
+///         /// Returns the current value.
+///         #[ink(message, payable)] // ... or specify payable inline.
 ///         pub fn get(&self) -> bool {
 ///             self.value
 ///         }

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -94,13 +94,18 @@ use proc_macro::TokenStream;
 ///
 /// - `compile_as_dependency: bool`
 ///
-///     Tells the ink! code generator to always or never
+///     Tells the ink! code generator to **always** or **never**
 ///     compile the smart contract as if it was used as a dependency of another ink!
 ///     smart contract.
+///
 ///     Normally this flag is only really useful for ink! developers who
 ///     want to inspect code generation of ink! smart contracts.
 ///     The author is not aware of any particular practical use case for users that
-///     makes use of this flag.
+///     makes use of this flag but contract writers are encouraged to disprove this.
+///
+///     Note that it is recommended to make use of the built-in crate feature
+///     `ink-as-dependency` to flag smart contract dependencies listed in a contract's
+///     `Cargo.toml` as actual dependencies to ink! so that ink!.
 ///
 ///     **Usage Example:**
 ///     ```

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -313,6 +313,46 @@ use proc_macro::TokenStream;
 ///     # }
 ///     ```
 ///
+///     **Controlling the messages selector:**
+///
+///     Every ink! message and ink! constructor has a unique selector with which the
+///     message or constructor can be uniquely identified within the ink! smart contract.
+///     These selectors are mainly used to drive the contract's dispatch upon calling it.
+///
+///     An ink! smart contract author can control the selector of an ink! message or ink!
+///     constructor using the `selector` flag. An example is shown below:
+///
+///     ```
+///     # use ink_lang as ink;
+///     # #[ink::contract]
+///     # mod flipper {
+///         # #[ink(storage)]
+///         # pub struct Flipper {
+///         #     value: bool,
+///         # }
+///     impl Flipper {
+///         #[ink(constructor)]
+///         #[ink(selector = "0xDEADBEEF")]
+///         pub fn new(initial_value: bool) -> Self {
+///             Flipper { value: false }
+///         }
+///
+///         # /// Flips the current value.
+///         # #[ink(message)]
+///         # #[ink(payable)] // You can either specify payable out-of-line.
+///         # pub fn flip(&mut self) {
+///         #     self.value = !self.value;
+///         # }
+///         #
+///         /// Returns the current value.
+///         #[ink(message, selector = "0xFEEDBEEF")] // ... or specify payable inline.
+///         pub fn get(&self) -> bool {
+///             self.value
+///         }
+///     }
+///     # }
+///     ```
+///
 /// ## Example: Flipper
 ///
 /// The below code shows the complete implementation of the so-called Flipper

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -353,6 +353,51 @@ use proc_macro::TokenStream;
 ///     # }
 ///     ```
 ///
+/// ## Interacting with the Contract Executor
+///
+/// The `ink_env` crate provides facitilies to interact with the contract executor that
+/// connects ink! smart contracts with the outer world.
+///
+/// For example it is possible to query the current call's caller via:
+/// ```
+/// # ink_env::test::run_test::<ink_env::DefaultEnvTypes, _>(|_| {
+/// let caller = ink_env::caller::<ink_env::DefaultEnvTypes>();
+/// # let _caller = caller;
+/// # Ok(())
+/// # }).unwrap();
+/// ```
+///
+/// However, ink! provides a much simpler way to interact with the contract executor
+/// via its environment accessor. An example below:
+///
+/// ```
+/// # use ink_lang as ink;
+/// #
+/// #[ink::contract]
+/// mod greeter {
+///     #[ink(storage)]
+///     pub struct Greeter;
+///
+///     impl Greeter {
+///         #[ink(constructor)]
+///         pub fn new() -> Self {
+///             let caller = Self::env().caller();
+///             let message = format!("thanks for instantiation {:?}", caller);
+///             ink_env::debug_println(&message);
+///             Greeter {}
+///         }
+///
+///         #[ink(message, payable)]
+///         pub fn fund(&mut self) {
+///             let caller = self.env().caller();
+///             let value = self.env().transferred_balance();
+///             let message = format!("thanks for the funding of {:?} from {:?}", value, caller);
+///             ink_env::debug_println(&message);
+///         }
+///     }
+/// }
+/// ```
+///
 /// ## Events
 ///
 /// An ink! smart contract may define events that it can emit during contract execution.

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -132,6 +132,10 @@ use proc_macro::TokenStream;
 ///     The environment must implement the `EnvTypes` (defined in `ink_env`) trait and provides
 ///     all the necessary fundamental type definitions for `Balance`, `AccountId` etc.
 ///
+///     When using a custom `EnvTypes` implementation for a smart contract all types
+///     that it exposes to the ink! smart contract and the mirrored types used in the runtime
+///     must be aligned with respect to SCALE encoding and semantics.
+///
 ///     **Usage Example:**
 ///
 ///     Given a custom `EnvTypes` implementation:

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -105,7 +105,7 @@ use proc_macro::TokenStream;
 ///
 ///     Note that it is recommended to make use of the built-in crate feature
 ///     `ink-as-dependency` to flag smart contract dependencies listed in a contract's
-///     `Cargo.toml` as actual dependencies to ink! so that ink!.
+///     `Cargo.toml` as actual dependencies to ink!.
 ///
 ///     **Usage Example:**
 ///     ```

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -28,10 +28,50 @@ pub fn trait_definition(attr: TokenStream, item: TokenStream) -> TokenStream {
     trait_def::analyze(attr.into(), item.into()).into()
 }
 
-#[cfg(test)]
-pub use contract::generate_or_err;
-
+/// Defines a unit test that makes use of ink!'s off-chain testing capabilities.
+///
+/// If your unit test does not require the existence of an off-chain environment
+/// it is fine to not use this macro since it bears some overhead with the test.
+///
+/// Note that this macro is not required to run unit tests that require ink!'s
+/// off-chain testing capabilities but merely improves code readability.
+///
+/// ## How do you find out if your test requires the off-chain environment?
+///
+/// Normally if the test recursively uses or invokes some contract methods that
+/// call a method defined in `self.env()` or `Self::env()`.
+///
+/// An examples is the following:
+///
+/// ```no_compile
+/// let caller: AccountId = self.env().caller();
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use ink_lang as ink;
+///
+/// #[cfg(test)]
+/// mod tests {
+///     // Conventional unit test that works with assertions.
+///     #[ink::test]
+///     fn test1() {
+///         // test code comes here as usual
+///     }
+///
+///     // Conventional unit test that returns some Result.
+///     // The test code can make use of operator-`?`.
+///     #[ink::test]
+///     fn test2() -> Result<(), ink_env::EnvError> {
+///         // test code that returns a Rust Result type
+///     }
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
     ink_test::generate(attr.into(), item.into()).into()
 }
+
+#[cfg(test)]
+pub use contract::generate_or_err;

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -335,14 +335,14 @@ use proc_macro::TokenStream;
 ///         # }
 ///     impl Flipper {
 ///         #[ink(constructor)]
-///         #[ink(selector = "0xDEADBEEF")]
+///         #[ink(selector = "0xDEADBEEF")] // Works on constructors as well.
 ///         pub fn new(initial_value: bool) -> Self {
 ///             Flipper { value: false }
 ///         }
 ///
 ///         # /// Flips the current value.
 ///         # #[ink(message)]
-///         # #[ink(payable)] // You can either specify payable out-of-line.
+///         # #[ink(selector = "0xCAFEBABE")] // You can either specify selector out-of-line.
 ///         # pub fn flip(&mut self) {
 ///         #     self.value = !self.value;
 ///         # }

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -58,6 +58,11 @@ use proc_macro::TokenStream;
 ///     This feature is generally only needed for smart contracts that try to model
 ///     their data in a way that contains storage entites within other storage
 ///     entities.
+///
+///     Contract writers should try to write smart contracts that do not depend on the
+///     dynamic storage allocator since enabling it comes at a cost of increased Wasm
+///     file size. Although it will enable interesting use cases. Use it with care!
+///
 ///     An example for this is the following type that could potentially be used
 ///     within a contract's storage struct definition:
 ///     ```

--- a/crates/storage/src/alloc/init.rs
+++ b/crates/storage/src/alloc/init.rs
@@ -126,7 +126,7 @@ impl DynamicAllocatorState {
             DynamicAllocatorState::Finalized => {
                 panic!(
                     "cannot finalize the dynamic storage allocator \
-                 after it has already been finalized"
+                     after it has already been finalized"
                 )
             }
             DynamicAllocatorState::UninitCall | DynamicAllocatorState::UninitDeploy => {

--- a/crates/storage/src/alloc/tests.rs
+++ b/crates/storage/src/alloc/tests.rs
@@ -194,7 +194,7 @@ fn test_call_setup_works() {
         assert_eq!(allocator.alloc(), DynamicAllocation(0));
         assert_eq!(allocator.alloc(), DynamicAllocation(1));
         let root_key = Key::from([0xFE; 32]);
-        SpreadLayout::push_spread(&allocator, &mut KeyPtr::from(root_key));
+        DynamicAllocator::push_spread(&allocator, &mut KeyPtr::from(root_key));
         alloc::initialize(ContractPhase::Call);
         assert_eq!(alloc(), DynamicAllocation(2));
         assert_eq!(alloc(), DynamicAllocation(3));

--- a/examples/trait-flipper/lib.rs
+++ b/examples/trait-flipper/lib.rs
@@ -25,6 +25,7 @@ pub trait Flip {
     /// Flips the current value of the Flipper's bool.
     #[ink(message)]
     fn flip(&mut self);
+
     /// Returns the current value of the Flipper's bool.
     #[ink(message)]
     fn get(&self) -> bool;


### PR DESCRIPTION
Adds missing documentation for all of the proc. macro provided by the `ink_lang_macro` crate.

## Screenshots

Some screenshots of the new rendered documentation below:

![2020-10-02-190324_1303x1108_scrot](https://user-images.githubusercontent.com/8193155/94949938-136d9200-04e2-11eb-90df-47cc0e198f5d.png)

![2020-10-02-190248_970x1274_scrot](https://user-images.githubusercontent.com/8193155/94950006-28e2bc00-04e2-11eb-8ce1-e29cae708d80.png)

![2020-10-02-190213_1289x1259_scrot](https://user-images.githubusercontent.com/8193155/94950009-2a13e900-04e2-11eb-91c2-f76991c1f1eb.png)

![2020-10-02-190150_1961x373_scrot](https://user-images.githubusercontent.com/8193155/94950011-2aac7f80-04e2-11eb-81d4-016aca080f86.png)



