### PR TITLE
Move hidden images folder as well

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -298,6 +298,7 @@ publish-docs:
     # remove everything and restore generated docs, README and Jekyll config
     - rm -rf ./*
     - mv /tmp/doc/* .
+    - mv /tmp/doc/.images .
     # Upload files
     - git add --all --force
     - git status


### PR DESCRIPTION
`mv /tmp/doc/* .` doesn't match the hidden `.images` folder, hence the images do not appear on https://paritytech.github.io/ink.

The copy of the `.images` folder happens a few lines above the change in this PR.