### PR TITLE
Debug why no issue is created for failing fuzz test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -316,7 +316,7 @@ fuzz-tests:
     <<:                              *docker-env
     variables:
         # The QUICKCHECK_TESTS default is 100
-        QUICKCHECK_TESTS:            100
+        QUICKCHECK_TESTS:            50000
     script:
         # We fuzz-test only crates which possess the `ink-fuzz-tests` feature
         - all_tests_passed=0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -324,8 +324,8 @@ fuzz-tests:
             if grep "ink-fuzz-tests =" crates/${crate}/Cargo.toml;
             then
                 echo "testing crate " ${crate};
-                cargo test --verbose --features ink-fuzz-tests --manifest-path crates/${crate}/Cargo.toml --no-fail-fast -- fuzz_;
-                all_tests_passed=$(( all_tests_passed | $? ));
+                cargo test --verbose --features ink-fuzz-tests --manifest-path crates/${crate}/Cargo.toml --no-fail-fast -- fuzz_ || exit_code=$?;
+                all_tests_passed=$(( all_tests_passed | $exit_code ));
                 echo "all_tests_passed " ${all_tests_passed};
             fi
           done

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -316,7 +316,7 @@ fuzz-tests:
     <<:                              *docker-env
     variables:
         # The QUICKCHECK_TESTS default is 100
-        QUICKCHECK_TESTS:            50000
+        QUICKCHECK_TESTS:            100
     script:
         # We fuzz-test only crates which possess the `ink-fuzz-tests` feature
         - all_tests_passed=0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -317,6 +317,9 @@ fuzz-tests:
     variables:
         # The QUICKCHECK_TESTS default is 100
         QUICKCHECK_TESTS:            50000
+    rules:
+        - if: $CI_PIPELINE_SOURCE == "schedule"
+        - if: $CI_COMMIT_REF_NAME == "master"
     script:
         # We fuzz-test only crates which possess the `ink-fuzz-tests` feature
         - all_tests_passed=0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -323,15 +323,11 @@ fuzz-tests:
         - for crate in ${ALL_CRATES}; do
             if grep "ink-fuzz-tests =" crates/${crate}/Cargo.toml;
             then
-                echo "testing crate " ${crate};
                 cargo test --verbose --features ink-fuzz-tests --manifest-path crates/${crate}/Cargo.toml --no-fail-fast -- fuzz_ || exit_code=$?;
                 all_tests_passed=$(( all_tests_passed | $exit_code ));
-                echo "all_tests_passed " ${all_tests_passed};
             fi
           done
-        - echo "about to test with " ${all_tests_passed};
         - if [ $all_tests_passed -eq 0 ]; then exit 0; fi
-        - echo "creating issue"
         - |
              curl -X "POST" "https://api.github.com/repos/paritytech/ink/issues" \
                 -H "Cookie: logged_in=no" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -317,9 +317,6 @@ fuzz-tests:
     variables:
         # The QUICKCHECK_TESTS default is 100
         QUICKCHECK_TESTS:            50000
-    rules:
-        - if: $CI_PIPELINE_SOURCE == "schedule"
-        - if: $CI_COMMIT_REF_NAME == "master"
     script:
         # We fuzz-test only crates which possess the `ink-fuzz-tests` feature
         - all_tests_passed=0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -323,11 +323,15 @@ fuzz-tests:
         - for crate in ${ALL_CRATES}; do
             if grep "ink-fuzz-tests =" crates/${crate}/Cargo.toml;
             then
+                echo "testing crate " ${crate};
                 cargo test --verbose --features ink-fuzz-tests --manifest-path crates/${crate}/Cargo.toml --no-fail-fast -- fuzz_;
                 all_tests_passed=$(( all_tests_passed | $? ));
+                echo "all_tests_passed " ${all_tests_passed};
             fi
           done
+        - echo "about to test with " ${all_tests_passed};
         - if [ $all_tests_passed -eq 0 ]; then exit 0; fi
+        - echo "creating issue"
         - |
              curl -X "POST" "https://api.github.com/repos/paritytech/ink/issues" \
                 -H "Cookie: logged_in=no" \


### PR DESCRIPTION
The CI for `master` currently fails because of 
```
test collections::hashmap::fuzz_tests::fuzz_removes ... FAILED
```

A GitHub issue should have been created automatically, but this hasn't happened.