### PR TITLE
Trim docs whitespaces for metadata

### DIFF
--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -352,7 +352,7 @@ impl<S> ConstructorSpecBuilder<S> {
     {
         let mut this = self;
         debug_assert!(this.spec.docs.is_empty());
-        this.spec.docs = docs.into_iter().collect::<Vec<_>>();
+        this.spec.docs = docs.into_iter().map(str::trim).collect::<Vec<_>>();
         this
     }
 }

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -169,3 +169,32 @@ fn spec_contract_json() {
         })
     )
 }
+
+#[test]
+fn trim_docs() {
+    // given
+    let name = "foo";
+    let cs = ConstructorSpec::from_name(name)
+        .selector(123_456_789u32.to_be_bytes())
+        .docs(vec![" foobar      "])
+        .done();
+    let mut registry = Registry::new();
+    let compact_spec = cs.into_compact(&mut registry);
+
+    // when
+    let json = serde_json::to_value(&compact_spec).unwrap();
+    let deserialized: ConstructorSpec<CompactForm> =
+        serde_json::from_value(json.clone()).unwrap();
+
+    // then
+    assert_eq!(
+        json,
+        json!({
+            "name": ["foo"],
+            "selector": "0x075bcd15",
+            "args": [],
+            "docs": ["foobar"]
+        })
+    );
+    assert_eq!(deserialized, compact_spec);
+}


### PR DESCRIPTION
I noticed that our generated contract metadata for the message/constructor docs always contains a space as a prefix to the actual String. I suppose this is because of the parsing logic for `/// Foobar`.

```bash
$ cat flipper.contract | jq ".. | .docs?  | select(.)" | egrep -v "\[|\]"
  " Creates a new flipper smart contract initialized with the given value."
  " Creates a new flipper smart contract initialized to `false`."
  " Flips the current value of the Flipper's bool."
  " Returns the current value of the Flipper's bool."
```