### PR TITLE
Build `.contract` bundles for delegator sub-contracts

### DIFF
--- a/examples/delegator/README.md
+++ b/examples/delegator/README.md
@@ -11,16 +11,11 @@ It consists in total of 4 different smart contract:
 
 In order to test this bundle of smart contracts you need to do the following:
 
-1. Compile all dependencies of the Delegator smart contract using the `./build-all.sh` script.
-   As usual you will receive their respective Wasm blobs in their respective `target` folders.
-   For the delegator (the root of the example) you will additionally get the smart contract as
-   `delegator.contract` in the `target` folder. This file contains the contracts ABI (i.e.
-   metadata) bundled together with its Wasm blob.
-   Note: You won't need a `.contract` file for the other smart contracts `adder`, `subber` and
-         `accumulator`, since we won't operate on them using the Polkadot UI.
-1. Put the Wasm blobs of Accumulator, Adder, Subber and the Delegator on the chain via `put_code` command.
-   While doing so note down their respective code hashes that you can inspect by extracting this information
-   out from the signalling events upon putting the code on the chain.
+1. Compile all contracts using the `./build-all.sh` script.
+   You will receive the respective `.contract` bundles for all the smart contracts in the `target/ink/` folder.
+1. Upload the `.contract` bundle of Accumulator, Adder, Subber and the Delegator to the chain.
+   While doing so note down their respective code hashes. You will see the contract hash on the success page
+   (or success event) after having uploaded the contract to the chain.
 1. Instantiate the Delegator smart contract given all of the code hashes and a starting value.
    The Delegator smart contract will take over the work of instantiating the other smart contracts for you.
 1. Now you are able to run the operations provided by the Delegator smart contract.

--- a/examples/delegator/build-all.sh
+++ b/examples/delegator/build-all.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-pushd accumulator && cargo +nightly contract build && popd &&
-pushd adder && cargo +nightly contract build && popd &&
-pushd subber && cargo +nightly contract build && popd &&
-cargo +nightly contract build
+cargo +nightly contract build --manifest-path accumulator/Cargo.toml
+cargo +nightly contract build --manifest-path adder/Cargo.toml
+cargo +nightly contract build --manifest-path subber/Cargo.toml
+cargo +nightly contract build --manifest-path Cargo.toml

--- a/examples/delegator/build-all.sh
+++ b/examples/delegator/build-all.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-pushd accumulator && cargo +nightly contract build --generate code-only && popd &&
-pushd adder && cargo +nightly contract build --generate code-only && popd &&
-pushd subber && cargo +nightly contract build --generate code-only && popd &&
+pushd accumulator && cargo +nightly contract build && popd &&
+pushd adder && cargo +nightly contract build && popd &&
+pushd subber && cargo +nightly contract build && popd &&
 cargo +nightly contract build

--- a/examples/delegator/build-all.sh
+++ b/examples/delegator/build-all.sh
@@ -5,4 +5,4 @@ set -eu
 cargo +nightly contract build --manifest-path accumulator/Cargo.toml
 cargo +nightly contract build --manifest-path adder/Cargo.toml
 cargo +nightly contract build --manifest-path subber/Cargo.toml
-cargo +nightly contract build --manifest-path Cargo.toml
+cargo +nightly contract build


### PR DESCRIPTION
Closes https://github.com/paritytech/ink/issues/684.

We have merged https://github.com/paritytech/cargo-contract/pull/174 now, thus enabling building `.contract` for sub-contracts.

CI fails for this PR because we haven't merged https://github.com/paritytech/ink/pull/686 yet.