### PR TITLE
Revert me: Disable clippy for `rand-extension` example

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,7 +243,7 @@ examples-clippy-std:
   script:
     # Revert as soon as the clippy nightly ice fix lands
     - for example in examples/*/; do
-        if [ "$example" != "rand-extension" ]; then
+        if [ "$example" != "examples/rand-extension/" ]; then
             cargo clippy --verbose --manifest-path ${example}/Cargo.toml -- -D warnings;
         fi
       done
@@ -254,7 +254,7 @@ examples-clippy-wasm:
   script:
     # Revert as soon as the clippy nightly ice fix lands
     - for example in examples/*/; do
-        if [ "$example" != "rand-extension" ]; then
+        if [ "$example" != "examples/rand-extension/" ]; then
             cargo clippy --verbose --manifest-path ${example}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
         fi
       done


### PR DESCRIPTION
In https://github.com/paritytech/ink/pull/719 I attempted to disable clippy for this example, the CI ran through on the branch, but fails on `master`. This is not the first time that I have the impression that our CI behaves differently on branches than on `master`.

@TriplEight Do you have an idea what could cause a different CI behavior on `master` vs. on PRs?

The example was not actually excluded, as can be seen on the current `master` run. This PR excludes it for real.