### PR TITLE
Fix clippy error: Manual implementation of `Option::map`

### DIFF
--- a/crates/storage/src/lazy/lazy_array.rs
+++ b/crates/storage/src/lazy/lazy_array.rs
@@ -103,12 +103,12 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map()
-            .entries(self.0.iter().enumerate().filter_map(|(key, entry)| {
-                match entry {
-                    Some(entry) => Some((key, entry)),
-                    None => None,
-                }
-            }))
+            .entries(
+                self.0
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(key, entry)| entry.as_ref().map(|entry| (key, entry))),
+            )
             .finish()
     }
 }


### PR DESCRIPTION
This the latest merge from https://github.com/paritytech/scripts/ fails building a new container due to our master being broken with this clippy error.