### PR TITLE
Fix execution context parameters in DNS example

### DIFF
--- a/examples/dns/lib.rs
+++ b/examples/dns/lib.rs
@@ -20,7 +20,9 @@ use ink_lang as ink;
 mod dns {
     #[cfg(not(feature = "ink-as-dependency"))]
     use ink_storage::{
-        collections::hashmap::Entry, collections::HashMap as StorageHashMap, lazy::Lazy,
+        collections::hashmap::Entry,
+        collections::HashMap as StorageHashMap,
+        lazy::Lazy,
     };
 
     /// Emitted whenever a new name is being registered.
@@ -123,7 +125,7 @@ mod dns {
             let caller = self.env().caller();
             let owner = self.get_owner_or_default(name);
             if caller != owner {
-                return Err(Error::CallerIsNotOwner);
+                return Err(Error::CallerIsNotOwner)
             }
             let old_address = self.name_to_address.insert(name, new_address);
             self.env().emit_event(SetAddress {
@@ -141,7 +143,7 @@ mod dns {
             let caller = self.env().caller();
             let owner = self.get_owner_or_default(name);
             if caller != owner {
-                return Err(Error::CallerIsNotOwner);
+                return Err(Error::CallerIsNotOwner)
             }
             let old_owner = self.name_to_owner.insert(name, to);
             self.env().emit_event(Transfer {

--- a/examples/dns/lib.rs
+++ b/examples/dns/lib.rs
@@ -20,9 +20,7 @@ use ink_lang as ink;
 mod dns {
     #[cfg(not(feature = "ink-as-dependency"))]
     use ink_storage::{
-        collections::hashmap::Entry,
-        collections::HashMap as StorageHashMap,
-        lazy::Lazy,
+        collections::hashmap::Entry, collections::HashMap as StorageHashMap, lazy::Lazy,
     };
 
     /// Emitted whenever a new name is being registered.
@@ -125,7 +123,7 @@ mod dns {
             let caller = self.env().caller();
             let owner = self.get_owner_or_default(name);
             if caller != owner {
-                return Err(Error::CallerIsNotOwner)
+                return Err(Error::CallerIsNotOwner);
             }
             let old_address = self.name_to_address.insert(name, new_address);
             self.env().emit_event(SetAddress {
@@ -143,7 +141,7 @@ mod dns {
             let caller = self.env().caller();
             let owner = self.get_owner_or_default(name);
             if caller != owner {
-                return Err(Error::CallerIsNotOwner)
+                return Err(Error::CallerIsNotOwner);
             }
             let old_owner = self.name_to_owner.insert(name, to);
             self.env().emit_event(Transfer {
@@ -197,8 +195,8 @@ mod dns {
             ink_env::test::push_execution_context::<ink_env::DefaultEnvironment>(
                 caller,
                 AccountId::from(DEFAULT_CALLEE_HASH),
-                DEFAULT_ENDOWMENT,
                 DEFAULT_GAS_LIMIT,
+                DEFAULT_ENDOWMENT,
                 ink_env::test::CallData::new(ink_env::call::Selector::new([0x00; 4])),
             )
         }


### PR DESCRIPTION
- Endowment and gas limit were flipped, which confused me when I used as reference, so figured I'd fix

I automatically format, so if you want me to keep the changes minimal and revert those, let me know :)