### PR TITLE
Make nested Lazy's clear storage properly

### DIFF
--- a/crates/env/src/engine/off_chain/db/accounts.rs
+++ b/crates/env/src/engine/off_chain/db/accounts.rs
@@ -267,6 +267,12 @@ impl Account {
     pub fn get_storage_rw(&self) -> Result<(usize, usize)> {
         self.contract_or_err().map(|contract| contract.get_rw())
     }
+
+    /// Returns the amount of used storage entries.
+    pub fn get_storage_used(&self) -> Result<usize> {
+        self.contract_or_err()
+            .map(|contract| contract.get_storage_used())
+    }
 }
 
 /// The kind of the account.
@@ -300,6 +306,11 @@ impl ContractAccount {
     /// Returns the number of reads and writes from and to the contract storage.
     pub fn get_rw(&self) -> (usize, usize) {
         self.storage.get_rw()
+    }
+
+    /// Returns the number of used storage entries.
+    pub fn get_storage_used(&self) -> usize {
+        self.storage.storage_used()
     }
 }
 
@@ -354,5 +365,10 @@ impl ContractStorage {
     pub fn clear_storage(&mut self, at: Key) {
         self.count_writes += 1;
         self.entries.remove(&at);
+    }
+
+    /// Returns the number of used storage entries.
+    pub fn storage_used(&self) -> usize {
+        self.entries.len()
     }
 }

--- a/crates/env/src/engine/off_chain/db/accounts.rs
+++ b/crates/env/src/engine/off_chain/db/accounts.rs
@@ -271,7 +271,7 @@ impl Account {
     /// Returns the amount of used storage entries.
     pub fn count_used_storage_cells(&self) -> Result<usize> {
         self.contract_or_err()
-            .map(|contract| contract.get_storage_used())
+            .map(|contract| contract.count_used_storage_cells())
     }
 }
 
@@ -310,7 +310,7 @@ impl ContractAccount {
 
     /// Returns the number of used storage entries.
     pub fn count_used_storage_cells(&self) -> usize {
-        self.storage.storage_used()
+        self.storage.count_used_storage_cells()
     }
 }
 

--- a/crates/env/src/engine/off_chain/db/accounts.rs
+++ b/crates/env/src/engine/off_chain/db/accounts.rs
@@ -269,7 +269,7 @@ impl Account {
     }
 
     /// Returns the amount of used storage entries.
-    pub fn get_storage_used(&self) -> Result<usize> {
+    pub fn count_used_storage_cells(&self) -> Result<usize> {
         self.contract_or_err()
             .map(|contract| contract.get_storage_used())
     }
@@ -309,7 +309,7 @@ impl ContractAccount {
     }
 
     /// Returns the number of used storage entries.
-    pub fn get_storage_used(&self) -> usize {
+    pub fn count_used_storage_cells(&self) -> usize {
         self.storage.storage_used()
     }
 }
@@ -368,7 +368,7 @@ impl ContractStorage {
     }
 
     /// Returns the number of used storage entries.
-    pub fn storage_used(&self) -> usize {
+    pub fn count_used_storage_cells(&self) -> usize {
         self.entries.len()
     }
 }

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -352,9 +352,9 @@ where
     })
 }
 
-/// Returns the amount of storage entries used by the account `account_id`.
+/// Returns the amount of storage cells used by the account `account_id`.
 ///
-/// Returns `None` if the account is non-existent.
+/// Returns `None` if the `account_id` is non-existent.
 pub fn count_used_storage_cells<T>(account_id: &T::AccountId) -> Result<usize>
 where
     T: Environment,

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -355,7 +355,7 @@ where
 /// Returns the amount of storage entries used by the account `account_id`.
 ///
 /// Returns `None` if the account is non-existent.
-pub fn get_storage_used<T>(account_id: &T::AccountId) -> Result<usize>
+pub fn count_used_storage_cells<T>(account_id: &T::AccountId) -> Result<usize>
 where
     T: Environment,
 {

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -365,7 +365,7 @@ where
             .get_account::<T>(account_id)
             .ok_or_else(|| AccountError::no_account_for_id::<T>(account_id))
             .map_err(Into::into)
-            .and_then(|account| account.get_storage_used().map_err(Into::into))
+            .and_then(|account| account.count_used_storage_cells().map_err(Into::into))
     })
 }
 
