### PR TITLE
Fix CI on master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -322,7 +322,7 @@ fuzz-tests:
             if grep "ink-fuzz-tests =" crates/${crate}/Cargo.toml;
             then
                 cargo test --verbose --features ink-fuzz-tests --manifest-path crates/${crate}/Cargo.toml --no-fail-fast -- fuzz_;
-                let "all_tests_passed |= $?";
+                all_tests_passed=$(( all_tests_passed | $? ));
             fi
           done
         - if [ $all_tests_passed -eq 0 ]; then exit 0; fi


### PR DESCRIPTION
CI fails on `master` currently for the fuzz tests stage.

This is because `let` has some strange exit codes if the computation succeeds (`1`). 