### PR TITLE
[examples] Add ERC-20 Trait-ified example

### DIFF
--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -152,7 +152,7 @@ mod erc20 {
         }
 
         fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
-            *self.balances.get(owner).unwrap_or(&0)
+            self.balances.get(owner).copied().unwrap_or(0)
         }
 
         fn allowance_of_or_zero(
@@ -160,7 +160,10 @@ mod erc20 {
             owner: &AccountId,
             spender: &AccountId,
         ) -> Balance {
-            *self.allowances.get(&(*owner, *spender)).unwrap_or(&0)
+            self.allowances
+                .get(&(*owner, *spender))
+                .copied()
+                .unwrap_or(0)
         }
     }
 

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -382,15 +382,12 @@ mod erc20 {
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
             data.push_arg(&accounts.bob);
             // Push the new execution context to set Bob as caller
-            assert_eq!(
-                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
-                    accounts.bob,
-                    callee,
-                    1000000,
-                    1000000,
-                    data
-                ),
-                ()
+            ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                accounts.bob,
+                callee,
+                1000000,
+                1000000,
+                data,
             );
 
             // Bob fails to transfers 10 tokens to Eve.
@@ -442,15 +439,12 @@ mod erc20 {
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
             data.push_arg(&accounts.bob);
             // Push the new execution context to set Bob as caller.
-            assert_eq!(
-                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
-                    accounts.bob,
-                    callee,
-                    1000000,
-                    1000000,
-                    data
-                ),
-                ()
+            ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                accounts.bob,
+                callee,
+                1000000,
+                1000000,
+                data,
             );
 
             // Bob transfers tokens from Alice to Eve.
@@ -499,15 +493,12 @@ mod erc20 {
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
             data.push_arg(&accounts.bob);
             // Push the new execution context to set Bob as caller.
-            assert_eq!(
-                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
-                    accounts.bob,
-                    callee,
-                    1000000,
-                    1000000,
-                    data
-                ),
-                ()
+            ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                accounts.bob,
+                callee,
+                1000000,
+                1000000,
+                data,
             );
 
             // Bob tries to transfer tokens from Alice to Eve.

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -478,5 +478,54 @@ mod erc20 {
                 10,
             );
         }
