### PR TITLE
Enable dependabot for examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     directory: "/examples/"
     schedule:
         interval: "daily"
+
+  # `delegator` needs to be a separate stage, since it's a separate workspace.
+  - package-ecosystem: "cargo"
+    directory: "/examples/delegator/"
+    schedule:
+        interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/examples/"
+    schedule:
+        interval: "daily"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,5 @@
+# This workspace has just been created so that dependabot can
+# batch upgrades to the example dependencies into a single PR,
+# instead of multiple isolated ones.
+[workspace]
+members = ["./*"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,3 +3,6 @@
 # instead of multiple isolated ones.
 [workspace]
 members = ["./*"]
+exclude = [
+    "delegator",
+]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,5 +4,7 @@
 [workspace]
 members = ["./*"]
 exclude = [
+    # we need to exclude `delegator` since it's a separate workspace
+    # and nested workspaces are not allowed.
     "delegator",
 ]

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "trait-erc20"
+name = "trait_erc20"
 version = "3.0.0-rc3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -15,7 +15,7 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 [lib]
-name = "erc20"
+name = "trait_erc20"
 path = "lib.rs"
 crate-type = ["cdylib"]
 

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "erc20"
+name = "trait-erc20"
 version = "3.0.0-rc3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "flipper"
+name = "trait-flipper"
 version = "3.0.0-rc3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "trait-flipper"
+name = "trait_flipper"
 version = "3.0.0-rc3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -15,7 +15,7 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 [lib]
-name = "flipper"
+name = "trait_flipper"
 path = "lib.rs"
 crate-type = ["cdylib"]
 


### PR DESCRIPTION
Closes https://github.com/paritytech/ink/issues/772.

Unfortunately it will still create two PR's when upgrading a package in all examples: one for `delegator`, one for the rest. This is because `delegator` is its own, separate workspace. Still, IMHO it's an improvement over the status quo of not having dependabot for the examples at all.

Let's hope it doesn't go rogue this time 🤞.