### PR TITLE
Fix `Greeter` and run documentation tests in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -376,7 +376,7 @@ fuzz-tests:
     <<:                              *docker-env
     variables:
         # The QUICKCHECK_TESTS default is 100
-        QUICKCHECK_TESTS:            40000
+        QUICKCHECK_TESTS:            20000
     rules:
         - if: $CI_PIPELINE_SOURCE == "schedule"
         - if: $CI_COMMIT_REF_NAME == "master"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,6 +141,7 @@ docs:
         -p ink_primitives -p ink_prelude
         -p ink_lang -p ink_lang_macro -p ink_lang_ir -p ink_lang_codegen
     - mv ${CARGO_TARGET_DIR}/doc ./crate-docs
+    - cargo test --doc --workspace
 
 spellcheck:
     stage:                           workspace

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,6 +122,7 @@ test:
       QUICKCHECK_TESTS:            0
   script:
     - cargo test --verbose --all-features --no-fail-fast --workspace
+    - cargo test --verbose --all-features --no-fail-fast --workspace --doc
 
 docs:
   stage:                           workspace
@@ -141,7 +142,6 @@ docs:
         -p ink_primitives -p ink_prelude
         -p ink_lang -p ink_lang_macro -p ink_lang_ir -p ink_lang_codegen
     - mv ${CARGO_TARGET_DIR}/doc ./crate-docs
-    - cargo test --doc --workspace
 
 spellcheck:
     stage:                           workspace

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -28,6 +28,7 @@ ink_metadata = { version = "3.0.0-rc3", path = "../../metadata/" }
 ink_env = { version = "3.0.0-rc3", path = "../../env/" }
 ink_storage = { version = "3.0.0-rc3", path = "../../storage/" }
 ink_lang = { version = "3.0.0-rc3", path = ".." }
+ink_prelude = { version = "3.0.0-rc3", path = "../../prelude/" }
 
 trybuild = "1.0.24"
 scale-info = { version = "0.6", default-features = false, features = ["derive"] }

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -412,7 +412,7 @@ use proc_macro::TokenStream;
 ///         }
 ///
 ///         #[ink(message, payable)]
-///         pub fn fund(&mut self) {
+///         pub fn fund(&self) {
 ///             let caller = self.env().caller();
 ///             let value = self.env().transferred_balance();
 ///             let message = format!("thanks for the funding of {:?} from {:?}", value, caller);

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -397,6 +397,8 @@ use proc_macro::TokenStream;
 /// #
 /// #[ink::contract]
 /// mod greeter {
+///     use ink_prelude::format;
+///
 ///     #[ink(storage)]
 ///     pub struct Greeter;
 ///


### PR DESCRIPTION
`Greeter` was not working in it's current stage.

Note that even though `cargo test --doc --workspace` improves our testing, it would still not have catched the `Greeter` error which this PR fixes.

I'll create follow-ups for `ink-docs` and the workshop, which are also missing `use ink_prelude::format`.