@@ -383,7 +383,7 @@ where
             .get_account::<T>(&account_id)
             .ok_or_else(|| AccountError::no_account_for_id::<T>(&account_id))
             .map_err(Into::into)
-            .and_then(|account| account.get_storage_used().map_err(Into::into))
+            .and_then(|account| account.count_used_storage_cells().map_err(Into::into))
     })
 }
 

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -369,24 +369,6 @@ where
     })
 }
 
-/// Returns the amount of storage entries used by the account `account_id`.
-///
-/// Returns `None` if no current account is existent.
-pub fn get_current_contract_storage_used<T>() -> Result<usize>
-where
-    T: Environment,
-{
-    let account_id = get_current_contract_account_id::<T>()?;
-    <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance
-            .accounts
-            .get_account::<T>(&account_id)
-            .ok_or_else(|| AccountError::no_account_for_id::<T>(&account_id))
-            .map_err(Into::into)
-            .and_then(|account| account.count_used_storage_cells().map_err(Into::into))
-    })
-}
-
 /// Returns the account id of the currently executing contract.
 pub fn get_current_contract_account_id<T>() -> Result<T::AccountId>
 where

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -352,6 +352,41 @@ where
     })
 }
 
+/// Returns the amount of storage entries used by the account `account_id`.
+///
+/// Returns `None` if the account is non-existent.
+pub fn get_storage_used<T>(account_id: &T::AccountId) -> Result<usize>
+where
+    T: Environment,
+{
+    <EnvInstance as OnInstance>::on_instance(|instance| {
+        instance
+            .accounts
+            .get_account::<T>(account_id)
+            .ok_or_else(|| AccountError::no_account_for_id::<T>(account_id))
+            .map_err(Into::into)
+            .and_then(|account| account.get_storage_used().map_err(Into::into))
+    })
+}
+
+/// Returns the amount of storage entries used by the account `account_id`.
+///
+/// Returns `None` if no current account is existent.
+pub fn get_current_contract_storage_used<T>() -> Result<usize>
+where
+    T: Environment,
+{
+    let account_id = get_current_contract_account_id::<T>()?;
+    <EnvInstance as OnInstance>::on_instance(|instance| {
+        instance
+            .accounts
+            .get_account::<T>(&account_id)
+            .ok_or_else(|| AccountError::no_account_for_id::<T>(&account_id))
+            .map_err(Into::into)
+            .and_then(|account| account.get_storage_used().map_err(Into::into))
+    })
+}
+
 /// Returns the account id of the currently executing contract.
 pub fn get_current_contract_account_id<T>() -> Result<T::AccountId>
 where

--- a/crates/storage/src/collections/hashmap/tests.rs
+++ b/crates/storage/src/collections/hashmap/tests.rs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 use super::HashMap as StorageHashMap;
-use crate::traits::{
-    KeyPtr,
-    SpreadLayout,
+use crate::{
+    traits::{
+        KeyPtr,
+        SpreadLayout,
+    },
+    Lazy,
 };
 use ink_primitives::Key;
 
@@ -315,6 +318,32 @@ fn spread_layout_clear_works() {
         let _ = <StorageHashMap<u8, i32> as SpreadLayout>::pull_spread(
             &mut KeyPtr::from(root_key),
         );
+        Ok(())
+    })
+    .unwrap()
+}
+
+#[test]
+fn storage_is_cleared_completely_after_pull_lazy() {
+    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+        // given
+        let root_key = Key::from([0x42; 32]);
+        let lazy_hmap = Lazy::new(filled_hmap());
+        SpreadLayout::push_spread(&lazy_hmap, &mut KeyPtr::from(root_key));
+        let pulled_hmap = <Lazy<StorageHashMap<u8, i32>> as SpreadLayout>::pull_spread(
+            &mut KeyPtr::from(root_key),
+        );
+
+        // when
+        SpreadLayout::clear_spread(&pulled_hmap, &mut KeyPtr::from(root_key));
+
+        // then
+        let storage_used = ink_env::test::get_current_contract_storage_used::<
+            ink_env::DefaultEnvironment,
+        >()
+        .expect("used storage must be returned");
+        assert_eq!(storage_used, 0);
+
         Ok(())
     })
     .unwrap()

