### PR TITLE
Remove iter_mut() for BinaryHeap

### DIFF
--- a/crates/storage/src/collections/binary_heap/children_vec.rs
+++ b/crates/storage/src/collections/binary_heap/children_vec.rs
@@ -23,7 +23,6 @@ use super::{
     StorageVec,
 };
 use crate::{
-    collections::extend_lifetime,
     traits::{
         KeyPtr,
         PackedLayout,

--- a/crates/storage/src/collections/binary_heap/mod.rs
+++ b/crates/storage/src/collections/binary_heap/mod.rs
@@ -32,10 +32,7 @@ use crate::{
     traits::PackedLayout,
 };
 
-pub use children_vec::{
-    Iter,
-    IterMut,
-};
+pub use children_vec::Iter;
 pub use reverse::Reverse;
 
 /// A priority queue implemented with a binary heap.
@@ -90,17 +87,6 @@ where
     /// of yielded elements.
     pub fn iter(&self) -> Iter<T> {
         self.elements.iter()
-    }
-
-    /// Returns an iterator yielding exclusive references to all elements of the heap.
-    ///
-    /// # Note
-    ///
-    /// Avoid unbounded iteration over big heaps.
-    /// Prefer using methods like `Iterator::take` in order to limit the number
-    /// of yielded elements.
-    pub fn iter_mut(&mut self) -> IterMut<T> {
-        self.elements.iter_mut()
     }
 
     /// Returns a shared reference to the greatest element of the heap


### PR DESCRIPTION
Mutations of the entries in the heap can mess up the sort oder. The Rust stdlib doesn't contain `BinaryHeap::iter_mut()` for this reason.

```
#[test]
fn mess_up_heap_order_via_iter_mut() {
    // Largest Element is 300
    let mut heap = heap_from_slice(&[100, 300, 200]);
    let largest = heap.pop().unwrap();
    assert_eq!(largest, 300);

    let mut heap = heap_from_slice(&[100, 300, 200]);
    heap.iter_mut().for_each(|current| {
        // If on iteration we find the element with 300, we change it to 1
        if *current == 300 {
            *current = 1;
        }
    });
    let largest = heap.pop().unwrap();
    // Largest Element will suddenly be 1 here, even though all others are larger
    assert_eq!(largest, 300);
}
```