### PR TITLE
Update `rand-extension` example

### DIFF
--- a/crates/storage/src/collections/bitvec/mod.rs
+++ b/crates/storage/src/collections/bitvec/mod.rs
@@ -268,7 +268,7 @@ impl Bitvec {
             if value {
                 // If `value` is `true` set its first bit to `1`.
                 bits256.set(0);
-                debug_assert_eq!(bits256.get(0), true);
+                debug_assert!(bits256.get(0));
             };
             self.bits.push(bits256);
             *self.len += 1;

--- a/examples/rand-extension/runtime/README.md
+++ b/examples/rand-extension/runtime/README.md
@@ -2,7 +2,7 @@
 
 To integrate this example into Substrate you need to do two things:
 
-* Use the code in `runtime/chain-extension-example.rs` as an implementation for
+* Use the code in [`chain-extension-example.rs`](./chain-extension-example.rs) as an implementation for
   the trait `ChainExtension` in Substrate.
   You can just copy/paste the content of that file into e.g. your `runtime/src/lib.rs`.
 

--- a/examples/rand-extension/runtime/README.md
+++ b/examples/rand-extension/runtime/README.md
@@ -1,4 +1,17 @@
 # Chain-side Extension
 
-Use this as an implementation of the trait `ChainExtension` in Substrate
-and use it as the associated type `ChainExtension` of the trait `pallet_contracts::Config`.
+To integrate this example into Substrate you need to do two things:
+
+* Use the code in `runtime/chain-extension-example.rs` as an implementation for
+  the trait `ChainExtension` in Substrate.
+  You can just copy/paste the content of that file into e.g. your `runtime/src/lib.rs`.
+
+* Use the implementation as the associated type `ChainExtension` of the trait
+  `pallet_contracts::Config`:
+  ```rust
+  impl pallet_contracts::Config for Runtime {
+    …
+    type ChainExtension = FetchRandomExtension;
+    …
+  }
+  ```

--- a/examples/rand-extension/runtime/chain-extension-example.rs
+++ b/examples/rand-extension/runtime/chain-extension-example.rs
@@ -1,39 +1,49 @@
-use codec::{Encode, Decode};
-
-use frame_support::debug::{error, native};
-use frame_support::traits::Randomness;
+use codec::Encode;
+use frame_support::log::{
+    error,
+    trace,
+};
 use pallet_contracts::chain_extension::{
-    ChainExtension, Environment, Ext, InitState, RetVal, SysConfig, UncheckedFrom,
+    ChainExtension,
+    Environment,
+    Ext,
+    InitState,
+    RetVal,
+    SysConfig,
+    UncheckedFrom,
 };
 use sp_runtime::DispatchError;
-use sp_std::vec::Vec;
 
-/// contract extension for `FetchRandom`
+/// Contract extension for `FetchRandom`
 pub struct FetchRandomExtension;
 
-impl ChainExtension for FetchRandomExtension {
-    fn call<E: Ext>(func_id: u32, env: Environment<E, InitState>) -> Result<RetVal, DispatchError>
-        where
-            <E::T as SysConfig>::AccountId: UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
+impl ChainExtension<Runtime> for FetchRandomExtension {
+    fn call<E: Ext>(
+        func_id: u32,
+        env: Environment<E, InitState>,
+    ) -> Result<RetVal, DispatchError>
+    where
+        <E::T as SysConfig>::AccountId:
+            UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
     {
-
         match func_id {
             1101 => {
                 let mut env = env.buf_in_buf_out();
-                let random_seed: [u8; 32] = super::RandomnessCollectiveFlip::random_seed().0;
+                let random_seed = crate::RandomnessCollectiveFlip::random_seed().0;
                 let random_slice = random_seed.encode();
-                native::trace!(
+                trace!(
                     target: "runtime",
                     "[ChainExtension]|call|func_id:{:}",
                     func_id
                 );
-                env.write(&random_slice, false, None)
-                    .map_err(|_| DispatchError::Other("ChainExtension failed to call random"))?;
+                env.write(&random_slice, false, None).map_err(|_| {
+                    DispatchError::Other("ChainExtension failed to call random")
+                })?;
             }
 
             _ => {
-                error!("call an unregistered `func_id`, func_id:{:}", func_id);
-                return Err(DispatchError::Other("Unimplemented func_id"));
+                error!("Called an unregistered `func_id`: {:}", func_id);
+                return Err(DispatchError::Other("Unimplemented func_id"))
             }
         }
         Ok(RetVal::Converging(0))


### PR DESCRIPTION
This PR fixes the example, it was broken due to changes in Substrate.

I found this while implementing tests for this example in `ink-waterfall`.

[Preview the updated README here](https://github.com/paritytech/ink/tree/cmichi-update-rand-extension-example/examples/rand-extension/runtime)