--- a/crates/storage/src/collections/hashmap/tests.rs
+++ b/crates/storage/src/collections/hashmap/tests.rs
@@ -338,11 +338,15 @@ fn storage_is_cleared_completely_after_pull_lazy() {
         SpreadLayout::clear_spread(&pulled_hmap, &mut KeyPtr::from(root_key));
 
         // then
-        let storage_used = ink_env::test::get_current_contract_storage_used::<
+        let contract_id = ink_env::test::get_current_contract_account_id::<
             ink_env::DefaultEnvironment,
         >()
-        .expect("used storage must be returned");
-        assert_eq!(storage_used, 0);
+        .expect("Cannot get contract id");
+        let used_cells = ink_env::test::count_used_storage_cells::<
+            ink_env::DefaultEnvironment,
+        >(&contract_id)
+        .expect("used cells must be returned");
+        assert_eq!(used_cells, 0);
 
         Ok(())
     })

--- a/crates/storage/src/collections/hashmap/tests.rs
+++ b/crates/storage/src/collections/hashmap/tests.rs
@@ -35,6 +35,13 @@ fn pull_hmap() -> StorageHashMap<u8, i32> {
     <StorageHashMap<u8, i32> as SpreadLayout>::pull_spread(&mut key_ptr())
 }
 
