### PR TITLE
[metadata] update scale-info, remove string parameterization 

### DIFF
--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -38,7 +38,7 @@ blake2 = { version = "0.9", optional = true }
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside of the off-chain environment!
 rand = { version = "0.8", default-features = false, features = ["alloc"], optional = true }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 [features]
 default = ["std"]

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -38,7 +38,7 @@ blake2 = { version = "0.9", optional = true }
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside of the off-chain environment!
 rand = { version = "0.8", default-features = false, features = ["alloc"], optional = true }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 [features]
 default = ["std"]

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -38,7 +38,7 @@ blake2 = { version = "0.9", optional = true }
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside of the off-chain environment!
 rand = { version = "0.8", default-features = false, features = ["alloc"], optional = true }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 [features]
 default = ["std"]

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -30,7 +30,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../storage/" }
 ink_lang = { version = "3.0.0-rc2", path = ".." }
 
 trybuild = "1.0.24"
-scale-info = { version = "0.5", default-features = false, features = ["derive"] }
+scale-info = { version = "0.6", default-features = false, features = ["derive"] }
 
 [lib]
 name = "ink_lang_macro"

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -30,7 +30,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../storage/" }
 ink_lang = { version = "3.0.0-rc2", path = ".." }
 
 trybuild = "1.0.24"
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"] }
+scale-info = { version = "0.5", default-features = false, features = ["derive"] }
 
 [lib]
 name = "ink_lang_macro"

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -30,7 +30,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../storage/" }
 ink_lang = { version = "3.0.0-rc2", path = ".." }
 
 trybuild = "1.0.24"
-scale-info = { version = "0.5", default-features = false, features = ["derive"] }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"] }
 
 [lib]
 name = "ink_lang_macro"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -21,7 +21,7 @@ ink_primitives = { version = "3.0.0-rc2", path = "../primitives/", default-featu
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.3.1"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "0.6", default-features = false, features = ["derive", "serde"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -21,7 +21,7 @@ ink_primitives = { version = "3.0.0-rc2", path = "../primitives/", default-featu
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.3.1"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "0.5", default-features = false, features = ["derive", "serde"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -21,7 +21,7 @@ ink_primitives = { version = "3.0.0-rc2", path = "../primitives/", default-featu
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.3.1"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive", "serde"] }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive", "serde"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -47,30 +47,25 @@ use impl_serde::serialize as serde_hex;
 
 #[cfg(feature = "derive")]
 use scale_info::{
-    form::{
-        FormString,
-        PortableForm,
-    },
+    form::PortableForm,
     IntoPortable as _,
     PortableRegistry,
     Registry,
 };
 use serde::{
-    de::DeserializeOwned,
     Deserialize,
     Serialize,
 };
 
 /// An entire ink! project for metadata file generation purposes.
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(bound(deserialize = "S: DeserializeOwned"))]
-pub struct InkProject<S: FormString = &'static str> {
+pub struct InkProject {
     #[serde(flatten)]
-    registry: PortableRegistry<S>,
+    registry: PortableRegistry,
     #[serde(rename = "storage")]
     /// The layout of the storage data structure
-    layout: layout::Layout<PortableForm<S>>,
-    spec: ContractSpec<PortableForm<S>>,
+    layout: layout::Layout<PortableForm>,
+    spec: ContractSpec<PortableForm>,
 }
 
 impl InkProject {
@@ -89,22 +84,19 @@ impl InkProject {
     }
 }
 
