### PR TITLE
CI: do not run spellcheck when pipeline is triggered

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,6 +144,9 @@ docs:
 spellcheck:
     stage:                           workspace
     <<:                              *docker-env
+    rules:
+      - if: $CI_PIPELINE_SOURCE == "pipeline"
+        when: never
     script:
         - cargo spellcheck check --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1
 


### PR DESCRIPTION
To avoid [this kind](https://gitlab.parity.io/parity/ink/-/pipelines/129685) of fails