### PR TITLE
Migrate magic number to global const

### DIFF
--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -161,7 +161,13 @@ where
             false => {
                 // Clear without loading from storage:
                 let footprint = <T as SpreadLayout>::FOOTPRINT;
-                assert!(footprint <= 16); // magic number
+                assert!(
+                    footprint <= crate::traits::MAX_FOOTPRINT,
+                    format!(
+                        "The footprint is limited to {}.",
+                        crate::traits::MAX_FOOTPRINT
+                    )
+                );
                 let mut key_ptr = KeyPtr::from(*root_key);
                 for _ in 0..footprint {
                     ink_env::clear_contract_storage(key_ptr.advance_by(1));

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -163,10 +163,7 @@ where
                 let footprint = <T as SpreadLayout>::FOOTPRINT;
                 assert!(
                     footprint <= crate::traits::MAX_FOOTPRINT,
-                    format!(
-                        "The footprint is limited to {}.",
-                        crate::traits::MAX_FOOTPRINT
-                    )
+                    "The footprint limit is violated for this type!"
                 );
                 let mut key_ptr = KeyPtr::from(*root_key);
                 for _ in 0..footprint {

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -161,11 +161,12 @@ where
             false => {
                 // Clear without loading from storage:
                 let footprint = <T as SpreadLayout>::FOOTPRINT;
+                let footprint_threshold = crate::traits::FOOTPRINT_CLEANUP_THRESHOLD;
                 assert!(
-                    footprint <= crate::traits::FOOTPRINT_CLEANUP_THRESHOLD,
+                    footprint <= footprint_threshold,
                     "cannot clean-up a storage entity with a footprint of {}. maximum threshold for clean-up is {}.",
                     footprint,
-                    crate::traits::FOOTPRINT_CLEANUP_THRESHOLD,
+                    footprint_threshold,
                 );
                 let mut key_ptr = KeyPtr::from(*root_key);
                 for _ in 0..footprint {

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -162,7 +162,7 @@ where
                 // Clear without loading from storage:
                 let footprint = <T as SpreadLayout>::FOOTPRINT;
                 assert!(
-                    footprint <= crate::traits::MAX_FOOTPRINT,
+                    footprint <= crate::traits::FOOTPRINT_CLEANUP_THRESHOLD,
                     "The footprint limit is violated for this type!"
                 );
                 let mut key_ptr = KeyPtr::from(*root_key);

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -165,7 +165,7 @@ where
                     footprint <= crate::traits::FOOTPRINT_CLEANUP_THRESHOLD,
                     "cannot clean-up a storage entity with a footprint of {}. maximum threshold for clean-up is {}.",
                     footprint,
-                    footprint_threshold,
+                    crate::traits::FOOTPRINT_CLEANUP_THRESHOLD,
                 );
                 let mut key_ptr = KeyPtr::from(*root_key);
                 for _ in 0..footprint {

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -163,7 +163,9 @@ where
                 let footprint = <T as SpreadLayout>::FOOTPRINT;
                 assert!(
                     footprint <= crate::traits::FOOTPRINT_CLEANUP_THRESHOLD,
-                    "The footprint limit is violated for this type!"
+                    "cannot clean-up a storage entity with a footprint of {}. maximum threshold for clean-up is {}.",
+                    footprint,
+                    footprint_threshold,
                 );
                 let mut key_ptr = KeyPtr::from(*root_key);
                 for _ in 0..footprint {

--- a/crates/storage/src/traits/mod.rs
+++ b/crates/storage/src/traits/mod.rs
@@ -55,7 +55,10 @@ pub use self::{
         KeyPtr,
     },
     packed::PackedLayout,
-    spread::SpreadLayout,
+    spread::{
+        SpreadLayout,
+        MAX_FOOTPRINT,
+    },
 };
 pub use ::ink_storage_derive::{
     PackedLayout,

--- a/crates/storage/src/traits/mod.rs
+++ b/crates/storage/src/traits/mod.rs
@@ -57,7 +57,7 @@ pub use self::{
     packed::PackedLayout,
     spread::{
         SpreadLayout,
-        MAX_FOOTPRINT,
+        FOOTPRINT_CLEANUP_THRESHOLD,
     },
 };
 pub use ::ink_storage_derive::{

--- a/crates/storage/src/traits/optspec.rs
+++ b/crates/storage/src/traits/optspec.rs
@@ -80,8 +80,7 @@ where
     // we will still load it first in order to not clean-up too many unneeded
     // storage cells.
     let footprint = <T as SpreadLayout>::FOOTPRINT;
-    let threshold = 16; // Arbitrarily chosen. Might need adjustments later.
-    if footprint >= threshold || <T as SpreadLayout>::REQUIRES_DEEP_CLEAN_UP {
+    if footprint >= super::MAX_FOOTPRINT || <T as SpreadLayout>::REQUIRES_DEEP_CLEAN_UP {
         // We need to load the entity before we remove its associated contract storage
         // because it requires a deep clean-up which propagates clearing to its fields,
         // for example in the case of `T` being a `storage::Box`.

--- a/crates/storage/src/traits/optspec.rs
+++ b/crates/storage/src/traits/optspec.rs
@@ -80,7 +80,9 @@ where
     // we will still load it first in order to not clean-up too many unneeded
     // storage cells.
     let footprint = <T as SpreadLayout>::FOOTPRINT;
-    if footprint >= super::MAX_FOOTPRINT || <T as SpreadLayout>::REQUIRES_DEEP_CLEAN_UP {
+    if footprint >= super::FOOTPRINT_CLEANUP_THRESHOLD
+        || <T as SpreadLayout>::REQUIRES_DEEP_CLEAN_UP
+    {
         // We need to load the entity before we remove its associated contract storage
         // because it requires a deep clean-up which propagates clearing to its fields,
         // for example in the case of `T` being a `storage::Box`.

--- a/crates/storage/src/traits/spread.rs
+++ b/crates/storage/src/traits/spread.rs
@@ -14,10 +14,12 @@
 
 use super::KeyPtr;
 
-/// The maximum number of adjunctive storage cells a type may require in
-/// order to be stored in the contract storage with `SpreadLayout`.
+/// This constant is used by some types to make sure that cleaning up
+/// behind them won't become way too expensive. Since we are missing
+/// Substrate's storage bulk removal feature we cannot do better than
+/// this at the moment.
 /// The number is arbitrarily chosen. Might need adjustments later.
-pub const MAX_FOOTPRINT: u64 = 16;
+pub const FOOTPRINT_CLEANUP_THRESHOLD: u64 = 32;
 
 /// Types that can be stored to and loaded from the contract storage.
 pub trait SpreadLayout {

--- a/crates/storage/src/traits/spread.rs
+++ b/crates/storage/src/traits/spread.rs
@@ -14,6 +14,11 @@
 
 use super::KeyPtr;
 
+/// The maximum number of adjunctive storage cells a type may require in
+/// order to be stored in the contract storage with `SpreadLayout`.
+/// The number is arbitrarily chosen. Might need adjustments later.
+pub const MAX_FOOTPRINT: u64 = 16;
+
 /// Types that can be stored to and loaded from the contract storage.
 pub trait SpreadLayout {
     /// The footprint of the type.

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -431,7 +431,7 @@ mod erc721 {
     }
 
     /// Increase token counter from the `of` AccountId.
-    fn increase_counter_of(entry: Entry<AccountId, u32>) -> () {
+    fn increase_counter_of(entry: Entry<AccountId, u32>) {
         entry.and_modify(|v| *v += 1).or_insert(1);
     }
 

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -319,7 +319,7 @@ mod erc721 {
                 return Err(Error::NotAllowed)
             };
             let entry = owned_tokens_count.entry(*to);
-            increase_counter_of(entry)?;
+            increase_counter_of(entry);
             vacant_token_owner.insert(*to);
             Ok(())
         }
@@ -431,9 +431,8 @@ mod erc721 {
     }
 
     /// Increase token counter from the `of` AccountId.
-    fn increase_counter_of(entry: Entry<AccountId, u32>) -> Result<(), Error> {
+    fn increase_counter_of(entry: Entry<AccountId, u32>) -> () {
         entry.and_modify(|v| *v += 1).or_insert(1);
-        Ok(())
     }
 
     /// Unit tests


### PR DESCRIPTION
I tried all kind of things to transition the runtime assertion to a compiler error, but with no success. The hold up is always that we need to compare our magic number against `<T as SpreadLayout>::FOOTPRINT`, which is not available at compile time in Rust at the moment.

I had tried via:
* asserting in a `const fn`
* `static_assertions` crate
* `const_fn_assert` crate
* the `const_generics` feature