### PR TITLE
Bring discord badge to life

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [i2]: https://paritytech.github.io/ink/ink_prelude
 [j1]: https://img.shields.io/badge/click-blue.svg
 [j2]: https://paritytech.github.io/ink/ink_lang
-[k1]: https://img.shields.io/badge/chat%20on-matrix-brightgreen.svg?style=flat
+[k1]: https://img.shields.io/badge/matrix-chat-brightgreen.svg?style=flat
 [k2]: https://riot.im/app/#/room/#ink:matrix.parity.io
 [l1]: https://img.shields.io/discord/722223075629727774?style=flat-square&label=discord
 [l2]: https://discord.gg/ztCASQE

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 [j2]: https://paritytech.github.io/ink/ink_lang
 [k1]: https://img.shields.io/badge/chat%20on-matrix-brightgreen.svg?style=flat
 [k2]: https://riot.im/app/#/room/#ink:matrix.parity.io
-[l1]: https://img.shields.io/badge/chat%20on-discord-brightgreen.svg?style=flat
+[l1]: https://img.shields.io/discord/722223075629727774?style=flat-square&label=discord
 [l2]: https://discord.gg/ztCASQE
 
 > <img src="./.images/ink-squid.svg" alt="squid, the ink! mascot" style="vertical-align: middle" align="left" height="60" />ink! is an [eDSL](https://wiki.haskell.org/Embedded_domain_specific_language) to write WebAssembly based smart contracts using the Rust programming language. The compilation target are blockchains built on the [Substrate](https://github.com/paritytech/substrate) framework.


### PR DESCRIPTION
[Preview here](https://github.com/paritytech/ink/tree/cmichi-discord-badge#----paritys-ink-for-writing-smart-contracts)

I talked to the ops people for our Discord channels and they activated a feature which lets us display the number of users online in the badge. IMO it makes sense to do that, since it depicts that the project is full of life.

For Matrix I also talked to the dedicated ops people for that, but for security reasons they won't enable the feature which lets us display the number of users in that badge.