+fn filled_hmap() -> StorageHashMap<u8, i32> {
+    [(b'A', 1), (b'B', 2), (b'C', 3), (b'D', 4)]
+        .iter()
+        .copied()
+        .collect::<StorageHashMap<u8, i32>>()
+}
+
 #[test]
 fn new_works() {
     // `StorageHashMap::new`
@@ -102,10 +109,7 @@ fn get_works() {
     assert_eq!(hmap.get(&b'A'), None);
     assert_eq!(hmap.get(&b'E'), None);
     // Filled hash map: `get`
-    let hmap = [(b'A', 1), (b'B', 2), (b'C', 3), (b'D', 4)]
-        .iter()
-        .copied()
-        .collect::<StorageHashMap<u8, i32>>();
+    let hmap = filled_hmap();
     assert_eq!(hmap.get(&b'A'), Some(&1));
     assert_eq!(hmap.get(&b'B'), Some(&2));
     assert_eq!(hmap.get(&b'C'), Some(&3));
@@ -150,10 +154,7 @@ fn take_works() {
     assert_eq!(hmap.take(&b'A'), None);
     assert_eq!(hmap.take(&b'E'), None);
     // Filled hash map: `get`
-    let mut hmap = [(b'A', 1), (b'B', 2), (b'C', 3), (b'D', 4)]
-        .iter()
-        .copied()
-        .collect::<StorageHashMap<u8, i32>>();
+    let mut hmap = filled_hmap();
     assert_eq!(hmap.len(), 4);
     assert_eq!(hmap.take(&b'A'), Some(1));
     assert_eq!(hmap.len(), 3);
@@ -171,10 +172,7 @@ fn take_works() {
 
 #[test]
 fn iter_next_works() {
-    let hmap = [(b'A', 1), (b'B', 2), (b'C', 3), (b'D', 4)]
-        .iter()
-        .copied()
-        .collect::<StorageHashMap<u8, i32>>();
+    let hmap = filled_hmap();
     // Test iterator over shared references:
     let mut iter = hmap.iter();
     assert_eq!(iter.count(), 4);
@@ -208,10 +206,7 @@ fn iter_next_works() {
 
 #[test]
 fn values_next_works() {
-    let hmap = [(b'A', 1), (b'B', 2), (b'C', 3), (b'D', 4)]
-        .iter()
-        .copied()
-        .collect::<StorageHashMap<u8, i32>>();
+    let hmap = filled_hmap();
     // Test iterator over shared references:
     let mut iter = hmap.values();
     assert_eq!(iter.count(), 4);
@@ -245,10 +240,7 @@ fn values_next_works() {
 
 #[test]
 fn keys_next_works() {
-    let hmap = [(b'A', 1), (b'B', 2), (b'C', 3), (b'D', 4)]
-        .iter()
-        .copied()
-        .collect::<StorageHashMap<u8, i32>>();
+    let hmap = filled_hmap();
     let mut iter = hmap.keys();
     assert_eq!(iter.count(), 4);
     assert_eq!(iter.size_hint(), (4, Some(4)));
@@ -272,10 +264,7 @@ fn defrag_works() {
         .copied()
         .collect::<StorageHashMap<u8, i32>>();
     // Defrag without limits:
-    let mut hmap = [(b'A', 1), (b'B', 2), (b'C', 3), (b'D', 4)]
-        .iter()
-        .copied()
-        .collect::<StorageHashMap<u8, i32>>();
+    let mut hmap = filled_hmap();
     assert_eq!(hmap.defrag(None), 0);
     assert_eq!(hmap.take(&b'B'), Some(2));
     assert_eq!(hmap.take(&b'C'), Some(3));
@@ -299,10 +288,7 @@ fn defrag_works() {
 #[test]
 fn spread_layout_push_pull_works() -> ink_env::Result<()> {
     ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
-        let hmap1 = [(b'A', 1), (b'B', 2), (b'C', 3), (b'D', 4)]
-            .iter()
-            .copied()
-            .collect::<StorageHashMap<u8, i32>>();
+        let hmap1 = filled_hmap();
         push_hmap(&hmap1);
         // Load the pushed storage hmap into another instance and check that
         // both instances are equal:
@@ -316,10 +302,7 @@ fn spread_layout_push_pull_works() -> ink_env::Result<()> {
 #[should_panic(expected = "storage entry was empty")]
 fn spread_layout_clear_works() {
     ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
-        let hmap1 = [(b'A', 1), (b'B', 2), (b'C', 3), (b'D', 4)]
-            .iter()
-            .copied()
-            .collect::<StorageHashMap<u8, i32>>();
+        let hmap1 = filled_hmap();
         let root_key = Key::from([0x42; 32]);
         SpreadLayout::push_spread(&hmap1, &mut KeyPtr::from(root_key));
         // It has already been asserted that a valid instance can be pulled

--- a/crates/storage/src/collections/hashmap/tests.rs
+++ b/crates/storage/src/collections/hashmap/tests.rs
@@ -304,7 +304,7 @@ fn spread_layout_push_pull_works() -> ink_env::Result<()> {
             .copied()
             .collect::<StorageHashMap<u8, i32>>();
         push_hmap(&hmap1);
-        // Load the pushed storage vector into another instance and check that
+        // Load the pushed storage hmap into another instance and check that
         // both instances are equal:
         let hmap2 = pull_hmap();
         assert_eq!(hmap1, hmap2);
@@ -327,7 +327,7 @@ fn spread_layout_clear_works() {
         //
         // Now clear the associated storage from `hmap1` and check whether
         // loading another instance from this storage will panic since the
-        // vector's length property cannot read a value:
+        // hmap's length property cannot read a value:
         SpreadLayout::clear_spread(&hmap1, &mut KeyPtr::from(root_key));
         let _ = <StorageHashMap<u8, i32> as SpreadLayout>::pull_spread(
             &mut KeyPtr::from(root_key),

--- a/crates/storage/src/collections/smallvec/mod.rs
+++ b/crates/storage/src/collections/smallvec/mod.rs
@@ -85,7 +85,7 @@ where
     ///
     /// # Note
     ///
-    /// This completely invalidates the storage vector's invariances about
+    /// This completely invalidates the storage vector's invariants about
     /// the contents of its associated storage region.
     ///
     /// This API is used for the `Drop` implementation of [`Vec`] as well as

--- a/crates/storage/src/collections/smallvec/tests.rs
+++ b/crates/storage/src/collections/smallvec/tests.rs
@@ -418,7 +418,7 @@ fn storage_is_cleared_completely_after_pull_lazy() {
         >()
         .expect("contract id must exist");
         let storage_used =
-            ink_env::test::get_storage_used::<ink_env::DefaultEnvironment>(&contract_id)
+            ink_env::test::count_used_storage_cells::<ink_env::DefaultEnvironment>(&contract_id)
                 .expect("used storage must be returned");
         assert_eq!(storage_used, 0);
 

--- a/crates/storage/src/collections/smallvec/tests.rs
+++ b/crates/storage/src/collections/smallvec/tests.rs
@@ -417,10 +417,11 @@ fn storage_is_cleared_completely_after_pull_lazy() {
             ink_env::DefaultEnvironment,
         >()
         .expect("contract id must exist");
-        let storage_used =
-            ink_env::test::count_used_storage_cells::<ink_env::DefaultEnvironment>(&contract_id)
-                .expect("used storage must be returned");
-        assert_eq!(storage_used, 0);
+        let used_cells = ink_env::test::count_used_storage_cells::<
+            ink_env::DefaultEnvironment,
+        >(&contract_id)
+        .expect("used cells must be returned");
+        assert_eq!(used_cells, 0);
 
         Ok(())
     })
@@ -444,11 +445,15 @@ fn drop_works() {
         });
         assert!(setup_result.is_ok(), "setup should not panic");
 
-        let storage_used = ink_env::test::get_current_contract_storage_used::<
+        let contract_id = ink_env::test::get_current_contract_account_id::<
             ink_env::DefaultEnvironment,
         >()
-        .expect("used storage must be returned");
-        assert_eq!(storage_used, 0);
+        .expect("Cannot get contract id");
+        let used_cells = ink_env::test::count_used_storage_cells::<
+            ink_env::DefaultEnvironment,
+        >(&contract_id)
+        .expect("used cells must be returned");
+        assert_eq!(used_cells, 0);
 
         let _ =
             <SmallVec<u8, U4> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));

--- a/crates/storage/src/collections/smallvec/tests.rs
+++ b/crates/storage/src/collections/smallvec/tests.rs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 use super::SmallVec;
-use crate::traits::{
-    KeyPtr,
-    SpreadLayout,
+use crate::{
+    traits::{
+        KeyPtr,
+        SpreadLayout,
+    },
+    Lazy,
 };
 use generic_array::typenum::*;
 use ink_primitives::Key;
@@ -388,6 +391,65 @@ fn spread_layout_clear_works() {
         // loading another instance from this storage will panic since the
         // vector's length property cannot read a value:
         SpreadLayout::clear_spread(&vec1, &mut KeyPtr::from(root_key));
+        let _ =
+            <SmallVec<u8, U4> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        Ok(())
+    })
+    .unwrap()
+}
+
+#[test]
+fn storage_is_cleared_completely_after_pull_lazy() {
+    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+        // given
+        let root_key = Key::from([0x42; 32]);
+        let lazy_vec = Lazy::new(vec_from_slice(&[b'a', b'b', b'c', b'd']));
+        SpreadLayout::push_spread(&lazy_vec, &mut KeyPtr::from(root_key));
+        let pulled_vec = <Lazy<SmallVec<u8, U4>> as SpreadLayout>::pull_spread(
+            &mut KeyPtr::from(root_key),
+        );
+
+        // when
+        SpreadLayout::clear_spread(&pulled_vec, &mut KeyPtr::from(root_key));
+
+        // then
+        let contract_id = ink_env::test::get_current_contract_account_id::<
+            ink_env::DefaultEnvironment,
+        >()
+        .expect("contract id must exist");
+        let storage_used =
+            ink_env::test::get_storage_used::<ink_env::DefaultEnvironment>(&contract_id)
+                .expect("used storage must be returned");
+        assert_eq!(storage_used, 0);
+
+        Ok(())
+    })
+    .unwrap()
+}
+
+#[test]
+#[should_panic(expected = "encountered empty storage cell")]
+fn drop_works() {
+    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+        let root_key = Key::from([0x42; 32]);
+
+        // if the setup panics it should not cause the test to pass
+        let setup_result = std::panic::catch_unwind(|| {
+            let vec = vec_from_slice(&[b'a', b'b', b'c', b'd']);
+            SpreadLayout::push_spread(&vec, &mut KeyPtr::from(root_key));
+            let _ = <SmallVec<u8, U4> as SpreadLayout>::pull_spread(&mut KeyPtr::from(
+                root_key,
+            ));
+            // vec is dropped which should clear the cells
+        });
+        assert!(setup_result.is_ok(), "setup should not panic");
+
+        let storage_used = ink_env::test::get_current_contract_storage_used::<
+            ink_env::DefaultEnvironment,
+        >()
+        .expect("used storage must be returned");
+        assert_eq!(storage_used, 0);
+
         let _ =
             <SmallVec<u8, U4> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
         Ok(())

--- a/crates/storage/src/collections/stash/mod.rs
+++ b/crates/storage/src/collections/stash/mod.rs
@@ -262,7 +262,7 @@ where
     ///
     /// # Note
     ///
-    /// This completely invalidates the storage vector's invariances about
+    /// This completely invalidates the storage vector's invariants about
     /// the contents of its associated storage region.
     ///
     /// This API is used for the `Drop` implementation of [`Vec`] as well as

--- a/crates/storage/src/collections/stash/tests.rs
+++ b/crates/storage/src/collections/stash/tests.rs
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 use super::Stash as StorageStash;
-use crate::traits::{
-    KeyPtr,
-    SpreadLayout,
+use crate::{
+    traits::{
+        KeyPtr,
+        SpreadLayout,
+    },
+    Lazy,
 };
 use ink_primitives::Key;
 
@@ -744,6 +747,32 @@ fn spread_layout_clear_works() {
         SpreadLayout::clear_spread(&stash1, &mut KeyPtr::from(root_key));
         let _ =
             <StorageStash<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        Ok(())
+    })
+    .unwrap()
+}
+
+#[test]
+fn storage_is_cleared_completely_after_pull_lazy() {
+    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+        // given
+        let root_key = Key::from([0x42; 32]);
+        let lazy_stash = Lazy::new(create_holey_stash());
+        SpreadLayout::push_spread(&lazy_stash, &mut KeyPtr::from(root_key));
+        let pulled_stash = <Lazy<StorageStash<u8>> as SpreadLayout>::pull_spread(
+            &mut KeyPtr::from(root_key),
+        );
+
+        // when
+        SpreadLayout::clear_spread(&pulled_stash, &mut KeyPtr::from(root_key));
+
+        // then
+        let storage_used = ink_env::test::get_current_contract_storage_used::<
+            ink_env::DefaultEnvironment,
+        >()
+        .expect("used storage must be returned");
+        assert_eq!(storage_used, 0);
+
         Ok(())
     })
     .unwrap()

--- a/crates/storage/src/collections/stash/tests.rs
+++ b/crates/storage/src/collections/stash/tests.rs
@@ -767,10 +767,14 @@ fn storage_is_cleared_completely_after_pull_lazy() {
         SpreadLayout::clear_spread(&pulled_stash, &mut KeyPtr::from(root_key));
 
         // then
-        let storage_used = ink_env::test::get_current_contract_storage_used::<
+        let contract_id = ink_env::test::get_current_contract_account_id::<
             ink_env::DefaultEnvironment,
         >()
-        .expect("used storage must be returned");
+        .expect("Cannot yet contract id");
+        let storage_used = ink_env::test::count_used_storage_cells::<
+            ink_env::DefaultEnvironment,
+        >(&contract_id)
+        .expect("used cells must be returned");
         assert_eq!(storage_used, 0);
 
         Ok(())

--- a/crates/storage/src/collections/vec/mod.rs
+++ b/crates/storage/src/collections/vec/mod.rs
@@ -105,7 +105,7 @@ where
     ///
     /// # Note
     ///
-    /// This completely invalidates the storage vector's invariances about
+    /// This completely invalidates the storage vector's invariants about
     /// the contents of its associated storage region.
     ///
     /// This API is used for the `Drop` implementation of [`Vec`] as well as

--- a/crates/storage/src/collections/vec/tests.rs
+++ b/crates/storage/src/collections/vec/tests.rs
@@ -19,6 +19,7 @@ use crate::{
         KeyPtr,
         SpreadLayout,
     },
+    Lazy,
 };
 use ink_primitives::Key;
 
@@ -424,4 +425,65 @@ fn clear_works_on_empty_vec() {
     let mut vec = vec_from_slice(&[]);
     vec.clear();
     assert!(vec.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "encountered empty storage cell")]
+fn storage_is_cleared_completely_after_pull_lazy() {
+    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+        // given
+        let root_key = Key::from([0x42; 32]);
+        let mut lazy_vec: Lazy<StorageVec<u32>> = Lazy::new(StorageVec::new());
+        lazy_vec.push(13u32);
+        lazy_vec.push(13u32);
+        SpreadLayout::push_spread(&lazy_vec, &mut KeyPtr::from(root_key));
+        let pulled_vec = <Lazy<StorageVec<u32>> as SpreadLayout>::pull_spread(
+            &mut KeyPtr::from(root_key),
+        );
+
+        // when
+        SpreadLayout::clear_spread(&pulled_vec, &mut KeyPtr::from(root_key));
+
+        // then
+        let storage_used = ink_env::test::get_current_contract_storage_used::<
+            ink_env::DefaultEnvironment,
+        >()
+        .expect("used storage must be returned");
+        assert_eq!(storage_used, 0);
+        let _ =
+            *<Lazy<Lazy<u32>> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+
+        Ok(())
+    })
+    .unwrap()
+}
+
+#[test]
+#[should_panic(expected = "encountered empty storage cell")]
+fn drop_works() {
+    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+        let root_key = Key::from([0x42; 32]);
+
+        // if the setup panics it should not cause the test to pass
+        let setup_result = std::panic::catch_unwind(|| {
+            let vec = vec_from_slice(&[b'a', b'b', b'c', b'd']);
+            SpreadLayout::push_spread(&vec, &mut KeyPtr::from(root_key));
+            let _ = <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(
+                root_key,
+            ));
+            // vec is dropped which should clear the cells
+        });
+        assert!(setup_result.is_ok(), "setup should not panic");
+
+        let storage_used = ink_env::test::get_current_contract_storage_used::<
+            ink_env::DefaultEnvironment,
+        >()
+        .expect("used storage must be returned");
+        assert_eq!(storage_used, 0);
+
+        let _ =
+            <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        Ok(())
+    })
+    .unwrap()
 }

--- a/crates/storage/src/collections/vec/tests.rs
+++ b/crates/storage/src/collections/vec/tests.rs
@@ -445,11 +445,15 @@ fn storage_is_cleared_completely_after_pull_lazy() {
         SpreadLayout::clear_spread(&pulled_vec, &mut KeyPtr::from(root_key));
 
         // then
-        let storage_used = ink_env::test::get_current_contract_storage_used::<
+        let contract_id = ink_env::test::get_current_contract_account_id::<
             ink_env::DefaultEnvironment,
         >()
-        .expect("used storage must be returned");
-        assert_eq!(storage_used, 0);
+        .expect("Cannot get contract id");
+        let used_cells = ink_env::test::count_used_storage_cells::<
+            ink_env::DefaultEnvironment,
+        >(&contract_id)
+        .expect("used cells must be returned");
+        assert_eq!(used_cells, 0);
         let _ =
             *<Lazy<Lazy<u32>> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
 
@@ -475,11 +479,15 @@ fn drop_works() {
         });
         assert!(setup_result.is_ok(), "setup should not panic");
 
-        let storage_used = ink_env::test::get_current_contract_storage_used::<
+        let contract_id = ink_env::test::get_current_contract_account_id::<
             ink_env::DefaultEnvironment,
         >()
-        .expect("used storage must be returned");
-        assert_eq!(storage_used, 0);
+        .expect("Cannot yet contract id");
+        let used_cells = ink_env::test::count_used_storage_cells::<
+            ink_env::DefaultEnvironment,
+        >(&contract_id)
+        .expect("used cells must be returned");
+        assert_eq!(used_cells, 0);
 
         let _ =
             <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -684,11 +684,15 @@ mod tests {
             SpreadLayout::clear_spread(&pulled_lazy, &mut KeyPtr::from(root_key));
 
             // then
-            let storage_used = ink_env::test::get_current_contract_storage_used::<
+            let contract_id = ink_env::test::get_current_contract_account_id::<
                 ink_env::DefaultEnvironment,
             >()
-            .expect("used storage must be returned");
-            assert_eq!(storage_used, 0);
+            .expect("Cannot yet contract id");
+            let used_cells = ink_env::test::count_used_storage_cells::<
+                ink_env::DefaultEnvironment,
+            >(&contract_id)
+            .expect("used cells must be returned");
+            assert_eq!(used_cells, 0);
             let _ = *<Lazy<Lazy<u32>> as SpreadLayout>::pull_spread(&mut KeyPtr::from(
                 root_key,
             ));

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -150,6 +150,9 @@ where
     }
 
     fn clear_spread(&self, ptr: &mut KeyPtr) {
+        // the inner cell needs to be cleared, no matter if it has been loaded or not.
+        // otherwise there might be leftovers.
+        let _ = self.get();
         let root_key = ExtKeyPtr::next_for::<Self>(ptr);
         if let Some(entry) = self.entry() {
             entry.clear_spread_root(root_key)


### PR DESCRIPTION
Closes #580.

The bug is that a `Lazy` doesn't clear up it's inner cell for `clear_spread`, if the inner cell has not been loaded. This can easily happen with nested `Lazy`'s ‒ like `Lazy<Lazy<…>>`.

But also we often use `Lazy` in storage structs like `StorageHashMap<…>` (with `values: LazyHashMap<…>` ‒ if these structs are then wrapped in a `Lazy` there is already a nested `Lazy`. `SmallVec`, `Vec`, `Stash` or other storage structs which have this bug if they are wrapped in a `Lazy`.

The way I fixed this for now will probably lead to some discussion and I'm open for other approaches.
