### PR TITLE
change (CI): remove bors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
-    - if: $CI_COMMIT_BRANCH
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   interruptible:                   true
   retry:

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,0 @@
-status = [
-    "ci/gitlab/gitlab.parity.io"
-]
-# The default is one hour (3600 sec).
-timeout_sec = 1800
-use_squash_merge = true
-required_approvals = 1


### PR DESCRIPTION
No one uses it and the specifics of it's setup are stopping [external](https://github.com/paritytech/devops/issues/710) contributors to leverage our open pipelines.

Closes paritytech/devops#710