### PR TITLE
Improve docs on transfer() + minimum_balance()

### DIFF
--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -422,9 +422,11 @@ where
 /// contract call or invoke a runtime function that performs the
 /// transaction.
 ///
-/// # Panics
+/// # Errors
 ///
-/// If the contract doesn't have sufficient funds.
+/// - If the contract doesn't have sufficient funds.
+/// - If the transfer would have brought the sender's total balance below the
+///   subsistence threshold.
 pub fn transfer<T>(destination: T::AccountId, value: T::Balance) -> Result<()>
 where
     T: Environment,

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -169,7 +169,7 @@ where
     })
 }
 
-/// Returns the minimum balance for the contracts chain.
+/// Returns the minimum balance that is required for creating an account.
 ///
 /// # Errors
 ///

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -210,7 +210,7 @@ pub trait TypedEnvBackend: EnvBackend {
     /// For more details visit: [`ink_env::block_number`]
     fn block_number<T: Environment>(&mut self) -> Result<T::BlockNumber>;
 
-    /// Returns the minimum balance of the contracts chain.
+    /// Returns the minimum balance that is required for creating an account.
     ///
     /// # Note
     ///

--- a/crates/env/src/engine/off_chain/db/chain_spec.rs
+++ b/crates/env/src/engine/off_chain/db/chain_spec.rs
@@ -83,7 +83,7 @@ impl ChainSpec {
         self.gas_price = OffBalance::new(&gas_price)
     }
 
-    /// Returns the minimum balance for an account on the chain.
+    /// Returns the minimum balance that is required for creating an account.
     pub fn minimum_balance<T>(&self) -> Result<T::Balance>
     where
         T: Environment,

--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -64,7 +64,7 @@ define_error_codes! {
     /// The passed key does not exist in storage.
     KeyNotFound = 3,
     /// Transfer failed because it would have brought the sender's total balance
-    /// bwlow the subsistence threshold.
+    /// below the subsistence threshold.
     BelowSubsistenceThreshold = 4,
     /// Transfer failed for other not further specified reason. Most probably
     /// reserved or locked balance of the sender that was preventing the transfer.

--- a/crates/env/src/error.rs
+++ b/crates/env/src/error.rs
@@ -32,7 +32,7 @@ pub enum Error {
     /// The queried contract storage entry is missing.
     KeyNotFound,
     /// Transfer failed because it would have brought the sender's total balance
-    /// bwlow the subsistence threshold.
+    /// below the subsistence threshold.
     BelowSubsistenceThreshold,
     /// Transfer failed for other not further specified reason. Most probably
     /// reserved or locked balance of the sender that was preventing the transfer.

--- a/crates/lang/src/env_access.rs
+++ b/crates/lang/src/env_access.rs
@@ -174,7 +174,7 @@ where
         ink_env::block_number::<T>().expect("couldn't decode block number")
     }
 
-    /// Returns the minimum balance for the contracts chain.
+    /// Returns the minimum balance that is required for creating an account.
     ///
     /// # Note
     ///


### PR DESCRIPTION
Closes #538 by clearing up the confusion that lead to it.

@athei I think it makes sense to expose a getter for the `subsistence_threshold` from seal. Otherwise it's not possible to take this variable into consideration in the smart contract when calculating how much to transfer (like in the issue).

```
/// Subsistence threshold is the extension of the minimum balance (aka existential deposit) by the
/// tombstone deposit, required for leaving a tombstone.
```
(from [here](https://github.com/paritytech/substrate/blob/master/frame/contracts/src/lib.rs#L778-L779))

We already have the `minimum_balance`, so it seems consistent to expose the subsistence threshold as well. Wdyt?