### PR TITLE
Enum support no struct

### DIFF
--- a/crates/metadata/src/layout/mod.rs
+++ b/crates/metadata/src/layout/mod.rs
@@ -17,30 +17,16 @@ mod tests;
 
 use crate::{
     serde_hex,
-    utils::{
-        deserialize_from_byte_str,
-        serialize_as_byte_str,
-    },
+    utils::{deserialize_from_byte_str, serialize_as_byte_str},
 };
 use derive_more::From;
 use ink_prelude::collections::btree_map::BTreeMap;
 use ink_primitives::Key;
 use scale_info::{
-    form::{
-        Form,
-        MetaForm,
-        PortableForm,
-    },
-    meta_type,
-    IntoPortable,
-    Registry,
-    TypeInfo,
+    form::{Form, MetaForm, PortableForm},
+    meta_type, IntoPortable, Registry, TypeInfo,
 };
-use serde::{
-    de::DeserializeOwned,
-    Deserialize,
-    Serialize,
-};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// Represents the static storage layout of an ink! smart contract.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, From, Serialize, Deserialize)]
@@ -535,7 +521,7 @@ pub struct EnumLayout<F: Form = MetaForm> {
     /// The key where the discriminant is stored to dispatch the variants.
     dispatch_key: LayoutKey,
     /// The variants of the enum.
-    variants: BTreeMap<Discriminant, StructLayout<F>>,
+    variants: BTreeMap<Discriminant, Layout<F>>,
 }
 
 impl EnumLayout {
@@ -543,7 +529,7 @@ impl EnumLayout {
     pub fn new<K, V>(dispatch_key: K, variants: V) -> Self
     where
         K: Into<LayoutKey>,
-        V: IntoIterator<Item = (Discriminant, StructLayout)>,
+        V: IntoIterator<Item = (Discriminant, Layout)>,
     {
         Self {
             dispatch_key: dispatch_key.into(),
@@ -562,7 +548,7 @@ where
     }
 
     /// Returns the variants of the enum.
-    pub fn variants(&self) -> &BTreeMap<Discriminant, StructLayout<F>> {
+    pub fn variants(&self) -> &BTreeMap<Discriminant, Layout<F>> {
         &self.variants
     }
 }

--- a/crates/metadata/src/layout/tests.rs
+++ b/crates/metadata/src/layout/tests.rs
@@ -144,9 +144,9 @@ fn clike_enum_layout(key_ptr: &mut KeyPtr) -> Layout {
     EnumLayout::new(
         key_ptr.advance_by(1),
         vec![
-            (Discriminant(0), StructLayout::new(vec![])),
-            (Discriminant(1), StructLayout::new(vec![])),
-            (Discriminant(2), StructLayout::new(vec![])),
+            (Discriminant(0), Layout::Struct(StructLayout::new(vec![]))),
+            (Discriminant(1), Layout::Struct(StructLayout::new(vec![]))),
+            (Discriminant(2), Layout::Struct(StructLayout::new(vec![]))),
         ],
     )
     .into()
@@ -168,13 +168,19 @@ fn clike_enum_work() {
                     0000000000000000",
                 "variants": {
                     "0": {
-                        "fields": [],
+                      "struct": {
+                       "fields": [],
+                      } ,
                     },
                     "1": {
-                        "fields": [],
+                        "struct": {
+                       "fields": [],
+                      } ,
                     },
                     "2": {
-                        "fields": [],
+                        "struct": {
+                       "fields": [],
+                      } ,
                     },
                 }
             }
@@ -187,12 +193,12 @@ fn mixed_enum_layout(key_ptr: &mut KeyPtr) -> Layout {
     EnumLayout::new(
         *key_ptr.advance_by(1),
         vec![
-            (Discriminant(0), StructLayout::new(vec![])),
+            (Discriminant(0), Layout::Struct(StructLayout::new(vec![]))),
             {
                 let mut variant_key_ptr = key_ptr.clone();
                 (
                     Discriminant(1),
-                    StructLayout::new(vec![
+                    Layout::Struct(StructLayout::new(vec![
                         FieldLayout::new(
                             None,
                             CellLayout::new::<i32>(LayoutKey::from(
@@ -205,14 +211,14 @@ fn mixed_enum_layout(key_ptr: &mut KeyPtr) -> Layout {
                                 variant_key_ptr.advance_by(1),
                             )),
                         ),
-                    ]),
+                    ])),
                 )
             },
             {
                 let mut variant_key_ptr = key_ptr.clone();
                 (
                     Discriminant(2),
-                    StructLayout::new(vec![
+                    Layout::Struct(StructLayout::new(vec![
                         FieldLayout::new(
                             "a",
                             CellLayout::new::<i32>(LayoutKey::from(
@@ -225,7 +231,7 @@ fn mixed_enum_layout(key_ptr: &mut KeyPtr) -> Layout {
                                 variant_key_ptr.advance_by(1),
                             )),
                         ),
-                    ]),
+                    ])),
                 )
             },
         ],
@@ -249,67 +255,73 @@ fn mixed_enum_work() {
                     0000000000000000",
                 "variants": {
                     "0": {
-                        "fields": [],
+                        "struct": {
+                            "fields": []
+                        },
                     },
                     "1": {
-                        "fields": [
-                            {
-                                "layout": {
-                                    "cell": {
-                                        "key": "0x\
-                                            0100000000000000\
-                                            0000000000000000\
-                                            0000000000000000\
-                                            0000000000000000",
-                                        "ty": 1,
-                                    }
+                        "struct": {
+                             "fields": [
+                                {
+                                    "layout": {
+                                        "cell": {
+                                            "key": "0x\
+                                                0100000000000000\
+                                                0000000000000000\
+                                                0000000000000000\
+                                                0000000000000000",
+                                            "ty": 1,
+                                        }
+                                    },
+                                    "name": null,
                                 },
-                                "name": null,
-                            },
-                            {
-                                "layout": {
-                                    "cell": {
-                                        "key": "0x\
-                                            0200000000000000\
-                                            0000000000000000\
-                                            0000000000000000\
-                                            0000000000000000",
-                                        "ty": 2,
-                                    }
-                                },
-                                "name": null,
-                            }
-                        ],
+                                {
+                                    "layout": {
+                                        "cell": {
+                                            "key": "0x\
+                                                0200000000000000\
+                                                0000000000000000\
+                                                0000000000000000\
+                                                0000000000000000",
+                                            "ty": 2,
+                                        }
+                                    },
+                                    "name": null,
+                                }
+                            ],
+                        }
                     },
                     "2": {
-                        "fields": [
-                            {
-                                "layout": {
-                                    "cell": {
-                                        "key": "0x\
-                                            0100000000000000\
-                                            0000000000000000\
-                                            0000000000000000\
-                                            0000000000000000",
-                                        "ty": 1,
-                                    }
+                        "struct": {
+                            "fields": [
+                                {
+                                    "layout": {
+                                        "cell": {
+                                            "key": "0x\
+                                                0100000000000000\
+                                                0000000000000000\
+                                                0000000000000000\
+                                                0000000000000000",
+                                            "ty": 1,
+                                        }
+                                    },
+                                    "name": "a",
                                 },
-                                "name": "a",
-                            },
-                            {
-                                "layout": {
-                                    "cell": {
-                                        "key": "0x\
-                                            0200000000000000\
-                                            0000000000000000\
-                                            0000000000000000\
-                                            0000000000000000",
-                                        "ty": 2,
-                                    }
-                                },
-                                "name": "b",
-                            }
-                        ],
+                                {
+                                    "layout": {
+                                        "cell": {
+                                            "key": "0x\
+                                                0200000000000000\
+                                                0000000000000000\
+                                                0000000000000000\
+                                                0000000000000000",
+                                            "ty": 2,
+                                        }
+                                    },
+                                    "name": "b",
+                                }
+                            ],
+                        }
                     },
                 }
             }

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -25,37 +25,17 @@ mod specs;
 mod utils;
 
 pub use self::specs::{
-    ConstructorSpec,
-    ConstructorSpecBuilder,
-    ContractSpec,
-    ContractSpecBuilder,
-    DisplayName,
-    EventParamSpec,
-    EventParamSpecBuilder,
-    EventSpec,
-    EventSpecBuilder,
-    MessageParamSpec,
-    MessageParamSpecBuilder,
-    MessageSpec,
-    MessageSpecBuilder,
-    ReturnTypeSpec,
-    Selector,
-    TypeSpec,
+    ConstructorSpec, ConstructorSpecBuilder, ContractSpec, ContractSpecBuilder,
+    DisplayName, EventParamSpec, EventParamSpecBuilder, EventSpec, EventSpecBuilder,
+    MessageParamSpec, MessageParamSpecBuilder, MessageSpec, MessageSpecBuilder,
+    ReturnTypeSpec, Selector, TypeSpec,
 };
 
 use impl_serde::serialize as serde_hex;
 
 #[cfg(feature = "derive")]
-use scale_info::{
-    form::PortableForm,
-    IntoPortable as _,
-    PortableRegistry,
-    Registry,
-};
-use serde::{
-    Deserialize,
-    Serialize,
-};
+use scale_info::{form::PortableForm, IntoPortable as _, PortableRegistry, Registry};
+use serde::{Deserialize, Serialize};
 
 /// An entire ink! project for metadata file generation purposes.
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -1011,7 +1011,6 @@ impl EventParamSpecBuilder {
     deserialize = "F::Type: DeserializeOwned, F::String: DeserializeOwned"
 ))]
 pub struct ReturnTypeSpec<F: Form = MetaForm> {
-    #[serde(rename = "type")]
     opt_type: Option<TypeSpec<F>>,
 }
 

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -16,28 +16,13 @@
 
 use crate::serde_hex;
 #[cfg(not(feature = "std"))]
-use alloc::{
-    format,
-    vec,
-    vec::Vec,
-};
+use alloc::{format, vec, vec::Vec};
 use core::marker::PhantomData;
 use scale_info::{
-    form::{
-        Form,
-        MetaForm,
-        PortableForm,
-    },
-    meta_type,
-    IntoPortable,
-    Registry,
-    TypeInfo,
+    form::{Form, MetaForm, PortableForm},
+    meta_type, IntoPortable, Registry, TypeInfo,
 };
-use serde::{
-    de::DeserializeOwned,
-    Deserialize,
-    Serialize,
-};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// Describes a contract.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -14,10 +14,7 @@
 
 use super::*;
 use pretty_assertions::assert_eq;
-use scale_info::{
-    IntoPortable,
-    Registry,
-};
+use scale_info::{IntoPortable, Registry};
 use serde_json::json;
 
 #[test]


### PR DESCRIPTION
The enum should support other layouts. What do you think about this?
This PR made incompatible changes to metadata.

BTW, Why use two styles of naming and organization for `storage` and `types` fields?