### PR TITLE
block number type change into u32

### DIFF
--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -128,7 +128,7 @@ pub type Balance = u128;
 pub type Timestamp = u64;
 
 /// The default block number type.
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 /// The default environment `AccountId` type.
 ///


### PR DESCRIPTION
fix [issue#638](https://github.com/paritytech/ink/issues/638)