### PR TITLE
[storage] Fix bug in push/pull prims tests

### DIFF
--- a/crates/storage/src/traits/impls/prims.rs
+++ b/crates/storage/src/traits/impls/prims.rs
@@ -270,7 +270,7 @@ mod tests {
                             let y: $name = pull_spread_root(&key);
                             assert_eq!(x, y);
                             push_packed_root(&x, &key2);
-                            let z: $name = pull_packed_root(&key);
+                            let z: $name = pull_packed_root(&key2);
                             assert_eq!(x, z);
                         })*
                     })


### PR DESCRIPTION
Here's the bug, taking the surrounding code into consideration:

```
let x: $name = $value;
let key = Key::from([0x42; 32]);
let key2 = Key::from([0x77; 32]);

// test 1: test that what we push is what we pull
push_spread_root(&x, &key);
let y: $name = pull_spread_root(&key);
assert_eq!(x, y);

// test 2: test that what we push is what we pull
push_packed_root(&x, &key2);           // this does not have any effect on this test, key2 is not used later
let z: $name = pull_packed_root(&key); // oh no
assert_eq!(x, z);
```