-impl<S> InkProject<S>
-where
-    S: FormString,
-{
+impl InkProject {
     /// Returns a read-only registry of types in the contract.
-    pub fn registry(&self) -> &PortableRegistry<S> {
+    pub fn registry(&self) -> &PortableRegistry {
         &self.registry
     }
 
     /// Returns the storage layout of the contract.
-    pub fn layout(&self) -> &layout::Layout<PortableForm<S>> {
+    pub fn layout(&self) -> &layout::Layout<PortableForm> {
         &self.layout
     }
 
     /// Returns the specification of the contract.
-    pub fn spec(&self) -> &ContractSpec<PortableForm<S>> {
+    pub fn spec(&self) -> &ContractSpec<PortableForm> {
         &self.spec
     }
 }

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -32,7 +32,7 @@ fn spec_constructor_selector_must_serialize_to_hex() {
 
     // when
     let json = serde_json::to_value(&portable_spec).unwrap();
-    let deserialized: ConstructorSpec<PortableForm<String>> =
+    let deserialized: ConstructorSpec<PortableForm> =
         serde_json::from_value(json.clone()).unwrap();
 
     // then
@@ -183,7 +183,7 @@ fn trim_docs() {
 
     // when
     let json = serde_json::to_value(&compact_spec).unwrap();
-    let deserialized: ConstructorSpec<PortableForm<String>> =
+    let deserialized: ConstructorSpec<PortableForm> =
         serde_json::from_value(json.clone()).unwrap();
 
     // then

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -18,7 +18,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 ink_prelude = { version = "3.0.0-rc2", path = "../prelude/", default-features = false }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive", "full"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [dev-dependencies]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -18,7 +18,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 ink_prelude = { version = "3.0.0-rc2", path = "../prelude/", default-features = false }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive", "full"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [dev-dependencies]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -18,7 +18,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 ink_prelude = { version = "3.0.0-rc2", path = "../prelude/", default-features = false }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive", "full"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [dev-dependencies]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -23,7 +23,7 @@ ink_prelude = { version = "3.0.0-rc2", path = "../prelude/", default-features = 
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1.0"
 array-init = "1.0"
 generic-array = "0.14.1"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -23,7 +23,7 @@ ink_prelude = { version = "3.0.0-rc2", path = "../prelude/", default-features = 
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1.0"
 array-init = "1.0"
 generic-array = "0.14.1"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -23,7 +23,7 @@ ink_prelude = { version = "3.0.0-rc2", path = "../prelude/", default-features = 
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1.0"
 array-init = "1.0"
 generic-array = "0.14.1"

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc1", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc1", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc1", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc1", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc1", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc1", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc1", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc1", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc1", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc1", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc1", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc1", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -16,7 +16,7 @@ scale = { package = "parity-scale-codec", version = "2.0", default-features = fa
 adder = { version = "3.0.0-rc2", path = "adder", default-features = false, features = ["ink-as-dependency"] }
 subber = { version = "3.0.0-rc2", path = "subber", default-features = false, features = ["ink-as-dependency"] }
 accumulator = { version = "3.0.0-rc2", path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "delegator"

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -16,7 +16,7 @@ scale = { package = "parity-scale-codec", version = "2.0", default-features = fa
 adder = { version = "3.0.0-rc2", path = "adder", default-features = false, features = ["ink-as-dependency"] }
 subber = { version = "3.0.0-rc2", path = "subber", default-features = false, features = ["ink-as-dependency"] }
 accumulator = { version = "3.0.0-rc2", path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "delegator"

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -16,7 +16,7 @@ scale = { package = "parity-scale-codec", version = "2.0", default-features = fa
 adder = { version = "3.0.0-rc2", path = "adder", default-features = false, features = ["ink-as-dependency"] }
 subber = { version = "3.0.0-rc2", path = "subber", default-features = false, features = ["ink-as-dependency"] }
 accumulator = { version = "3.0.0-rc2", path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "delegator"

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../../crates/storage", default
 ink_lang = { version = "3.0.0-rc2", path = "../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../../crates/storage", default
 ink_lang = { version = "3.0.0-rc2", path = "../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../../crates/storage", default
 ink_lang = { version = "3.0.0-rc2", path = "../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -14,7 +14,7 @@ ink_lang = { version = "3.0.0-rc2", path = "../../../crates/lang", default-featu
 accumulator = { version = "3.0.0-rc2", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -14,7 +14,7 @@ ink_lang = { version = "3.0.0-rc2", path = "../../../crates/lang", default-featu
 accumulator = { version = "3.0.0-rc2", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -14,7 +14,7 @@ ink_lang = { version = "3.0.0-rc2", path = "../../../crates/lang", default-featu
 accumulator = { version = "3.0.0-rc2", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -14,7 +14,7 @@ ink_lang = { version = "3.0.0-rc2", path = "../../../crates/lang", default-featu
 accumulator = { version = "3.0.0-rc2", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -14,7 +14,7 @@ ink_lang = { version = "3.0.0-rc2", path = "../../../crates/lang", default-featu
 accumulator = { version = "3.0.0-rc2", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -14,7 +14,7 @@ ink_lang = { version = "3.0.0-rc2", path = "../../../crates/lang", default-featu
 accumulator = { version = "3.0.0-rc2", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/multisig_plain/Cargo.toml
+++ b/examples/multisig_plain/Cargo.toml
@@ -13,7 +13,7 @@ ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features
 ink_prelude = { version = "3.0.0-rc2", path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/multisig_plain/Cargo.toml
+++ b/examples/multisig_plain/Cargo.toml
@@ -13,7 +13,7 @@ ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features
 ink_prelude = { version = "3.0.0-rc2", path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/multisig_plain/Cargo.toml
+++ b/examples/multisig_plain/Cargo.toml
@@ -13,7 +13,7 @@ ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features
 ink_prelude = { version = "3.0.0-rc2", path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { path = "../../crates/storage", default-features = false }
 ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "rand_extension"

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { path = "../../crates/storage", default-features = false }
 ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "rand_extension"

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { path = "../../crates/storage", default-features = false }
 ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "rand_extension"

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 
 [lib]

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "flipper"

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
+scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "flipper"

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc2", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { git = "https://github.com/paritytech/scale-info", branch = "aj-decode-feature", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "flipper"


### PR DESCRIPTION
Removes the parameterization of scale-info strings, as originally suggested https://github.com/paritytech/ink/pull/663#issuecomment-769027344, and further discussed in https://github.com/paritytech/scale-info/issues/58

Temporarily using branch from https://github.com/paritytech/scale-info/pull/59. Once that is merged and included in a new `scale-info` release I will update this PR and mark it ready for review.