### PR TITLE
Build entire `delegator` example in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -273,6 +273,13 @@ examples-contract-build:
         popd;
       done
 
+examples-contract-build-delegator:
+    stage:                           examples
+    <<:                              *docker-env
+    script:
+        - cargo contract -V
+        - cd examples/delegator/ && ./build-all.sh
+
 examples-docs:
     stage:                           examples
     <<:                              *docker-env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ variables:
   # this var is changed to "-:staging" when the CI image gets rebuilt
   # read more https://github.com/paritytech/scripts/pull/244
   ALL_CRATES:                      "${PURELY_STD_CRATES} ${ALSO_WASM_CRATES}"
-  DELEGATOR_SUBCONTRACTS:           ("accumulator" "adder" "subber")
+  DELEGATOR_SUBCONTRACTS:           "accumulator adder subber"
 
 workflow:
   rules:
@@ -235,7 +235,7 @@ examples-test:
     - for example in examples/*/; do
         cargo test --verbose --manifest-path ${example}/Cargo.toml;
       done
-    - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+    - for contract in ${DELEGATOR_SUBCONTRACTS}; do
         cargo test --verbose --manifest-path ${contract}/Cargo.toml;
       done
 
@@ -246,7 +246,7 @@ examples-fmt:
     - for example in examples/*/; do
         cargo fmt --verbose --manifest-path ${example}/Cargo.toml -- --check;
       done
-    - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+    - for contract in ${DELEGATOR_SUBCONTRACTS}; do
         cargo fmt --verbose --manifest-path ${contract}/Cargo.toml -- --check;
       done
 
@@ -260,7 +260,7 @@ examples-clippy-std:
     - for example in examples/*/; do
         cargo clippy --verbose --manifest-path ${example}/Cargo.toml -- -D warnings;
       done
-    - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+    - for contract in ${DELEGATOR_SUBCONTRACTS}; do
         cargo clippy --verbose --manifest-path ${contract}/Cargo.toml -- -D warnings;
       done
 
@@ -271,7 +271,7 @@ examples-clippy-wasm:
     - for example in examples/*/; do
         cargo clippy --verbose --manifest-path ${example}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
       done
-    - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+    - for contract in ${DELEGATOR_SUBCONTRACTS}; do
         cargo clippy --verbose --manifest-path ${contract}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
       done
 
@@ -285,7 +285,7 @@ examples-contract-build:
         cargo contract build &&
         popd;
       done
-    - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+    - for contract in ${DELEGATOR_SUBCONTRACTS}; do
         pushd $contract &&
         cargo contract build &&
         popd;
@@ -311,7 +311,7 @@ examples-docs:
         - for example in examples/*/; do
             cargo doc --manifest-path ${example}/Cargo.toml --document-private-items --verbose --no-deps;
           done
-        - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+        - for contract in ${DELEGATOR_SUBCONTRACTS}; do
             cargo doc --manifest-path ${contract}/Cargo.toml --document-private-items --verbose --no-deps;
           done
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -273,12 +273,20 @@ examples-contract-build:
         popd;
       done
 
-examples-contract-build-delegator:
+examples-contract-test-entire-delegator:
     stage:                           examples
     <<:                              *docker-env
     script:
         - cargo contract -V
-        - cd examples/delegator/ && ./build-all.sh
+        - cd examples/delegator/
+        - SUBCONTRACTS=("accumulator" "adder" "subber")
+        - for contract in ${SUBCONTRACTS[*]}; do
+            cargo fmt --verbose --manifest-path ${contract}/Cargo.toml -- --check;
+            cargo clippy --verbose --manifest-path ${contract}/Cargo.toml -- -D warnings;
+            cargo clippy --verbose --manifest-path ${contract}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
+            cargo test --verbose --manifest-path ${contract}/Cargo.toml;
+          done
+        - ./build-all.sh
 
 examples-docs:
     stage:                           examples

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -236,7 +236,7 @@ examples-test:
         cargo test --verbose --manifest-path ${example}/Cargo.toml;
       done
     - for contract in ${DELEGATOR_SUBCONTRACTS}; do
-        cargo test --verbose --manifest-path ${contract}/Cargo.toml;
+        cargo test --verbose --manifest-path examples/delegator/${contract}/Cargo.toml;
       done
 
 examples-fmt:
@@ -247,7 +247,7 @@ examples-fmt:
         cargo fmt --verbose --manifest-path ${example}/Cargo.toml -- --check;
       done
     - for contract in ${DELEGATOR_SUBCONTRACTS}; do
-        cargo fmt --verbose --manifest-path ${contract}/Cargo.toml -- --check;
+        cargo fmt --verbose --manifest-path examples/delegator/${contract}/Cargo.toml -- --check;
       done
 
 examples-clippy-std:
@@ -261,7 +261,7 @@ examples-clippy-std:
         cargo clippy --verbose --manifest-path ${example}/Cargo.toml -- -D warnings;
       done
     - for contract in ${DELEGATOR_SUBCONTRACTS}; do
-        cargo clippy --verbose --manifest-path ${contract}/Cargo.toml -- -D warnings;
+        cargo clippy --verbose --manifest-path examples/delegator/${contract}/Cargo.toml -- -D warnings;
       done
 
 examples-clippy-wasm:
@@ -272,7 +272,7 @@ examples-clippy-wasm:
         cargo clippy --verbose --manifest-path ${example}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
       done
     - for contract in ${DELEGATOR_SUBCONTRACTS}; do
-        cargo clippy --verbose --manifest-path ${contract}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
+        cargo clippy --verbose --manifest-path examples/delegator/${contract}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
       done
 
 examples-contract-build:
@@ -286,7 +286,7 @@ examples-contract-build:
         popd;
       done
     - for contract in ${DELEGATOR_SUBCONTRACTS}; do
-        pushd $contract &&
+        pushd examples/delegator/$contract &&
         cargo contract build &&
         popd;
       done
@@ -312,7 +312,7 @@ examples-docs:
             cargo doc --manifest-path ${example}/Cargo.toml --document-private-items --verbose --no-deps;
           done
         - for contract in ${DELEGATOR_SUBCONTRACTS}; do
-            cargo doc --manifest-path ${contract}/Cargo.toml --document-private-items --verbose --no-deps;
+            cargo doc --manifest-path examples/delegator/${contract}/Cargo.toml --document-private-items --verbose --no-deps;
           done
 
 #### stage:                        publish

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ variables:
   # this var is changed to "-:staging" when the CI image gets rebuilt
   # read more https://github.com/paritytech/scripts/pull/244
   ALL_CRATES:                      "${PURELY_STD_CRATES} ${ALSO_WASM_CRATES}"
+  DELEGATOR_SUBCONTRACTS:           ("accumulator" "adder" "subber")
 
 workflow:
   rules:
@@ -234,6 +235,9 @@ examples-test:
     - for example in examples/*/; do
         cargo test --verbose --manifest-path ${example}/Cargo.toml;
       done
