### PR TITLE
Upgrade to `array-init` 2.0

### DIFF
--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -25,7 +25,7 @@ scale = { package = "parity-scale-codec", version = "2.0", default-features = fa
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1.0"
-array-init = { version = "1.0", default-features = false, features = ["const-generics"] }
+array-init = { version = "2.0", default-features = false }
 
 # Workaround: we actually just need criterion as a dev-dependency, but
 # there is an issue with a doubly included std lib when executing

--- a/crates/storage/src/traits/impls/arrays.rs
+++ b/crates/storage/src/traits/impls/arrays.rs
@@ -55,7 +55,7 @@ macro_rules! impl_layout_for_array {
                 }
 
                 fn pull_spread(ptr: &mut KeyPtr) -> Self {
-                    array_init::<Self, _>(|_| <T as SpreadLayout>::pull_spread(ptr))
+                    array_init::<_, T, $len>(|_| <T as SpreadLayout>::pull_spread(ptr))
                 }
             }
 


### PR DESCRIPTION
The function signaure for `array_init()` changed:

```
- pub fn array_init<Array, F>(mut initializer: F) -> Array
+ pub fn array_init<F, T, const N: usize>(mut initializer: F) -> [T; N]
```

See https://github.com/Manishearth/array-init/commit/723f80e0c2a3c89cf02e8f9bab80babad0ca6d55.