### PR TITLE
Migrate to `panic_any`

### DIFF
--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -278,7 +278,7 @@ impl EnvInstance {
             beneficiary,
             transferred: all,
         };
-        panic!("{:?}", scale::Encode::encode(&res));
+        std::panic::panic_any(scale::Encode::encode(&res));
     }
 }
 

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -422,17 +422,10 @@ pub fn assert_contract_termination<T, F>(
     let value_any = ::std::panic::catch_unwind(should_terminate)
         .expect_err("contract did not terminate");
     let encoded_input = value_any
-        .downcast_ref::<String>()
+        .downcast_ref::<Vec<u8>>()
         .expect("panic object can not be cast");
-    let deserialized_vec = encoded_input
-        .replace("[", "")
-        .replace("]", "")
-        .split(", ")
-        .map(|s| u8::from_str(s).expect("u8 cannot be extracted from str"))
-        .collect::<Vec<u8>>();
     let res: ContractTerminationResult<T> =
-        scale::Decode::decode(&mut &deserialized_vec[..])
-            .expect("input can not be decoded");
+        scale::Decode::decode(&mut &encoded_input[..]).expect("input can not be decoded");
 
     assert_eq!(res.beneficiary, expected_beneficiary);
     assert_eq!(res.transferred, expected_balance);

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -31,7 +31,7 @@ use crate::{
     Result,
 };
 use ink_prelude::string::String;
-use std::str::FromStr;
+use std::panic::UnwindSafe;
 
 /// Pushes a contract execution context.
 ///
@@ -390,9 +390,6 @@ where
     pub transferred: <E as Environment>::Balance,
 }
 
-#[cfg(feature = "std")]
-use std::panic::UnwindSafe;
-
 /// Tests if a contract terminates successfully after `self.env().terminate()`
 /// has been called.
 ///
@@ -408,7 +405,6 @@ use std::panic::UnwindSafe;
 /// ```
 ///
 /// See `examples/contract-terminate` for a complete usage example.
-#[cfg(feature = "std")]
 pub fn assert_contract_termination<T, F>(
     should_terminate: F,
     expected_beneficiary: T::AccountId,


### PR DESCRIPTION
Has been stabilized with 1.51.

Closes https://github.com/paritytech/ink/issues/696.