### PR TITLE
Remove `ink-unstable` feature

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -56,7 +56,6 @@ std = [
     "scale-info/std",
 ]
 ink-fuzz-tests = ["std"]
-ink-unstable = ["std"]
 
 [[bench]]
 name = "bench_lazy"

--- a/crates/storage/src/collections/mod.rs
+++ b/crates/storage/src/collections/mod.rs
@@ -22,7 +22,6 @@ pub mod binary_heap;
 pub mod bitstash;
 pub mod bitvec;
 pub mod hashmap;
-#[cfg(feature = "ink-unstable")]
 pub mod smallvec;
 pub mod stash;
 pub mod vec;
@@ -37,7 +36,6 @@ pub use self::{
     vec::Vec,
 };
 
-#[cfg(feature = "ink-unstable")]
 #[doc(inline)]
 pub use self::smallvec::SmallVec;
 

--- a/crates/storage/src/collections/smallvec/storage.rs
+++ b/crates/storage/src/collections/smallvec/storage.rs
@@ -21,7 +21,6 @@ use crate::traits::{
 
 #[cfg(feature = "std")]
 const _: () = {
-    #[cfg(feature = "ink-unstable")]
     use crate::lazy::LazyArray;
     use crate::traits::StorageLayout;
     use ink_metadata::layout::{

--- a/crates/storage/src/collections/smallvec/storage.rs
+++ b/crates/storage/src/collections/smallvec/storage.rs
@@ -21,8 +21,10 @@ use crate::traits::{
 
 #[cfg(feature = "std")]
 const _: () = {
-    use crate::lazy::LazyArray;
-    use crate::traits::StorageLayout;
+    use crate::{
+        lazy::LazyArray,
+        traits::StorageLayout,
+    };
     use ink_metadata::layout::{
         FieldLayout,
         Layout,

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -28,12 +28,10 @@ pub mod lazy_hmap;
 
 mod cache_cell;
 mod entry;
-#[cfg(feature = "ink-unstable")]
 mod lazy_array;
 mod lazy_cell;
 mod lazy_imap;
 
-#[cfg(feature = "ink-unstable")]
 #[doc(inline)]
 pub use self::lazy_array::LazyArray;
 use self::{


### PR DESCRIPTION
No longer necessary, since Rust 1.51.1 has just been released.