### PR TITLE
Fix lazy bug

### DIFF
--- a/crates/storage/src/lazy/entry.rs
+++ b/crates/storage/src/lazy/entry.rs
@@ -204,7 +204,6 @@ where
     pub fn push_packed_root(&self, root_key: &Key) {
         let old_state = self.replace_state(EntryState::Preserved);
         if old_state.is_mutated() {
-            self.replace_state(EntryState::Preserved);
             push_packed_root_opt::<T>(self.value().into(), &root_key);
         }
     }

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -503,4 +503,44 @@ mod tests {
             Ok(())
         })
     }
+
+    #[test]
+    fn regression_test_for_issue_528() -> ink_env::Result<()> {
+        run_test::<ink_env::DefaultEnvironment, _>(|_| {
+            let root_key = Key::from([0x00; 32]);
+            {
+                // Step 1: Push a valid pair onto the contract storage.
+                let pair = (LazyCell::new(Some(1i32)), 2i32);
+                SpreadLayout::push_spread(&pair, &mut KeyPtr::from(root_key));
+            }
+            {
+                // Step 2: Pull the pair from the step before.
+                //
+                // 1. Change the second `i32` value of the pair.
+                // 2. Push the pair again to contract storage.
+                //
+                // We prevent the intermediate instance from clearing the storage preemtively by wrapping
+                // it inside `ManuallyDrop`. The third step will clean up the same storage region afterwards.
+                //
+                // We explicitely do not touch or assert the value of `pulled_pair.0` in order to trigger
+                // the bug.
+                let pulled_pair: (LazyCell<i32>, i32) = SpreadLayout::pull_spread(&mut KeyPtr::from(root_key));
+                let mut pulled_pair = core::mem::ManuallyDrop::new(pulled_pair);
+                assert_eq!(pulled_pair.1, 2i32);
+                pulled_pair.1 = 3i32;
+                SpreadLayout::push_spread(&*pulled_pair, &mut KeyPtr::from(root_key));
+            }
+            {
+                // Step 3: Pull the pair again from the storage.
+                //
+                // If the bug with `Lazy` that has been fixed in PR #528 has been fixed we should be
+                // able to inspect the correct values for both pair entries which is: `(Some(1), 3)`
+                let pulled_pair: (LazyCell<i32>, i32) =
+                    SpreadLayout::pull_spread(&mut KeyPtr::from(root_key));
+                assert_eq!(pulled_pair.0.get(), Some(&1i32));
+                assert_eq!(pulled_pair.1, 3i32);
+            }
+            Ok(())
+        })
+    }
 }

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -142,14 +142,16 @@ where
     }
 
     fn push_spread(&self, ptr: &mut KeyPtr) {
+        let root_key = ExtKeyPtr::next_for::<Self>(ptr);
         if let Some(entry) = self.entry() {
-            SpreadLayout::push_spread(entry, ptr)
+            SpreadLayout::push_spread(entry, &mut KeyPtr::from(*root_key))
         }
     }
 
     fn clear_spread(&self, ptr: &mut KeyPtr) {
+        let root_key = ExtKeyPtr::next_for::<Self>(ptr);
         if let Some(entry) = self.entry() {
-            SpreadLayout::clear_spread(entry, ptr)
+            SpreadLayout::clear_spread(entry, &mut KeyPtr::from(*root_key))
         }
     }
 }

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -525,7 +525,8 @@ mod tests {
                 //
                 // We explicitely do not touch or assert the value of `pulled_pair.0` in order to trigger
                 // the bug.
-                let pulled_pair: (LazyCell<i32>, i32) = SpreadLayout::pull_spread(&mut KeyPtr::from(root_key));
+                let pulled_pair: (LazyCell<i32>, i32) =
+                    SpreadLayout::pull_spread(&mut KeyPtr::from(root_key));
                 let mut pulled_pair = core::mem::ManuallyDrop::new(pulled_pair);
                 assert_eq!(pulled_pair.1, 2i32);
                 pulled_pair.1 = 3i32;

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -138,20 +138,21 @@ where
     const FOOTPRINT: u64 = <T as SpreadLayout>::FOOTPRINT;
 
     fn pull_spread(ptr: &mut KeyPtr) -> Self {
-        Self::lazy(*KeyPtr::next_for::<T>(ptr))
+        let root_key = ExtKeyPtr::next_for::<Self>(ptr);
+        Self::lazy(*root_key)
     }
 
     fn push_spread(&self, ptr: &mut KeyPtr) {
         let root_key = ExtKeyPtr::next_for::<Self>(ptr);
         if let Some(entry) = self.entry() {
-            SpreadLayout::push_spread(entry, &mut KeyPtr::from(*root_key))
+            entry.push_spread_root(root_key)
         }
     }
 
     fn clear_spread(&self, ptr: &mut KeyPtr) {
         let root_key = ExtKeyPtr::next_for::<Self>(ptr);
         if let Some(entry) = self.entry() {
-            SpreadLayout::clear_spread(entry, &mut KeyPtr::from(*root_key))
+            entry.clear_spread_root(root_key)
         }
     }
 }

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -119,7 +119,7 @@ where
 
     /// Creates a true lazy storage value for the given key.
     #[must_use]
-    pub fn lazy(key: Key) -> Self {
+    pub(crate) fn lazy(key: Key) -> Self {
         Self {
             cell: LazyCell::lazy(key),
         }


### PR DESCRIPTION
The problem was that if a `Lazy` instance has not been used in an execution (which it its whole point of existence) then it corrupted the `KeyPtr` for all following computations.

Unfortunately this bug went unnoticed in our extensive test suite.

- [x] Fixed the code causing the issue.
- [x] Cleaned up the surrounding code.
- [x] Added regression unit test.