+
+        #[ink::test]
+        fn allowance_must_not_change_on_failed_transfer() {
+            let mut erc20 = Erc20::new(100);
+            let accounts =
+                ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
+                    .expect("Cannot get accounts");
+
+            // Alice approves Bob for token transfers on her behalf.
+            let alice_balance = erc20.balance_of(accounts.alice);
+            let initial_allowance = alice_balance + 2;
+            assert_eq!(erc20.approve(accounts.bob, initial_allowance), Ok(()));
+
+            // Get contract address.
+            let callee = ink_env::account_id::<ink_env::DefaultEnvironment>()
+                .unwrap_or([0x0; 32].into());
+            // Create call.
+            let mut data =
+                ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
+            data.push_arg(&accounts.bob);
+            // Push the new execution context to set Bob as caller.
+            assert_eq!(
+                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                    accounts.bob,
+                    callee,
+                    1000000,
+                    1000000,
+                    data
+                ),
+                ()
+            );
+
+            // Bob tries to transfer tokens from Alice to Eve.
+            let emitted_events_before =
+                ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, alice_balance + 1),
+                Err(Error::InsufficientBalance)
+            );
+            // Allowance must have stayed the same
+            assert_eq!(
+                erc20.allowance(accounts.alice, accounts.bob),
+                initial_allowance
+            );
+            // No more events must have been emitted
+            let emitted_events_after =
+                ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events_before.len(), emitted_events_after.len());
+        }
     }
 }

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -111,10 +111,7 @@ mod erc20 {
         /// Returns `0` if no allowance has been set `0`.
         #[ink(message)]
         pub fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
-            self.allowances
-                .get(&(owner, spender))
-                .copied()
-                .unwrap_or(0)
+            self.allowances.get(&(owner, spender)).copied().unwrap_or(0)
         }
 
         /// Transfers `value` amount of tokens from the caller's account to account `to`.

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -158,8 +158,11 @@ mod erc20 {
         ///
         /// # Errors
         ///
-        /// Returns `InsufficientAllowance` error if there are not enough tokens on
-        /// the caller's account balance.
+        /// Returns `InsufficientAllowance` error if there are not enough tokens allowed
+        /// for the caller to withdraw from `from`.
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
+        /// the the account balance of `from`.
         #[ink(message)]
         pub fn transfer_from(
             &mut self,
@@ -172,8 +175,9 @@ mod erc20 {
             if allowance < value {
                 return Err(Error::InsufficientAllowance)
             }
+            self.transfer_from_to(from, to, value)?;
             self.allowances.insert((from, caller), allowance - value);
-            self.transfer_from_to(from, to, value)
+            Ok(())
         }
 
         /// Transfers `value` amount of tokens from the caller's account to account `to`.

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -124,6 +124,8 @@ mod erc20 {
         /// the `value` amount.
         ///
         /// If this function is called again it overwrites the current allowance with `value`.
+        ///
+        /// An `Approval` event is emitted.
         #[ink(message)]
         pub fn approve(&mut self, spender: AccountId, value: Balance) -> Result<()> {
             let owner = self.env().caller();

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -65,6 +65,8 @@ mod erc20 {
     pub enum Error {
         /// Returned if not enough balance to fulfill a request is available.
         InsufficientBalance,
+        /// Returned if not enough allowance to fulfill a request is available.
+        InsufficientAllowance,
     }
 
     /// The ERC-20 result type.
@@ -112,7 +114,7 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error:InsufficientBalance)` if there are not enough tokens on
+        /// Returns `Err(Error::InsufficientBalance)` if there are not enough tokens on
         /// the caller's account balance.
         #[ink(message)]
         pub fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()> {
@@ -145,7 +147,7 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error:InsufficientBalance)` if there are not enough tokens on
+        /// Returns `Err(Error::InsufficientAllowance)` if there are not enough tokens on
         /// the caller's account balance.
         #[ink(message)]
         pub fn transfer_from(
@@ -157,7 +159,7 @@ mod erc20 {
             let caller = self.env().caller();
             let allowance = self.allowance_of_or_zero(&from, &caller);
             if allowance < value {
-                return Err(Error::InsufficientBalance)
+                return Err(Error::InsufficientAllowance)
             }
             self.allowances.insert((from, caller), allowance - value);
             self.transfer_from_to(from, to, value)
@@ -167,7 +169,7 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error:InsufficientBalance)` if there are not enough tokens on
+        /// Returns `Err(Error::InsufficientBalance)` if there are not enough tokens on
         /// the caller's account balance.
         fn transfer_from_to(
             &mut self,
@@ -431,7 +433,7 @@ mod erc20 {
             // Bob fails to transfer tokens owned by Alice.
             assert_eq!(
                 erc20.transfer_from(accounts.alice, accounts.eve, 10),
-                Err(Error::InsufficientBalance)
+                Err(Error::InsufficientAllowance)
             );
             // Alice approves Bob for token transfers on her behalf.
             assert_eq!(erc20.approve(accounts.bob, 10), Ok(()));

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -114,7 +114,9 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error::InsufficientBalance)` if there are not enough tokens on
+        /// # Errors
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
         /// the caller's account balance.
         #[ink(message)]
         pub fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()> {
@@ -147,7 +149,9 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error::InsufficientAllowance)` if there are not enough tokens on
+        /// # Errors
+        ///
+        /// Returns `InsufficientAllowance` error if there are not enough tokens on
         /// the caller's account balance.
         #[ink(message)]
         pub fn transfer_from(
@@ -169,7 +173,9 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error::InsufficientBalance)` if there are not enough tokens on
+        /// # Errors
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
         /// the caller's account balance.
         fn transfer_from_to(
             &mut self,

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -47,7 +47,8 @@ mod erc20 {
         value: Balance,
     }
 
-    /// Event emitted when a token approve occurs.
+    /// Event emitted when an approval occurs that `spender` is allowed to withdraw
+    /// up to the amount of `value` tokens from `owner`.
     #[ink(event)]
     pub struct Approval {
         #[ink(topic)]

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -118,7 +118,7 @@ mod erc721 {
         id: TokenId,
     }
 
-    /// Event emmited when a token approve occurs.
+    /// Event emitted when a token approve occurs.
     #[ink(event)]
     pub struct Approval {
         #[ink(topic)]

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -532,15 +532,12 @@ mod erc721 {
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
             data.push_arg(&accounts.bob);
             // Push the new execution context to set Bob as caller
-            assert_eq!(
-                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
-                    accounts.bob,
-                    callee,
-                    1000000,
-                    1000000,
-                    data
-                ),
-                ()
+            ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                accounts.bob,
+                callee,
+                1000000,
+                1000000,
+                data,
             );
             // Bob cannot transfer not owned tokens.
             assert_eq!(erc721.transfer(accounts.eve, 2), Err(Error::NotApproved));
@@ -567,15 +564,12 @@ mod erc721 {
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
             data.push_arg(&accounts.bob);
             // Push the new execution context to set Bob as caller
-            assert_eq!(
-                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
-                    accounts.bob,
-                    callee,
-                    1000000,
-                    1000000,
-                    data
-                ),
-                ()
+            ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                accounts.bob,
+                callee,
+                1000000,
+                1000000,
+                data,
             );
             // Bob transfers token Id 1 from Alice to Eve.
             assert_eq!(
@@ -620,15 +614,12 @@ mod erc721 {
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
             data.push_arg(&accounts.bob);
             // Push the new execution context to set Bob as caller
-            assert_eq!(
-                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
-                    accounts.bob,
-                    callee,
-                    1000000,
-                    1000000,
-                    data
-                ),
-                ()
+            ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                accounts.bob,
+                callee,
+                1000000,
+                1000000,
+                data,
             );
             // Bob transfers token Id 1 from Alice to Eve.
             assert_eq!(
@@ -682,15 +673,12 @@ mod erc721 {
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
             data.push_arg(&accounts.bob);
             // Push the new execution context to set Eve as caller
-            assert_eq!(
-                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
-                    accounts.eve,
-                    callee,
-                    1000000,
-                    1000000,
-                    data
-                ),
-                ()
+            ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                accounts.eve,
+                callee,
+                1000000,
+                1000000,
+                data,
             );
             // Eve is not an approved operator by Alice.
             assert_eq!(

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -118,7 +118,7 @@ mod erc721 {
         id: TokenId,
     }
 
-    /// Event emited when a token approve occurs.
+    /// Event emmited when a token approve occurs.
     #[ink(event)]
     pub struct Approval {
         #[ink(topic)]

--- a/examples/trait-erc20/.gitignore
+++ b/examples/trait-erc20/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "erc20"
+version = "3.0.0-rc1"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+
+[dependencies]
+ink_primitives = { version = "3.0.0-rc1", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc1", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc1", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc1", path = "../../crates/lang", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
+scale-info = { version = "0.4", default-features = false, features = ["derive"], optional = true }
+
+
+[lib]
+name = "erc20"
+path = "lib.rs"
+crate-type = ["cdylib"]
+
+[features]
+default = ["std"]
+std = [
+    "ink_primitives/std",
+    "ink_metadata",
+    "ink_metadata/std",
+    "ink_env/std",
+    "ink_storage/std",
+    "ink_lang/std",
+    "scale/std",
+    "scale-info",
+    "scale-info/std",
+]
+ink-as-dependency = []

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -1,0 +1,495 @@
+// Copyright 2018-2020 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use ink_env::{
+    DefaultEnvironment,
+    Environment,
+};
+use ink_lang as ink;
+
+pub use erc20::Erc20;
+
+type Balance = <DefaultEnvironment as Environment>::Balance;
+type AccountId = <DefaultEnvironment as Environment>::AccountId;
+
+/// The ERC-20 error types.
+#[derive(Debug, PartialEq, Eq, scale::Encode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Error {
+    /// Returned if not enough balance to fulfill a request is available.
+    InsufficientBalance,
+}
+
+/// The ERC-20 result type.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Trait implemented by all ERC-20 respecting smart contracts.
+#[ink::trait_definition]
+pub trait BaseErc20 {
+    #[ink(constructor)]
+    fn new(initial_supply: Balance) -> Self;
+
+    #[ink(message)]
+    fn total_supply(&self) -> Balance;
+
+    #[ink(message)]
+    fn balance_of(&self, owner: AccountId) -> Balance;
+
+    #[ink(message)]
+    fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance;
+
+    #[ink(message)]
+    fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()>;
+
+    #[ink(message)]
+    fn approve(&mut self, spender: AccountId, value: Balance) -> Result<()>;
+
+    #[ink(message)]
+    fn transfer_from(
+        &mut self,
+        from: AccountId,
+        to: AccountId,
+        value: Balance,
+    ) -> Result<()>;
+}
+
+#[ink::contract]
+mod erc20 {
+    use super::{
+        BaseErc20,
+        Error,
+        Result,
+    };
+
+    #[cfg(not(feature = "ink-as-dependency"))]
+    use ink_lang::{
+        EmitEvent,
+        Env,
+    };
+
+    #[cfg(not(feature = "ink-as-dependency"))]
+    use ink_storage::{
+        collections::HashMap as StorageHashMap,
+        lazy::Lazy,
+    };
+
+    #[ink(storage)]
+    pub struct Erc20 {
+        total_supply: Lazy<Balance>,
+        balances: StorageHashMap<AccountId, Balance>,
+        allowances: StorageHashMap<(AccountId, AccountId), Balance>,
+    }
+
+    #[ink(event)]
+    pub struct Transfer {
+        #[ink(topic)]
+        from: Option<AccountId>,
+        #[ink(topic)]
+        to: Option<AccountId>,
+        #[ink(topic)]
+        value: Balance,
+    }
+
+    #[ink(event)]
+    pub struct Approval {
+        #[ink(topic)]
+        owner: AccountId,
+        #[ink(topic)]
+        spender: AccountId,
+        #[ink(topic)]
+        value: Balance,
+    }
+
+    impl BaseErc20 for Erc20 {
+        #[ink(constructor)]
+        fn new(initial_supply: Balance) -> Self {
+            let caller = Self::env().caller();
+            let mut balances = StorageHashMap::new();
+            balances.insert(caller, initial_supply);
+            let instance = Self {
+                total_supply: Lazy::new(initial_supply),
+                balances,
+                allowances: StorageHashMap::new(),
+            };
+            Self::env().emit_event(Transfer {
+                from: None,
+                to: Some(caller),
+                value: initial_supply,
+            });
+            instance
+        }
+
+        #[ink(message)]
+        fn total_supply(&self) -> Balance {
+            *self.total_supply
+        }
+
+        #[ink(message)]
+        fn balance_of(&self, owner: AccountId) -> Balance {
+            self.balance_of_or_zero(&owner)
+        }
+
+        #[ink(message)]
+        fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
+            self.allowance_of_or_zero(&owner, &spender)
+        }
+
+        #[ink(message)]
+        fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()> {
+            let from = self.env().caller();
+            self.transfer_from_to(from, to, value)
+        }
+
+        #[ink(message)]
+        fn approve(&mut self, spender: AccountId, value: Balance) -> Result<()> {
+            let owner = self.env().caller();
+            self.allowances.insert((owner, spender), value);
+            self.env().emit_event(Approval {
+                owner,
+                spender,
+                value,
+            });
+            Ok(())
+        }
+
+        #[ink(message)]
+        fn transfer_from(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> Result<()> {
+            let caller = self.env().caller();
+            let allowance = self.allowance_of_or_zero(&from, &caller);
+            if allowance < value {
+                return Err(Error::InsufficientBalance)
+            }
+            self.allowances.insert((from, caller), allowance - value);
+            self.transfer_from_to(from, to, value)
+        }
+    }
+
+    impl Erc20 {
+        fn transfer_from_to(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> Result<()> {
+            let from_balance = self.balance_of_or_zero(&from);
+            if from_balance < value {
+                return Err(Error::InsufficientBalance)
+            }
+            self.balances.insert(from, from_balance - value);
+            let to_balance = self.balance_of_or_zero(&to);
+            self.balances.insert(to, to_balance + value);
+            self.env().emit_event(Transfer {
+                from: Some(from),
+                to: Some(to),
+                value,
+            });
+            Ok(())
+        }
+
+        fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
+            *self.balances.get(owner).unwrap_or(&0)
+        }
+
+        fn allowance_of_or_zero(
+            &self,
+            owner: &AccountId,
+            spender: &AccountId,
+        ) -> Balance {
+            *self.allowances.get(&(*owner, *spender)).unwrap_or(&0)
+        }
+    }
+
+    /// Unit tests.
+    #[cfg(test)]
+    mod tests {
+        /// Imports all the definitions from the outer scope so we can use them here.
+        use super::*;
+        use ink_env::{
+            hash::{
+                Blake2x256,
+                CryptoHash,
+                HashOutput,
+            },
+            Clear,
+        };
+        use ink_lang as ink;
+
+        type Event = <Erc20 as ::ink_lang::BaseEvent>::Type;
+
+        fn assert_transfer_event(
+            event: &ink_env::test::EmittedEvent,
+            expected_from: Option<AccountId>,
+            expected_to: Option<AccountId>,
+            expected_value: Balance,
+        ) {
+            let decoded_event = <Event as scale::Decode>::decode(&mut &event.data[..])
+                .expect("encountered invalid contract event data buffer");
+            if let Event::Transfer(Transfer { from, to, value }) = decoded_event {
+                assert_eq!(from, expected_from, "encountered invalid Transfer.from");
+                assert_eq!(to, expected_to, "encountered invalid Transfer.to");
+                assert_eq!(value, expected_value, "encountered invalid Trasfer.value");
+            } else {
+                panic!("encountered unexpected event kind: expected a Transfer event")
+            }
+            fn encoded_into_hash<T>(entity: &T) -> Hash
+            where
+                T: scale::Encode,
+            {
+                let mut result = Hash::clear();
+                let len_result = result.as_ref().len();
+                let encoded = entity.encode();
+                let len_encoded = encoded.len();
+                if len_encoded <= len_result {
+                    result.as_mut()[..len_encoded].copy_from_slice(&encoded);
+                    return result
+                }
+                let mut hash_output =
+                    <<Blake2x256 as HashOutput>::Type as Default>::default();
+                <Blake2x256 as CryptoHash>::hash(&encoded, &mut hash_output);
+                let copy_len = core::cmp::min(hash_output.len(), len_result);
+                result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
+                result
+            }
+            let expected_topics = vec![
+                encoded_into_hash(b"Erc20::Transfer"),
+                encoded_into_hash(&expected_from),
+                encoded_into_hash(&expected_to),
+                encoded_into_hash(&expected_value),
+            ];
+            for (n, (actual_topic, expected_topic)) in
+                event.topics.iter().zip(expected_topics).enumerate()
+            {
+                let topic = actual_topic
+                    .decode::<Hash>()
+                    .expect("encountered invalid topic encoding");
+                assert_eq!(topic, expected_topic, "encountered invalid topic at {}", n);
+            }
+        }
+
+        /// The default constructor does its job.
+        #[ink::test]
+        fn new_works() {
+            // Constructor works.
+            let initial_supply = 100;
+            let erc20 = Erc20::new(initial_supply);
+
+            // The `BaseErc20` trait has indeed been implemented.
+            assert_eq!(<Erc20 as BaseErc20>::total_supply(&erc20), initial_supply);
+
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(1, emitted_events.len());
+
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+        }
+
+        /// The total supply was applied.
+        #[ink::test]
+        fn total_supply_works() {
+            // Constructor works.
+            let erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // Get the token total supply.
+            assert_eq!(erc20.total_supply(), 100);
+        }
+
+        /// Get the actual balance of an account.
+        #[ink::test]
+        fn balance_of_works() {
+            // Constructor works
+            let erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            let accounts =
+                ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
+                    .expect("Cannot get accounts");
+            // Alice owns all the tokens on deployment
+            assert_eq!(erc20.balance_of(accounts.alice), 100);
+            // Bob does not owns tokens
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+        }
+
+        #[ink::test]
+        fn transfer_works() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let accounts =
+                ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
+                    .expect("Cannot get accounts");
+
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+            // Alice transfers 10 tokens to Bob.
+            assert_eq!(erc20.transfer(accounts.bob, 10), Ok(()));
+            // Bob owns 10 tokens.
+            assert_eq!(erc20.balance_of(accounts.bob), 10);
+
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 2);
+            // Check first transfer event related to ERC-20 instantiation.
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // Check the second transfer event relating to the actual trasfer.
+            assert_transfer_event(
+                &emitted_events[1],
+                Some(AccountId::from([0x01; 32])),
+                Some(AccountId::from([0x02; 32])),
+                10,
+            );
+        }
+
+        #[ink::test]
+        fn invalid_transfer_should_fail() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            let accounts =
+                ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
+                    .expect("Cannot get accounts");
+
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+            // Get contract address.
+            let callee = ink_env::account_id::<ink_env::DefaultEnvironment>()
+                .unwrap_or([0x0; 32].into());
+            // Create call
+            let mut data =
+                ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
+            data.push_arg(&accounts.bob);
+            // Push the new execution context to set Bob as caller
+            assert_eq!(
+                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                    accounts.bob,
+                    callee,
+                    1000000,
+                    1000000,
+                    data
+                ),
+                ()
+            );
+
+            // Bob fails to transfers 10 tokens to Eve.
+            assert_eq!(
+                erc20.transfer(accounts.eve, 10),
+                Err(Error::InsufficientBalance)
+            );
+            // Alice owns all the tokens.
+            assert_eq!(erc20.balance_of(accounts.alice), 100);
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+            assert_eq!(erc20.balance_of(accounts.eve), 0);
+
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 1);
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+        }
+
+        #[ink::test]
+        fn transfer_from_works() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let accounts =
+                ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
+                    .expect("Cannot get accounts");
+
+            // Bob fails to transfer tokens owned by Alice.
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, 10),
+                Err(Error::InsufficientBalance)
+            );
+            // Alice approves Bob for token transfers on her behalf.
+            assert_eq!(erc20.approve(accounts.bob, 10), Ok(()));
+
+            // The approve event takes place.
+            assert_eq!(ink_env::test::recorded_events().count(), 2);
+
+            // Get contract address.
+            let callee = ink_env::account_id::<ink_env::DefaultEnvironment>()
+                .unwrap_or([0x0; 32].into());
+            // Create call.
+            let mut data =
+                ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
+            data.push_arg(&accounts.bob);
+            // Push the new execution context to set Bob as caller.
+            assert_eq!(
+                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                    accounts.bob,
+                    callee,
+                    1000000,
+                    1000000,
+                    data
+                ),
+                ()
+            );
+
+            // Bob transfers tokens from Alice to Eve.
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, 10),
+                Ok(())
+            );
+            // Eve owns tokens.
+            assert_eq!(erc20.balance_of(accounts.eve), 10);
+
+            // Check all transfer events that happened during the previous calls:
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 3);
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // The second event `emitted_events[1]` is an Approve event that we skip checking.
+            assert_transfer_event(
+                &emitted_events[2],
+                Some(AccountId::from([0x01; 32])),
+                Some(AccountId::from([0x05; 32])),
+                10,
+            );
+        }
+    }
+}

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -171,6 +171,8 @@ mod erc20 {
         /// the `value` amount.
         ///
         /// If this function is called again it overwrites the current allowance with `value`.
+        ///
+        /// An `Approval` event is emitted.
         #[ink(message)]
         fn approve(&mut self, spender: AccountId, value: Balance) -> Result<()> {
             let owner = self.env().caller();

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -161,7 +161,9 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error::InsufficientBalance)` if there are not enough tokens on
+        /// # Errors
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
         /// the caller's account balance.
         #[ink(message)]
         fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()> {
@@ -194,7 +196,9 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error::InsufficientAllowance)` if there are not enough tokens on
+        /// # Errors
+        ///
+        /// Returns `InsufficientAllowance` error if there are not enough tokens on
         /// the caller's account balance.
         #[ink(message)]
         fn transfer_from(
@@ -218,7 +222,9 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error::InsufficientBalance)` if there are not enough tokens on
+        /// # Errors
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
         /// the caller's account balance.
         fn transfer_from_to(
             &mut self,

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -146,15 +146,22 @@ mod erc20 {
         }
 
         /// Returns the account balance for the specified `owner`.
+        ///
+        /// Returns `0` if the account is non-existent.
         #[ink(message)]
         fn balance_of(&self, owner: AccountId) -> Balance {
-            self.balance_of_or_zero(&owner)
+            self.balances.get(&owner).copied().unwrap_or(0)
         }
 
         /// Returns the amount which `spender` is still allowed to withdraw from `owner`.
+        ///
+        /// Returns `0` if no allowance has been set `0`.
         #[ink(message)]
         fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
-            self.allowance_of_or_zero(&owner, &spender)
+            self.allowances
+                .get(&(owner, spender))
+                .copied()
+                .unwrap_or(0)
         }
 
         /// Transfers `value` amount of tokens from the caller's account to account `to`.
@@ -208,7 +215,7 @@ mod erc20 {
             value: Balance,
         ) -> Result<()> {
             let caller = self.env().caller();
-            let allowance = self.allowance_of_or_zero(&from, &caller);
+            let allowance = self.allowance(from, caller);
             if allowance < value {
                 return Err(Error::InsufficientAllowance)
             }
@@ -232,12 +239,12 @@ mod erc20 {
             to: AccountId,
             value: Balance,
         ) -> Result<()> {
-            let from_balance = self.balance_of_or_zero(&from);
+            let from_balance = self.balance_of(from);
             if from_balance < value {
                 return Err(Error::InsufficientBalance)
             }
             self.balances.insert(from, from_balance - value);
-            let to_balance = self.balance_of_or_zero(&to);
+            let to_balance = self.balance_of(to);
             self.balances.insert(to, to_balance + value);
             self.env().emit_event(Transfer {
                 from: Some(from),
@@ -245,27 +252,6 @@ mod erc20 {
                 value,
             });
             Ok(())
-        }
-
-        /// Returns the balance of the `owner` account.
-        ///
-        /// Returns `0` if the account is non-existent..
-        fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
-            self.balances.get(owner).copied().unwrap_or(0)
-        }
-
-        /// Returns the amount which `spender` is allowed to withdraw from `owner`.
-        ///
-        /// Returns `0` if no allowance has been set `0`.
-        fn allowance_of_or_zero(
-            &self,
-            owner: &AccountId,
-            spender: &AccountId,
-        ) -> Balance {
-            self.allowances
-                .get(&(*owner, *spender))
-                .copied()
-                .unwrap_or(0)
         }
     }
 

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -20,8 +20,6 @@ use ink_env::{
 };
 use ink_lang as ink;
 
-pub use erc20::Erc20;
-
 type Balance = <DefaultEnvironment as Environment>::Balance;
 type AccountId = <DefaultEnvironment as Environment>::AccountId;
 

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -434,15 +434,12 @@ mod erc20 {
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
             data.push_arg(&accounts.bob);
             // Push the new execution context to set Bob as caller
-            assert_eq!(
-                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
-                    accounts.bob,
-                    callee,
-                    1000000,
-                    1000000,
-                    data
-                ),
-                ()
+            ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                accounts.bob,
+                callee,
+                1000000,
+                1000000,
+                data,
             );
 
             // Bob fails to transfers 10 tokens to Eve.
@@ -494,15 +491,12 @@ mod erc20 {
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
             data.push_arg(&accounts.bob);
             // Push the new execution context to set Bob as caller.
-            assert_eq!(
-                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
-                    accounts.bob,
-                    callee,
-                    1000000,
-                    1000000,
-                    data
-                ),
-                ()
+            ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                accounts.bob,
+                callee,
+                1000000,
+                1000000,
+                data,
             );
 
             // Bob transfers tokens from Alice to Eve.
@@ -551,15 +545,12 @@ mod erc20 {
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])); // balance_of
             data.push_arg(&accounts.bob);
             // Push the new execution context to set Bob as caller.
-            assert_eq!(
-                ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
-                    accounts.bob,
-                    callee,
-                    1000000,
-                    1000000,
-                    data
-                ),
-                ()
+            ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
+                accounts.bob,
+                callee,
+                1000000,
+                1000000,
+                data,
             );
 
             // Bob tries to transfer tokens from Alice to Eve.

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -158,10 +158,7 @@ mod erc20 {
         /// Returns `0` if no allowance has been set `0`.
         #[ink(message)]
         fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
-            self.allowances
-                .get(&(owner, spender))
-                .copied()
-                .unwrap_or(0)
+            self.allowances.get(&(owner, spender)).copied().unwrap_or(0)
         }
 
         /// Transfers `value` amount of tokens from the caller's account to account `to`.
@@ -566,15 +563,20 @@ mod erc20 {
             );
 
             // Bob tries to transfer tokens from Alice to Eve.
-            let emitted_events_before = ink_env::test::recorded_events().collect::<Vec<_>>();
+            let emitted_events_before =
+                ink_env::test::recorded_events().collect::<Vec<_>>();
             assert_eq!(
                 erc20.transfer_from(accounts.alice, accounts.eve, alice_balance + 1),
                 Err(Error::InsufficientBalance)
             );
             // Allowance must have stayed the same
-            assert_eq!(erc20.allowance(accounts.alice, accounts.bob), initial_allowance);
+            assert_eq!(
+                erc20.allowance(accounts.alice, accounts.bob),
+                initial_allowance
+            );
             // No more events must have been emitted
-            let emitted_events_after = ink_env::test::recorded_events().collect::<Vec<_>>();
+            let emitted_events_after =
+                ink_env::test::recorded_events().collect::<Vec<_>>();
             assert_eq!(emitted_events_before.len(), emitted_events_after.len());
         }
     }

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -205,8 +205,11 @@ mod erc20 {
         ///
         /// # Errors
         ///
-        /// Returns `InsufficientAllowance` error if there are not enough tokens on
-        /// the caller's account balance.
+        /// Returns `InsufficientAllowance` error if there are not enough tokens allowed
+        /// for the caller to withdraw from `from`.
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
+        /// the the account balance of `from`.
         #[ink(message)]
         fn transfer_from(
             &mut self,
@@ -219,8 +222,9 @@ mod erc20 {
             if allowance < value {
                 return Err(Error::InsufficientAllowance)
             }
+            self.transfer_from_to(from, to, value)?;
             self.allowances.insert((from, caller), allowance - value);
-            self.transfer_from_to(from, to, value)
+            Ok(())
         }
     }
 

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -205,7 +205,7 @@ mod erc20 {
         }
 
         fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
-            *self.balances.get(owner).unwrap_or(&0)
+            self.balances.get(owner).copied().unwrap_or(0)
         }
 
         fn allowance_of_or_zero(
@@ -213,7 +213,10 @@ mod erc20 {
             owner: &AccountId,
             spender: &AccountId,
         ) -> Balance {
-            *self.allowances.get(&(*owner, *spender)).unwrap_or(&0)
+            self.allowances
+                .get(&(*owner, *spender))
+                .copied()
+                .unwrap_or(0)
         }
     }
 

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -14,63 +14,12 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use ink_env::{
-    DefaultEnvironment,
-    Environment,
-};
 use ink_lang as ink;
-
-type Balance = <DefaultEnvironment as Environment>::Balance;
-type AccountId = <DefaultEnvironment as Environment>::AccountId;
-
-/// The ERC-20 error types.
-#[derive(Debug, PartialEq, Eq, scale::Encode)]
-#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-pub enum Error {
-    /// Returned if not enough balance to fulfill a request is available.
-    InsufficientBalance,
-}
-
-/// The ERC-20 result type.
-pub type Result<T> = core::result::Result<T, Error>;
-
-/// Trait implemented by all ERC-20 respecting smart contracts.
-#[ink::trait_definition]
-pub trait BaseErc20 {
-    #[ink(constructor)]
-    fn new(initial_supply: Balance) -> Self;
-
-    #[ink(message)]
-    fn total_supply(&self) -> Balance;
-
-    #[ink(message)]
-    fn balance_of(&self, owner: AccountId) -> Balance;
-
-    #[ink(message)]
-    fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance;
-
-    #[ink(message)]
-    fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()>;
-
-    #[ink(message)]
-    fn approve(&mut self, spender: AccountId, value: Balance) -> Result<()>;
-
-    #[ink(message)]
-    fn transfer_from(
-        &mut self,
-        from: AccountId,
-        to: AccountId,
-        value: Balance,
-    ) -> Result<()>;
-}
 
 #[ink::contract]
 mod erc20 {
-    use super::{
-        BaseErc20,
-        Error,
-        Result,
-    };
+    #[cfg(not(feature = "ink-as-dependency"))]
+    use ink_lang as ink;
 
     #[cfg(not(feature = "ink-as-dependency"))]
     use ink_lang::{
@@ -83,6 +32,47 @@ mod erc20 {
         collections::HashMap as StorageHashMap,
         lazy::Lazy,
     };
+
+    /// The ERC-20 error types.
+    #[derive(Debug, PartialEq, Eq, scale::Encode)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum Error {
+        /// Returned if not enough balance to fulfill a request is available.
+        InsufficientBalance,
+    }
+
+    /// The ERC-20 result type.
+    pub type Result<T> = core::result::Result<T, Error>;
+
+    /// Trait implemented by all ERC-20 respecting smart contracts.
+    #[ink::trait_definition]
+    pub trait BaseErc20 {
+        #[ink(constructor)]
+        fn new(initial_supply: Balance) -> Self;
+
+        #[ink(message)]
+        fn total_supply(&self) -> Balance;
+
+        #[ink(message)]
+        fn balance_of(&self, owner: AccountId) -> Balance;
+
+        #[ink(message)]
+        fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance;
+
+        #[ink(message)]
+        fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()>;
+
+        #[ink(message)]
+        fn approve(&mut self, spender: AccountId, value: Balance) -> Result<()>;
+
+        #[ink(message)]
+        fn transfer_from(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> Result<()>;
+    }
 
     #[ink(storage)]
     pub struct Erc20 {

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -105,7 +105,8 @@ mod erc20 {
         value: Balance,
     }
 
-    /// Event emitted when a token approve occurs.
+    /// Event emitted when an approval occurs that `spender` is allowed to withdraw
+    /// up to the amount of `value` tokens from `owner`.
     #[ink(event)]
     pub struct Approval {
         #[ink(topic)]

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -39,6 +39,8 @@ mod erc20 {
     pub enum Error {
         /// Returned if not enough balance to fulfill a request is available.
         InsufficientBalance,
+        /// Returned if not enough allowance to fulfill a request is available.
+        InsufficientAllowance,
     }
 
     /// The ERC-20 result type.
@@ -159,7 +161,7 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error:InsufficientBalance)` if there are not enough tokens on
+        /// Returns `Err(Error::InsufficientBalance)` if there are not enough tokens on
         /// the caller's account balance.
         #[ink(message)]
         fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()> {
@@ -192,7 +194,7 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error:InsufficientBalance)` if there are not enough tokens on
+        /// Returns `Err(Error::InsufficientAllowance)` if there are not enough tokens on
         /// the caller's account balance.
         #[ink(message)]
         fn transfer_from(
@@ -204,7 +206,7 @@ mod erc20 {
             let caller = self.env().caller();
             let allowance = self.allowance_of_or_zero(&from, &caller);
             if allowance < value {
-                return Err(Error::InsufficientBalance)
+                return Err(Error::InsufficientAllowance)
             }
             self.allowances.insert((from, caller), allowance - value);
             self.transfer_from_to(from, to, value)
@@ -216,7 +218,7 @@ mod erc20 {
         ///
         /// On success a `Transfer` event is emitted.
         ///
-        /// Returns `Err(Error:InsufficientBalance)` if there are not enough tokens on
+        /// Returns `Err(Error::InsufficientBalance)` if there are not enough tokens on
         /// the caller's account balance.
         fn transfer_from_to(
             &mut self,
@@ -483,7 +485,7 @@ mod erc20 {
             // Bob fails to transfer tokens owned by Alice.
             assert_eq!(
                 erc20.transfer_from(accounts.alice, accounts.eve, 10),
-                Err(Error::InsufficientBalance)
+                Err(Error::InsufficientAllowance)
             );
             // Alice approves Bob for token transfers on her behalf.
             assert_eq!(erc20.approve(accounts.bob, 10), Ok(()));

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -47,24 +47,32 @@ mod erc20 {
     /// Trait implemented by all ERC-20 respecting smart contracts.
     #[ink::trait_definition]
     pub trait BaseErc20 {
+        /// Creates a new ERC-20 contract with the specified initial supply.
         #[ink(constructor)]
         fn new(initial_supply: Balance) -> Self;
 
+        /// Returns the total token supply.
         #[ink(message)]
         fn total_supply(&self) -> Balance;
 
+        /// Returns the account balance for the specified `owner`.
         #[ink(message)]
         fn balance_of(&self, owner: AccountId) -> Balance;
 
+        /// Returns the amount which `spender` is still allowed to withdraw from `owner`.
         #[ink(message)]
         fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance;
 
+        /// Transfers `value` amount of tokens from the caller's account to account `to`.
         #[ink(message)]
         fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()>;
 
+        /// Allows `spender` to withdraw from the caller's account multiple times, up to
+        /// the `value` amount.
         #[ink(message)]
         fn approve(&mut self, spender: AccountId, value: Balance) -> Result<()>;
 
+        /// Transfers `value` tokens on the behalf of `from` to the account `to`.
         #[ink(message)]
         fn transfer_from(
             &mut self,
@@ -74,13 +82,19 @@ mod erc20 {
         ) -> Result<()>;
     }
 
+    /// A simple ERC-20 contract.
     #[ink(storage)]
     pub struct Erc20 {
+        /// Total token supply.
         total_supply: Lazy<Balance>,
+        /// Mapping from owner to number of owned token.
         balances: StorageHashMap<AccountId, Balance>,
+        /// Mapping of the token amount which an account is allowed to withdraw
+        /// from another account.
         allowances: StorageHashMap<(AccountId, AccountId), Balance>,
     }
 
+    /// Event emitted when a token transfer occurs.
     #[ink(event)]
     pub struct Transfer {
         #[ink(topic)]
@@ -91,6 +105,7 @@ mod erc20 {
         value: Balance,
     }
 
+    /// Event emitted when a token approve occurs.
     #[ink(event)]
     pub struct Approval {
         #[ink(topic)]
@@ -102,6 +117,7 @@ mod erc20 {
     }
 
     impl BaseErc20 for Erc20 {
+        /// Creates a new ERC-20 contract with the specified initial supply.
         #[ink(constructor)]
         fn new(initial_supply: Balance) -> Self {
             let caller = Self::env().caller();
@@ -120,27 +136,40 @@ mod erc20 {
             instance
         }
 
+        /// Returns the total token supply.
         #[ink(message)]
         fn total_supply(&self) -> Balance {
             *self.total_supply
         }
 
+        /// Returns the account balance for the specified `owner`.
         #[ink(message)]
         fn balance_of(&self, owner: AccountId) -> Balance {
             self.balance_of_or_zero(&owner)
         }
 
+        /// Returns the amount which `spender` is still allowed to withdraw from `owner`.
         #[ink(message)]
         fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
             self.allowance_of_or_zero(&owner, &spender)
         }
 
+        /// Transfers `value` amount of tokens from the caller's account to account `to`.
+        ///
+        /// On success a `Transfer` event is emitted.
+        ///
+        /// Returns `Err(Error:InsufficientBalance)` if there are not enough tokens on
+        /// the caller's account balance.
         #[ink(message)]
         fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()> {
             let from = self.env().caller();
             self.transfer_from_to(from, to, value)
         }
 
+        /// Allows `spender` to withdraw from the caller's account multiple times, up to
+        /// the `value` amount.
+        ///
+        /// If this function is called again it overwrites the current allowance with `value`.
         #[ink(message)]
         fn approve(&mut self, spender: AccountId, value: Balance) -> Result<()> {
             let owner = self.env().caller();
@@ -153,6 +182,15 @@ mod erc20 {
             Ok(())
         }
 
+        /// Transfers `value` tokens on the behalf of `from` to the account `to`.
+        ///
+        /// This can be used to allow a contract to transfer tokens on ones behalf and/or
+        /// to charge fees in sub-currencies, for example.
+        ///
+        /// On success a `Transfer` event is emitted.
+        ///
+        /// Returns `Err(Error:InsufficientBalance)` if there are not enough tokens on
+        /// the caller's account balance.
         #[ink(message)]
         fn transfer_from(
             &mut self,
@@ -171,6 +209,12 @@ mod erc20 {
     }
 
     impl Erc20 {
+        /// Transfers `value` amount of tokens from the caller's account to account `to`.
+        ///
+        /// On success a `Transfer` event is emitted.
+        ///
+        /// Returns `Err(Error:InsufficientBalance)` if there are not enough tokens on
+        /// the caller's account balance.
         fn transfer_from_to(
             &mut self,
             from: AccountId,
@@ -192,10 +236,16 @@ mod erc20 {
             Ok(())
         }
 
+        /// Returns the balance of the `owner` account.
+        ///
+        /// Returns `0` if the account is non-existent..
         fn balance_of_or_zero(&self, owner: &AccountId) -> Balance {
             self.balances.get(owner).copied().unwrap_or(0)
         }
 
+        /// Returns the amount which `spender` is allowed to withdraw from `owner`.
+        ///
+        /// Returns `0` if no allowance has been set `0`.
         fn allowance_of_or_zero(
             &self,
             owner: &AccountId,


### PR DESCRIPTION
…and migrate the existing ERC-20 example to use proper Rust `Result` types instead of returning `bool`.