### PR TITLE
Make jekyll serve hidden folder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,4 @@
 theme: jekyll-theme-midnight
 markdown: GFM
+include:
+    - .images/


### PR DESCRIPTION
By default hidden folders are not served by Jekyll 😔.