### PR TITLE
Make contract docs visible to rustdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Below you can see the code using the `ink_lang` version of ink!.
 use ink_lang as ink;
 
 #[ink::contract]
-mod flipper {
+pub mod flipper {
     /// The storage of the flipper contract.
     #[ink(storage)]
     pub struct Flipper {

--- a/crates/lang/codegen/src/generator/item_impls.rs
+++ b/crates/lang/codegen/src/generator/item_impls.rs
@@ -69,7 +69,7 @@ impl GenerateCode for ItemImpls<'_> {
                 #doc_item_impls
             )*
         };
-        tokens.into()
+        tokens
     }
 }
 

--- a/crates/lang/codegen/src/generator/item_impls.rs
+++ b/crates/lang/codegen/src/generator/item_impls.rs
@@ -48,6 +48,7 @@ impl GenerateCode for ItemImpls<'_> {
             .module()
             .impls()
             .map(|item_impl| self.generate_item_impl(item_impl));
+        let doc_item_impls = item_impls.clone();
         let no_cross_calling_cfg =
             self.generate_code_using::<generator::CrossCallingConflictCfg>();
         quote! {
@@ -57,6 +58,9 @@ impl GenerateCode for ItemImpls<'_> {
 
                 #( #item_impls )*
             };
+
+            #[cfg(doc)]
+            #( #doc_item_impls )*
         }
     }
 }

--- a/crates/lang/ir/src/ir/item_mod.rs
+++ b/crates/lang/ir/src/ir/item_mod.rs
@@ -438,6 +438,7 @@ impl ItemMod {
 }
 
 /// Iterator yielding ink! item definitions of the ink! smart contract.
+#[derive(Clone)]
 pub struct IterInkItems<'a> {
     items_iter: core::slice::Iter<'a, ir::Item>,
 }
@@ -504,6 +505,7 @@ impl<'a> Iterator for IterEvents<'a> {
 
 /// Iterator yielding all ink! implementation block definitions within the ink!
 /// [`ItemMod`](`crate::ir::ItemMod`).
+#[derive(Clone)]
 pub struct IterItemImpls<'a> {
     items_iter: IterInkItems<'a>,
 }

--- a/examples/delegator/adder/lib.rs
+++ b/examples/delegator/adder/lib.rs
@@ -18,7 +18,7 @@ pub use self::adder::Adder;
 use ink_lang as ink;
 
 #[ink::contract]
-mod adder {
+pub mod adder {
     use accumulator::Accumulator;
 
     /// Increments the underlying accumulator's value.

--- a/examples/delegator/lib.rs
+++ b/examples/delegator/lib.rs
@@ -17,7 +17,7 @@
 use ink_lang as ink;
 
 #[ink::contract]
-mod delegator {
+pub mod delegator {
     use accumulator::Accumulator;
     use adder::Adder;
     use ink_storage::{

--- a/examples/delegator/subber/lib.rs
+++ b/examples/delegator/subber/lib.rs
@@ -18,7 +18,7 @@ pub use self::subber::Subber;
 use ink_lang as ink;
 
 #[ink::contract]
-mod subber {
+pub mod subber {
     use accumulator::Accumulator;
 
     /// Decreases the underlying accumulator's value.

--- a/examples/dns/lib.rs
+++ b/examples/dns/lib.rs
@@ -17,7 +17,7 @@
 use ink_lang as ink;
 
 #[ink::contract]
-mod dns {
+pub mod dns {
     #[cfg(not(feature = "ink-as-dependency"))]
     use ink_storage::{
         collections::hashmap::Entry,

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -17,7 +17,7 @@
 use ink_lang as ink;
 
 #[ink::contract]
-mod erc20 {
+pub mod erc20 {
     #[cfg(not(feature = "ink-as-dependency"))]
     use ink_storage::{
         collections::HashMap as StorageHashMap,

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -67,7 +67,7 @@
 use ink_lang as ink;
 
 #[ink::contract]
-mod erc721 {
+pub mod erc721 {
     #[cfg(not(feature = "ink-as-dependency"))]
     use ink_storage::collections::{
         hashmap::Entry,

--- a/examples/incrementer/lib.rs
+++ b/examples/incrementer/lib.rs
@@ -17,7 +17,7 @@
 use ink_lang as ink;
 
 #[ink::contract]
-mod incrementer {
+pub mod incrementer {
     #[ink(storage)]
     pub struct Incrementer {
         value: i32,

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -77,7 +77,7 @@ pub use self::multisig_plain::{
 use ink_lang as ink;
 
 #[ink::contract]
-mod multisig_plain {
+pub mod multisig_plain {
     use ink_env::call::{
         build_call,
         utils::ReturnType,

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -17,7 +17,7 @@
 use ink_lang as ink;
 
 #[ink::contract]
-mod erc20 {
+pub mod erc20 {
     #[cfg(not(feature = "ink-as-dependency"))]
     use ink_lang as ink;
 


### PR DESCRIPTION
Closes #336.
 
I need to make some of our example `mod` public, otherwise there will never be any documentation for the `pub`'s in that module. We should also think about if we want to change the `cargo contract new` template and the workshops.

In terms of how it currently looks I uploaded the output of `cargo doc --no-deps` for two examples:

* [flipper](http://tmp.creal.de/flipper-doc/flipper/index.html)
* [trait-erc20](http://tmp.creal.de/trait-erc20-doc/erc20/index.html)

I expect that we will need to discuss further details of what we want to hide/show in these docs, I created this PR also with the intention of starting this discussion and not with the idea of providing a perfect solution from the start. For example: Do we always want to hide `__ink` in the contract docs? Even if it's [the event base](http://tmp.creal.de/trait-erc20-doc/erc20/erc20/enum.__ink_EventBase.html)?