### PR TITLE
Fix `clippy::upper-case-acronyms`

### DIFF
--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -411,7 +411,7 @@ impl Dispatch<'_> {
     /// ## Example
     ///
     /// Given prefix of `"Message"` and selector with bytes `0xDEADBEEF` we
-    /// generate the following idenfitier: `__ink_Message_0xDEADBEEF`
+    /// generate the following idenfitier: `__ink_Message_0xdeadbeef`
     ///
     /// This way it is clear that this is an ink! generated identifier and even
     /// encodes the unique selector bytes to make the identifier unique.
@@ -428,7 +428,7 @@ impl Dispatch<'_> {
             ir::CallableKind::Constructor => "Constructor",
         };
         quote::format_ident!(
-            "__ink_{}_0x{:02X}{:02X}{:02X}{:02X}",
+            "__ink_{}_0x{:02x}{:02x}{:02x}{:02x}",
             prefix,
             selector_bytes[0],
             selector_bytes[1],

--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -411,7 +411,7 @@ impl Dispatch<'_> {
     /// ## Example
     ///
     /// Given prefix of `"Message"` and selector with bytes `0xDEADBEEF` we
-    /// generate the following idenfitier: `__ink_Message_0xdeadbeef`
+    /// generate the following identifier: `__ink_Message_0xdeadbeef`
     ///
     /// This way it is clear that this is an ink! generated identifier and even
     /// encodes the unique selector bytes to make the identifier unique.

--- a/crates/storage/src/test_utils.rs
+++ b/crates/storage/src/test_utils.rs
@@ -200,6 +200,7 @@ macro_rules! fuzz_storage {
 }
 
 /// Asserts that the storage is empty, without any leftovers.
+#[cfg(test)]
 pub fn assert_storage_clean() {
     let contract_id =
         ink_env::test::get_current_contract_account_id::<ink_env::DefaultEnvironment>()


### PR DESCRIPTION
Currently clippy breaks on master due to
```
error: name `__ink_Message_0x17FEB370` contains a capitalized acronym
  --> lib.rs:23:1
   |
23 | #[ink::contract]
   | ^^^^^^^^^^^^^^^^
   |
   = note: `-D clippy::upper-case-acronyms` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
error: name `__ink_Constructor_0x9BAE9D5E` contains a capitalized acronym
  --> lib.rs:23:1
   |
23 | #[ink::contract]
   | ^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
error: aborting due to 2 previous errors
error: could not compile `contract_terminate`
```