### PR TITLE
Adjust `max_gas` workaround for `delegator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 [k1]: https://img.shields.io/badge/matrix-chat-brightgreen.svg?style=flat
 [k2]: https://riot.im/app/#/room/#ink:matrix.parity.io
 [l1]: https://img.shields.io/discord/722223075629727774?style=flat-square&label=discord
-[l2]: https://discord.gg/HZJyAy4rrU
+[l2]: https://discord.gg/j2DKRRbSJr
 
 > <img src="./.images/ink-squid.svg" alt="squink, the ink! mascot" style="vertical-align: middle" align="left" height="60" />ink! is an [eDSL](https://wiki.haskell.org/Embedded_domain_specific_language) to write smart contracts in Rust for blockchains built on the [Substrate](https://github.com/paritytech/substrate) framework. ink! contracts are compiled to WebAssembly.
 

--- a/examples/delegator/README.md
+++ b/examples/delegator/README.md
@@ -40,4 +40,4 @@ is an easy way to get a local smart contract chain running.
    > __Note:__<br/>
    > Depending on your Substrate version you might encounter [a bug with the pre-filled gas estimation of the UI](https://github.com/paritytech/substrate/issues/8693)
    > and get the error `ExtrinsicFailed: OutOfGas`.
-   > As a workaround set the maximum allowed gas manually (e.g. to 2500).
+   > As a workaround set the maximum allowed gas manually (e.g. to 5000).


### PR DESCRIPTION
Something must have changed recently, the `ink-waterfall` tests also broke. They had used 2500 to work around the bug.