### PR TITLE
Small fixes for case when contract is compiled with compile_as_dependency = true

### DIFF
--- a/crates/lang/codegen/src/generator/cross_calling.rs
+++ b/crates/lang/codegen/src/generator/cross_calling.rs
@@ -685,7 +685,7 @@ impl CrossCalling<'_> {
             fn #ident(
                 #( #input_bindings : #input_types ),*
             ) -> Self::#output_ident {
-                ::ink_env::call::build_create::<Environment, Salt, Self>()
+                ::ink_env::call::build_create::<Environment, Self>()
                     .exec_input(
                         ::ink_env::call::ExecutionInput::new(
                             ::ink_env::call::Selector::new([ #( #composed_selector ),* ])


### PR DESCRIPTION
Not generate metadata if compile_as_dependency is true
Remove not used Salt