### PR TITLE
Generalize conflicting attribute error reporting

### DIFF
--- a/crates/lang/ir/src/ir/attrs.rs
+++ b/crates/lang/ir/src/ir/attrs.rs
@@ -695,7 +695,7 @@ impl InkAttribute {
     ///
     /// The `is_conflicting_attr` closure returns `Ok` if the attribute does not conflict,
     /// returns `Err(None)` if the attribute conflicts but without providing further reasoning
-    /// and `Err(Some(reason))` if the attribute conflict given additional context information.
+    /// and `Err(Some(reason))` if the attribute conflicts given additional context information.
     pub fn ensure_no_conflicts<'a, P>(
         &'a self,
         mut is_conflicting: P,

--- a/crates/lang/ir/src/ir/attrs.rs
+++ b/crates/lang/ir/src/ir/attrs.rs
@@ -577,7 +577,7 @@ where
 ///
 /// The `is_conflicting_attr` closure returns `Ok` if the attribute does not conflict,
 /// returns `Err(None)` if the attribute conflicts but without providing further reasoning
-/// and `Err(Some(reason))` if the attribute conflict given additional context information.
+/// and `Err(Some(reason))` if the attribute conflicts given additional context information.
 ///
 /// # Errors
 ///

--- a/crates/lang/ir/src/ir/chain_extension.rs
+++ b/crates/lang/ir/src/ir/chain_extension.rs
@@ -486,13 +486,13 @@ impl ChainExtension {
             item_method.span(),
             item_method.attrs.clone(),
             &ir::AttributeArgKind::Extension,
-            |c| {
-                !matches!(
-                    c,
+            |arg| {
+                match arg.kind() {
                     ir::AttributeArg::Extension(_)
-                        | ir::AttributeArg::HandleStatus(_)
-                        | ir::AttributeArg::ReturnsResult(_)
-                )
+                    | ir::AttributeArg::HandleStatus(_)
+                    | ir::AttributeArg::ReturnsResult(_) => Ok(()),
+                    _ => Err(None),
+                }
             },
         )?;
         if let Some(receiver) = item_method.sig.receiver() {

--- a/crates/lang/ir/src/ir/item/event.rs
+++ b/crates/lang/ir/src/ir/item/event.rs
@@ -86,7 +86,12 @@ impl TryFrom<syn::ItemStruct> for Event {
             struct_span,
             item_struct.attrs,
             &ir::AttributeArgKind::Event,
-            |kind| !matches!(kind, ir::AttributeArg::Event | ir::AttributeArg::Anonymous),
+            |arg| {
+                match arg.kind() {
+                    ir::AttributeArg::Event | ir::AttributeArg::Anonymous => Ok(()),
+                    _ => Err(None),
+                }
+            },
         )?;
         if !item_struct.generics.params.is_empty() {
             return Err(format_err_spanned!(

--- a/crates/lang/ir/src/ir/item/storage.rs
+++ b/crates/lang/ir/src/ir/item/storage.rs
@@ -86,7 +86,12 @@ impl TryFrom<syn::ItemStruct> for Storage {
             struct_span,
             item_struct.attrs,
             &ir::AttributeArgKind::Storage,
-            |kind| !matches!(kind, ir::AttributeArg::Storage),
+            |arg| {
+                match arg.kind() {
+                    ir::AttributeArg::Storage => Ok(()),
+                    _ => Err(None),
+                }
+            },
         )?;
         if !item_struct.generics.params.is_empty() {
             return Err(format_err_spanned!(

--- a/crates/lang/ir/src/ir/item_impl/constructor.rs
+++ b/crates/lang/ir/src/ir/item_impl/constructor.rs
@@ -153,11 +153,19 @@ impl Constructor {
             method_item.span(),
             method_item.attrs.clone(),
             &ir::AttributeArgKind::Constructor,
-            |kind| {
-                !matches!(
-                    kind,
-                    ir::AttributeArg::Constructor | ir::AttributeArg::Selector(_)
-                )
+            |arg| {
+                match arg.kind() {
+                    ir::AttributeArg::Constructor | ir::AttributeArg::Selector(_) => {
+                        Ok(())
+                    }
+                    ir::AttributeArg::Payable => {
+                        Err(Some(format_err!(
+                            arg.span(),
+                            "constructors are implicitly payable"
+                        )))
+                    }
+                    _ => Err(None),
+                }
             },
         )
     }

--- a/crates/lang/ir/src/ir/item_impl/message.rs
+++ b/crates/lang/ir/src/ir/item_impl/message.rs
@@ -180,13 +180,13 @@ impl Message {
             method_item.span(),
             method_item.attrs.clone(),
             &ir::AttributeArgKind::Message,
-            |kind| {
-                !matches!(
-                    kind,
+            |arg| {
+                match arg.kind() {
                     ir::AttributeArg::Message
-                        | ir::AttributeArg::Payable
-                        | ir::AttributeArg::Selector(_)
-                )
+                    | ir::AttributeArg::Payable
+                    | ir::AttributeArg::Selector(_) => Ok(()),
+                    _ => Err(None),
+                }
             },
         )
     }

--- a/crates/lang/ir/src/ir/item_impl/mod.rs
+++ b/crates/lang/ir/src/ir/item_impl/mod.rs
@@ -299,10 +299,12 @@ impl TryFrom<syn::ItemImpl> for ItemImpl {
                     err.into_combine(format_err!(impl_block_span, "at this invocation",))
                 })?;
             normalized.ensure_no_conflicts(|arg| {
-                !matches!(
-                    arg.kind(),
-                    ir::AttributeArg::Implementation | ir::AttributeArg::Namespace(_)
-                )
+                match arg.kind() {
+                    ir::AttributeArg::Implementation | ir::AttributeArg::Namespace(_) => {
+                        Ok(())
+                    }
+                    _ => Err(None),
+                }
             })?;
             namespace = normalized.namespace();
         }

--- a/crates/lang/ir/src/ir/trait_def.rs
+++ b/crates/lang/ir/src/ir/trait_def.rs
@@ -498,7 +498,12 @@ impl InkTrait {
             constructor.span(),
             constructor.attrs.clone(),
             &ir::AttributeArgKind::Constructor,
-            |c| !matches!(c, ir::AttributeArg::Constructor),
+            |arg| {
+                match arg.kind() {
+                    ir::AttributeArg::Constructor => Ok(()),
+                    _ => Err(None),
+                }
+            },
         )?;
         if let Some(receiver) = constructor.sig.receiver() {
             return Err(format_err_spanned!(
@@ -545,7 +550,12 @@ impl InkTrait {
             message.span(),
             message.attrs.clone(),
             &ir::AttributeArgKind::Message,
-            |c| !matches!(c, ir::AttributeArg::Message),
+            |arg| {
+                match arg.kind() {
+                    ir::AttributeArg::Message => Ok(()),
+                    _ => Err(None),
+                }
+            },
         )?;
         match message.sig.receiver() {
             None | Some(syn::FnArg::Typed(_)) => {

--- a/crates/lang/macro/tests/compile_tests.rs
+++ b/crates/lang/macro/tests/compile_tests.rs
@@ -36,6 +36,8 @@ fn compile_tests() {
     t.compile_fail("tests/ui/fail/C-11-unsafe-constructor.rs");
     t.compile_fail("tests/ui/fail/C-12-const-constructor.rs");
     t.compile_fail("tests/ui/fail/C-13-abi-constructor.rs");
+    t.compile_fail("tests/ui/fail/C-14-payable-constructor.rs");
+    t.compile_fail("tests/ui/fail/C-15-payable-trait-constructor.rs");
 
     t.compile_fail("tests/ui/fail/H-01-invalid-dyn-alloc.rs");
     t.compile_fail("tests/ui/fail/H-02-invalid-as-dependency.rs");

--- a/crates/lang/macro/tests/ui/fail/C-14-payable-constructor.rs
+++ b/crates/lang/macro/tests/ui/fail/C-14-payable-constructor.rs
@@ -1,0 +1,19 @@
+use ink_lang as ink;
+
+#[ink::contract]
+mod noop {
+    #[ink(storage)]
+    pub struct Noop {}
+
+    impl Noop {
+        #[ink(constructor, payable)]
+        pub fn abi_constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn noop(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/lang/macro/tests/ui/fail/C-14-payable-constructor.stderr
+++ b/crates/lang/macro/tests/ui/fail/C-14-payable-constructor.stderr
@@ -1,0 +1,11 @@
+error: encountered conflicting ink! attribute argument
+ --> $DIR/C-14-payable-constructor.rs:9:28
+  |
+9 |         #[ink(constructor, payable)]
+  |                            ^^^^^^^
+
+error: constructors are implicitly payable
+ --> $DIR/C-14-payable-constructor.rs:9:28
+  |
+9 |         #[ink(constructor, payable)]
+  |                            ^^^^^^^

--- a/crates/lang/macro/tests/ui/fail/C-15-payable-trait-constructor.rs
+++ b/crates/lang/macro/tests/ui/fail/C-15-payable-trait-constructor.rs
@@ -1,0 +1,27 @@
+use ink_lang as ink;
+
+#[ink::trait_definition]
+pub trait Constructor {
+    #[ink(constructor)]
+    fn constructor() -> Self;
+}
+
+#[ink::contract]
+mod noop {
+    #[ink(storage)]
+    pub struct Noop {}
+
+    impl Constructor for Noop {
+        #[ink(constructor, payable)]
+        fn constructor() -> Self {
+            Self {}
+        }
+    }
+
+    impl Noop {
+        #[ink(message)]
+        pub fn noop(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/lang/macro/tests/ui/fail/C-15-payable-trait-constructor.stderr
+++ b/crates/lang/macro/tests/ui/fail/C-15-payable-trait-constructor.stderr
@@ -1,0 +1,11 @@
+error: encountered conflicting ink! attribute argument
+  --> $DIR/C-15-payable-trait-constructor.rs:15:28
+   |
+15 |         #[ink(constructor, payable)]
+   |                            ^^^^^^^
+
+error: constructors are implicitly payable
+  --> $DIR/C-15-payable-trait-constructor.rs:15:28
+   |
+15 |         #[ink(constructor, payable)]
+   |                            ^^^^^^^


### PR DESCRIPTION
- Generalizes error reporting for conflicting ink! attributes.
- Improves error reporting for `payable` ink! constructors.

Closes https://github.com/paritytech/ink/issues/553.
Superseeds: https://github.com/paritytech/ink/pull/541