+    - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+        cargo test --verbose --manifest-path ${contract}/Cargo.toml;
+      done
 
 examples-fmt:
   stage:                           examples
@@ -241,6 +245,9 @@ examples-fmt:
   script:
     - for example in examples/*/; do
         cargo fmt --verbose --manifest-path ${example}/Cargo.toml -- --check;
+      done
+    - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+        cargo fmt --verbose --manifest-path ${contract}/Cargo.toml -- --check;
       done
 
 examples-clippy-std:
@@ -253,6 +260,9 @@ examples-clippy-std:
     - for example in examples/*/; do
         cargo clippy --verbose --manifest-path ${example}/Cargo.toml -- -D warnings;
       done
+    - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+        cargo clippy --verbose --manifest-path ${contract}/Cargo.toml -- -D warnings;
+      done
 
 examples-clippy-wasm:
   stage:                           examples
@@ -260,6 +270,9 @@ examples-clippy-wasm:
   script:
     - for example in examples/*/; do
         cargo clippy --verbose --manifest-path ${example}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
+      done
+    - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+        cargo clippy --verbose --manifest-path ${contract}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
       done
 
 examples-contract-build:
@@ -272,21 +285,18 @@ examples-contract-build:
         cargo contract build &&
         popd;
       done
+    - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+        pushd $contract &&
+        cargo contract build &&
+        popd;
+      done
 
-examples-contract-test-entire-delegator:
+examples-contract-build-delegator:
     stage:                           examples
     <<:                              *docker-env
     script:
         - cargo contract -V
-        - cd examples/delegator/
-        - SUBCONTRACTS=("accumulator" "adder" "subber")
-        - for contract in ${SUBCONTRACTS[*]}; do
-            cargo fmt --verbose --manifest-path ${contract}/Cargo.toml -- --check;
-            cargo clippy --verbose --manifest-path ${contract}/Cargo.toml -- -D warnings;
-            cargo clippy --verbose --manifest-path ${contract}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
-            cargo test --verbose --manifest-path ${contract}/Cargo.toml;
-          done
-        - ./build-all.sh
+        - cd examples/delegator/ && ./build-all.sh
 
 examples-docs:
     stage:                           examples
@@ -300,6 +310,9 @@ examples-docs:
         # of this flag.
         - for example in examples/*/; do
             cargo doc --manifest-path ${example}/Cargo.toml --document-private-items --verbose --no-deps;
+          done
+        - for contract in ${DELEGATOR_SUBCONTRACTS[*]}; do
+            cargo doc --manifest-path ${contract}/Cargo.toml --document-private-items --verbose --no-deps;
           done
 
 #### stage:                        publish


### PR DESCRIPTION
Just noticed that we don't test 
* building the `delegator` example
* the `delegator` sub-contracts