### PR TITLE
[ci] Fix overwriting existing files on `publish-docs`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -294,7 +294,7 @@ publish-docs:
     # remove everything and restore generated docs, README and Jekyll config
     - rm -rf ./*
     - mv /tmp/doc/* .
-    - mv /tmp/doc/.images .
+    - mv /tmp/doc/.images/* .images/
     # Upload files
     - git add --all --force
     - git status

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -298,8 +298,9 @@ publish-docs:
     - mv _config.yml /tmp/doc/
     # remove everything and restore generated docs, README and Jekyll config
     - rm -rf ./*
+    - rm -rf ./.images
     - mv /tmp/doc/* .
-    - mv /tmp/doc/.images/* .images/
+    - mv /tmp/doc/.images .
     # Upload files
     - git add --all --force
     - git status

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -275,11 +275,6 @@ publish-docs:
   variables:
     GIT_DEPTH:                     0
     GIT_STRATEGY:                  none
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME == "tags"
   script:
     - rm -rf /tmp/*
     - unset CARGO_TARGET_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -275,6 +275,11 @@ publish-docs:
   variables:
     GIT_DEPTH:                     0
     GIT_STRATEGY:                  none
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
   script:
     - rm -rf /tmp/*
     - unset CARGO_TARGET_DIR


### PR DESCRIPTION
Currently on `master` the job fails with

```
$ mv /tmp/doc/.images .
mv: inter-device move failed: '/tmp/doc/.images' to './.images'; unable to remove target: Directory not empty```

We need to remove the directory first, before moving it from artifacts. We do the same thing for all other non-hidden files.