### PR TITLE
Run dependabot for `examples`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,47 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/contract-terminate"
+    schedule:
+        interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/contract-transfer"
+    schedule:
+        interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/delegator"
+    schedule:
+        interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/dns"
+    schedule:
+        interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/erc20"
+    schedule:
+        interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/erc721"
+    schedule:
+        interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/flipper"
+    schedule:
+        interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/incrementer"
+    schedule:
+        interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/multisig_plain"
+    schedule:
+        interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/trait-erc20"
+    schedule:
+        interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/trait-flipper"
+    schedule:
+        interval: "daily"


### PR DESCRIPTION
Our `/Cargo.toml` contains
```
exclude = [
    "examples/",
]
```
hence we need so explicitly include `examples` for our dependabot.

We need to list each example individually, since `dependabot` unfortunately does not support wildcards yet (the tracking issue is https://github.com/dependabot/dependabot-core/issues/2178).

For the `delegator` example we don't need to include the `accumulator`, `subber`, etc. specifically, since they are listed in the workspace of `delegator`.