### PR TITLE
Spellchecking for examples + Fix master CI

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -35,9 +35,7 @@ scalable
 adjunctive
 invariants
 deserializes
-Dapp
-untyped
-subber
+DApp
 
 hasher/S
 hashmap/S

--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -35,6 +35,9 @@ scalable
 adjunctive
 invariants
 deserializes
+Dapp
+untyped
+subber
 
 hasher/S
 hashmap/S
@@ -48,3 +51,4 @@ defragment/SD
 layout/JG
 endian/P
 accessor/S
+NFT/S

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,6 +157,12 @@ spellcheck:
         when: never
     script:
         - cargo spellcheck check --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1
+        - for example in examples/*/; do
+            cargo spellcheck check --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 ${example};
+          done
+        - for contract in ${DELEGATOR_SUBCONTRACTS}; do
+            cargo spellcheck check --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 examples/delegator/${contract}/;
+          done
 
 codecov:
   stage:                           workspace

--- a/crates/engine/src/database.rs
+++ b/crates/engine/src/database.rs
@@ -69,7 +69,7 @@ impl Database {
         account_id: &[u8],
         key: &[u8],
     ) -> Option<&Vec<u8>> {
-        let hashed_key = storage_of_contract_key(&account_id, key);
+        let hashed_key = storage_of_contract_key(account_id, key);
         self.hmap.get(&hashed_key.to_vec())
     }
 
@@ -80,7 +80,7 @@ impl Database {
         key: &[u8],
         value: Vec<u8>,
     ) -> Option<Vec<u8>> {
-        let hashed_key = storage_of_contract_key(&account_id, key);
+        let hashed_key = storage_of_contract_key(account_id, key);
         self.hmap.insert(hashed_key.to_vec(), value)
     }
 
@@ -90,7 +90,7 @@ impl Database {
         account_id: &[u8],
         key: &[u8],
     ) -> Option<Vec<u8>> {
-        let hashed_key = storage_of_contract_key(&account_id, key);
+        let hashed_key = storage_of_contract_key(account_id, key);
         self.hmap.remove(&hashed_key.to_vec())
     }
 
@@ -112,7 +112,7 @@ impl Database {
 
     /// Returns the balance of `account_id`, if available.
     pub fn get_balance(&self, account_id: &[u8]) -> Option<Balance> {
-        let hashed_key = balance_of_key(&account_id);
+        let hashed_key = balance_of_key(account_id);
         self.get(&hashed_key).map(|encoded_balance| {
             scale::Decode::decode(&mut &encoded_balance[..])
                 .expect("unable to decode balance from database")
@@ -121,7 +121,7 @@ impl Database {
 
     /// Sets the balance of `account_id` to `new_balance`.
     pub fn set_balance(&mut self, account_id: &[u8], new_balance: Balance) {
-        let hashed_key = balance_of_key(&account_id);
+        let hashed_key = balance_of_key(account_id);
         let encoded_balance = scale::Encode::encode(&new_balance);
         self.hmap
             .entry(hashed_key.to_vec())

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -343,10 +343,6 @@ impl Engine {
         super::hashing::keccak_256(input, output);
     }
 
-    pub fn now(&self, _output: &mut &mut [u8]) {
-        unimplemented!("off-chain environment does not yet support `now`");
-    }
-
     pub fn block_number(&self, _output: &mut &mut [u8]) {
         unimplemented!("off-chain environment does not yet support `block_number`");
     }

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -347,6 +347,10 @@ impl Engine {
         unimplemented!("off-chain environment does not yet support `block_number`");
     }
 
+    pub fn block_timestamp(&self, _output: &mut &mut [u8]) {
+        unimplemented!("off-chain environment does not yet support `block_timestamp`");
+    }
+
     pub fn gas_left(&self, _output: &mut &mut [u8]) {
         unimplemented!("off-chain environment does not yet support `gas_left`");
     }

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -291,7 +291,7 @@ impl Engine {
             .as_ref()
             .expect("no callee has been set")
             .as_bytes();
-        set_output(output, &callee)
+        set_output(output, callee)
     }
 
     /// Restores a tombstone to the original smart contract.

--- a/crates/env/src/engine/experimental_off_chain/impls.rs
+++ b/crates/env/src/engine/experimental_off_chain/impls.rs
@@ -288,7 +288,7 @@ impl TypedEnvBackend for EnvInstance {
     }
 
     fn block_timestamp<T: Environment>(&mut self) -> Result<T::Timestamp> {
-        self.get_property::<T::Timestamp>(Engine::now)
+        self.get_property::<T::Timestamp>(Engine::block_timestamp)
     }
 
     fn account_id<T: Environment>(&mut self) -> Result<T::AccountId> {

--- a/crates/env/src/engine/off_chain/db/accounts.rs
+++ b/crates/env/src/engine/off_chain/db/accounts.rs
@@ -92,7 +92,7 @@ impl AccountsDb {
         //       the borrow-checker somehow cannot make sense of it according
         //       to its lifetime analysis. Consider this to be a hack until
         //       the borrow-checker eventually let's us do this.
-        if self.get_account::<T>(&at).is_some() {
+        if self.get_account::<T>(at).is_some() {
             self.get_account_mut::<T>(at)
                 .expect("just checked that account exists")
         } else {

--- a/crates/lang/codegen/src/generator/item_impls.rs
+++ b/crates/lang/codegen/src/generator/item_impls.rs
@@ -37,7 +37,7 @@ pub struct ItemImpls<'a> {
 
 impl AsRef<ir::Contract> for ItemImpls<'_> {
     fn as_ref(&self) -> &ir::Contract {
-        &self.contract
+        self.contract
     }
 }
 

--- a/crates/lang/codegen/src/generator/metadata.rs
+++ b/crates/lang/codegen/src/generator/metadata.rs
@@ -125,7 +125,7 @@ impl Metadata<'_> {
             .map(|(trait_ident, constructor)| {
                 let span = constructor.span();
                 let attrs = constructor.attrs();
-                let docs = Self::extract_doc_comments(&attrs);
+                let docs = Self::extract_doc_comments(attrs);
                 let selector = constructor.composed_selector();
                 let selector_bytes = selector.as_bytes();
                 let constructor = constructor.callable();
@@ -216,7 +216,7 @@ impl Metadata<'_> {
             .map(|(trait_ident, message)| {
                 let span = message.span();
                 let attrs = message.attrs();
-                let docs = Self::extract_doc_comments(&attrs);
+                let docs = Self::extract_doc_comments(attrs);
                 let selector = message.composed_selector();
                 let selector_bytes = selector.as_bytes();
                 let is_payable = message.is_payable();

--- a/crates/lang/ir/src/ir/item_impl/callable.rs
+++ b/crates/lang/ir/src/ir/item_impl/callable.rs
@@ -101,35 +101,35 @@ where
     C: Callable,
 {
     fn kind(&self) -> CallableKind {
-        <C as Callable>::kind(&self.callable)
+        <C as Callable>::kind(self.callable)
     }
 
     fn ident(&self) -> &Ident {
-        <C as Callable>::ident(&self.callable)
+        <C as Callable>::ident(self.callable)
     }
 
     fn user_provided_selector(&self) -> Option<&ir::Selector> {
-        <C as Callable>::user_provided_selector(&self.callable)
+        <C as Callable>::user_provided_selector(self.callable)
     }
 
     fn is_payable(&self) -> bool {
-        <C as Callable>::is_payable(&self.callable)
+        <C as Callable>::is_payable(self.callable)
     }
 
     fn visibility(&self) -> Visibility {
-        <C as Callable>::visibility(&self.callable)
+        <C as Callable>::visibility(self.callable)
     }
 
     fn inputs(&self) -> InputsIter {
-        <C as Callable>::inputs(&self.callable)
+        <C as Callable>::inputs(self.callable)
     }
 
     fn inputs_span(&self) -> Span {
-        <C as Callable>::inputs_span(&self.callable)
+        <C as Callable>::inputs_span(self.callable)
     }
 
     fn statements(&self) -> &[syn::Stmt] {
-        <C as Callable>::statements(&self.callable)
+        <C as Callable>::statements(self.callable)
     }
 }
 
@@ -137,7 +137,7 @@ impl<'a, C> ::core::ops::Deref for CallableWithSelector<'a, C> {
     type Target = C;
 
     fn deref(&self) -> &Self::Target {
-        &self.callable
+        self.callable
     }
 }
 

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -500,13 +500,13 @@ use proc_macro::TokenStream;
 ///             Self { value: init_value }
 ///         }
 ///
-///         /// Flips the current value of the Flipper's bool.
+///         /// Flips the current value of the Flipper's boolean.
 ///         #[ink(message)]
 ///         pub fn flip(&mut self) {
 ///             self.value = !self.value;
 ///         }
 ///
-///         /// Returns the current value of the Flipper's bool.
+///         /// Returns the current value of the Flipper's boolean.
 ///         #[ink(message)]
 ///         pub fn get(&self) -> bool {
 ///             self.value

--- a/crates/lang/macro/tests/ui/pass/05-erc721-contract.rs
+++ b/crates/lang/macro/tests/ui/pass/05-erc721-contract.rs
@@ -75,7 +75,7 @@ mod erc721 {
     }
 
     impl Erc721 {
-        /// Creates a new ERC721 token contract.
+        /// Creates a new ERC-721 token contract.
         #[ink(constructor)]
         pub fn new() -> Self {
             Self {
@@ -193,7 +193,7 @@ mod erc721 {
             Ok(())
         }
 
-        /// Transfers token `id` `from` the sender to the `to` AccountId.
+        /// Transfers token `id` `from` the sender to the `to` `AccountId`.
         fn transfer_token_from(
             &mut self,
             from: &AccountId,
@@ -336,7 +336,7 @@ mod erc721 {
                 .unwrap_or(&false)
         }
 
-        /// Returns true if the AccountId `from` is the owner of token `id`
+        /// Returns true if the `AccountId` `from` is the owner of token `id`
         /// or it has been approved on behalf of the token `id` owner.
         fn approved_or_owner(&self, from: Option<AccountId>, id: TokenId) -> bool {
             let owner = self.owner_of(id);

--- a/crates/storage/src/alloc/boxed/storage.rs
+++ b/crates/storage/src/alloc/boxed/storage.rs
@@ -85,11 +85,11 @@ where
     }
 
     fn push_spread(&self, ptr: &mut KeyPtr) {
-        forward_push_packed::<Self>(&self, ptr)
+        forward_push_packed::<Self>(self, ptr)
     }
 
     fn clear_spread(&self, ptr: &mut KeyPtr) {
-        forward_clear_packed::<Self>(&self, ptr)
+        forward_clear_packed::<Self>(self, ptr)
     }
 }
 

--- a/crates/storage/src/alloc/init.rs
+++ b/crates/storage/src/alloc/init.rs
@@ -114,7 +114,7 @@ impl DynamicAllocatorState {
                 // Push all state of the global dynamic storage allocator
                 // instance back onto the contract storage.
                 push_spread_root::<DynamicAllocator>(
-                    &allocator,
+                    allocator,
                     &Key::from(DYNAMIC_ALLOCATOR_KEY_OFFSET),
                 );
                 // Prevent calling `drop` on the dynamic storage allocator

--- a/crates/storage/src/collections/binary_heap/children_vec.rs
+++ b/crates/storage/src/collections/binary_heap/children_vec.rs
@@ -175,7 +175,7 @@ where
     /// Prefer using methods like `Iterator::take` in order to limit the number
     /// of yielded elements.
     pub fn iter(&self) -> Iter<T> {
-        Iter::new(&self)
+        Iter::new(self)
     }
 
     /// Returns a shared reference to the first element if any.

--- a/crates/storage/src/collections/hashmap/mod.rs
+++ b/crates/storage/src/collections/hashmap/mod.rs
@@ -415,8 +415,8 @@ where
     /// Returns a reference to this entry's key.
     pub fn key(&self) -> &K {
         match self {
-            Entry::Occupied(entry) => &entry.values_entry.key(),
-            Entry::Vacant(entry) => &entry.values_entry.key(),
+            Entry::Occupied(entry) => entry.values_entry.key(),
+            Entry::Vacant(entry) => entry.values_entry.key(),
         }
     }
 
@@ -459,7 +459,7 @@ where
     {
         match self {
             Entry::Occupied(entry) => &mut entry.values_entry.into_mut().value,
-            Entry::Vacant(entry) => Entry::insert(default(&entry.key()), entry),
+            Entry::Vacant(entry) => Entry::insert(default(entry.key()), entry),
         }
     }
 
@@ -494,7 +494,7 @@ where
 {
     /// Gets a reference to the key that would be used when inserting a value through the `VacantEntry`.
     pub fn key(&self) -> &K {
-        &self.values_entry.key()
+        self.values_entry.key()
     }
 
     /// Take ownership of the key.
@@ -520,7 +520,7 @@ where
 {
     /// Gets a reference to the key in the entry.
     pub fn key(&self) -> &K {
-        &self.values_entry.key()
+        self.values_entry.key()
     }
 
     /// Take the ownership of the key and value from the map.

--- a/crates/storage/src/collections/stash/tests.rs
+++ b/crates/storage/src/collections/stash/tests.rs
@@ -24,7 +24,7 @@ use ink_primitives::Key;
 
 #[test]
 fn regression_stash_unreachable_minified() {
-    // This regression has been discovered in the ERC721 example implementation
+    // This regression has been discovered in the ERC-721 example implementation
     // `approved_for_all_works` unit test. The fix was to adjust
     // `Stash::remove_vacant_entry` to update `header.last_vacant` if the
     // removed index was the last remaining vacant index in the stash.

--- a/crates/storage/src/lazy/entry.rs
+++ b/crates/storage/src/lazy/entry.rs
@@ -185,7 +185,7 @@ where
     /// Mainly used by lazy storage abstractions that only allow operating on
     /// packed storage entities such as [`LazyCell`][`crate::lazy::LazyCell`].
     pub fn pull_spread_root(root_key: &Key) -> Self {
-        Self::new(pull_spread_root_opt::<T>(&root_key), EntryState::Preserved)
+        Self::new(pull_spread_root_opt::<T>(root_key), EntryState::Preserved)
     }
 
     /// Pushes the underlying associated data to the contract storage using
@@ -198,7 +198,7 @@ where
     pub fn push_spread_root(&self, root_key: &Key) {
         let old_state = self.replace_state(EntryState::Preserved);
         if old_state.is_mutated() {
-            push_spread_root_opt::<T>(self.value().into(), &root_key);
+            push_spread_root_opt::<T>(self.value().into(), root_key);
         }
     }
 
@@ -209,7 +209,7 @@ where
     /// Mainly used by lazy storage abstractions that only allow operating on
     /// packed storage entities such as [`LazyCell`][`crate::lazy::LazyCell`].
     pub fn clear_spread_root(&self, root_key: &Key) {
-        clear_spread_root_opt::<T, _>(&root_key, || self.value().into());
+        clear_spread_root_opt::<T, _>(root_key, || self.value().into());
     }
 }
 
@@ -238,7 +238,7 @@ where
     pub fn push_packed_root(&self, root_key: &Key) {
         let old_state = self.replace_state(EntryState::Preserved);
         if old_state.is_mutated() {
-            push_packed_root_opt::<T>(self.value().into(), &root_key);
+            push_packed_root_opt::<T>(self.value().into(), root_key);
         }
     }
 
@@ -250,7 +250,7 @@ where
     /// packed storage entities such as [`LazyIndexMap`][`crate::lazy::LazyIndexMap`]
     /// or [`LazyArray`][`crate::lazy::LazyArray`].
     pub fn clear_packed_root(&self, root_key: &Key) {
-        clear_packed_root::<Option<T>>(self.value(), &root_key);
+        clear_packed_root::<Option<T>>(self.value(), root_key);
     }
 }
 

--- a/crates/storage/src/lazy/lazy_array.rs
+++ b/crates/storage/src/lazy/lazy_array.rs
@@ -294,7 +294,7 @@ where
             // because it requires a deep clean-up which propagates clearing to its fields,
             // for example in the case of `T` being a `storage::Box`.
             let entity = self.get(index).expect("cannot clear a non existing entity");
-            clear_packed_root::<T>(&entity, &root_key);
+            clear_packed_root::<T>(entity, &root_key);
         } else {
             // The type does not require deep clean-up so we can simply clean-up
             // its associated storage cell and be done without having to load it first.

--- a/crates/storage/src/lazy/lazy_hmap.rs
+++ b/crates/storage/src/lazy/lazy_hmap.rs
@@ -271,7 +271,7 @@ where
     fn push_spread(&self, ptr: &mut KeyPtr) {
         let offset_key = ExtKeyPtr::next_for::<Self>(ptr);
         for (index, entry) in self.entries().iter() {
-            let root_key = self.to_offset_key(&offset_key, index);
+            let root_key = self.to_offset_key(offset_key, index);
             entry.push_packed_root(&root_key);
         }
     }
@@ -638,7 +638,7 @@ where
             // because it requires a deep clean-up which propagates clearing to its fields,
             // for example in the case of `T` being a `storage::Box`.
             let entity = self.get(index).expect("cannot clear a non existing entity");
-            clear_packed_root::<V>(&entity, &root_key);
+            clear_packed_root::<V>(entity, &root_key);
         } else {
             // The type does not require deep clean-up so we can simply clean-up
             // its associated storage cell and be done without having to load it first.

--- a/crates/storage/src/lazy/lazy_imap.rs
+++ b/crates/storage/src/lazy/lazy_imap.rs
@@ -284,7 +284,7 @@ where
             // because it requires a deep clean-up which propagates clearing to its fields,
             // for example in the case of `T` being a `storage::Box`.
             let entity = self.get(index).expect("cannot clear a non existing entity");
-            clear_packed_root::<V>(&entity, &root_key);
+            clear_packed_root::<V>(entity, &root_key);
         } else {
             // The type does not require deep clean-up so we can simply clean-up
             // its associated storage cell and be done without having to load it first.

--- a/crates/storage/src/traits/impls/mod.rs
+++ b/crates/storage/src/traits/impls/mod.rs
@@ -118,7 +118,7 @@ pub fn forward_pull_packed<T>(ptr: &mut KeyPtr) -> T
 where
     T: PackedLayout,
 {
-    pull_packed_root::<T>(&ptr.next_for::<T>())
+    pull_packed_root::<T>(ptr.next_for::<T>())
 }
 
 /// Pushes an instance of type `T` in packed fashion to the contract storage.
@@ -135,7 +135,7 @@ pub fn forward_push_packed<T>(entity: &T, ptr: &mut KeyPtr)
 where
     T: PackedLayout,
 {
-    push_packed_root::<T>(entity, &ptr.next_for::<T>())
+    push_packed_root::<T>(entity, ptr.next_for::<T>())
 }
 
 /// Clears an instance of type `T` in packed fashion from the contract storage.
@@ -152,5 +152,5 @@ pub fn forward_clear_packed<T>(entity: &T, ptr: &mut KeyPtr)
 where
     T: PackedLayout,
 {
-    clear_packed_root::<T>(entity, &ptr.next_for::<T>())
+    clear_packed_root::<T>(entity, ptr.next_for::<T>())
 }

--- a/examples/delegator/accumulator/lib.rs
+++ b/examples/delegator/accumulator/lib.rs
@@ -19,7 +19,7 @@ use ink_lang as ink;
 
 #[ink::contract]
 pub mod accumulator {
-    /// Holds a simple i32 value that can be incremented and decremented.
+    /// Holds a simple `i32` value that can be incremented and decremented.
     #[ink(storage)]
     pub struct Accumulator {
         value: i32,

--- a/examples/delegator/adder/lib.rs
+++ b/examples/delegator/adder/lib.rs
@@ -21,21 +21,21 @@ use ink_lang as ink;
 mod adder {
     use accumulator::Accumulator;
 
-    /// Increments the underlying accumulator's value.
+    /// Increments the underlying `accumulator` value.
     #[ink(storage)]
     pub struct Adder {
-        /// The accumulator to store the value.
+        /// The `accumulator` to store the value.
         accumulator: accumulator::Accumulator,
     }
 
     impl Adder {
-        /// Creates a new adder from the given accumulator.
+        /// Creates a new `adder` from the given `accumulator`.
         #[ink(constructor)]
         pub fn new(accumulator: Accumulator) -> Self {
             Self { accumulator }
         }
 
-        /// Increases the accumulator's value by some amount.
+        /// Increases the `accumulator` value by some amount.
         #[ink(message)]
         pub fn inc(&mut self, by: i32) {
             self.accumulator.inc(by)

--- a/examples/delegator/lib.rs
+++ b/examples/delegator/lib.rs
@@ -55,23 +55,23 @@ mod delegator {
         Subber,
     }
 
-    /// Delegates calls to an adder or subber contract to mutate
-    /// a value in an accumulator contract.
+    /// Delegates calls to an `adder` or `subber` contract to mutate
+    /// a value in an `accumulator` contract.
     ///
     /// In order to deploy the delegator smart contract we first
-    /// have to manually put the code of the accumulator, adder
-    /// and subber smart contracts, receive their code hashes from
+    /// have to manually put the code of the `accumulator`, `adder`
+    /// and `subber` smart contracts, receive their code hashes from
     /// the signalled events and put their code hash into our
     /// delegator smart contract.
     #[ink(storage)]
     pub struct Delegator {
-        /// Says which of adder or subber is currently in use.
+        /// Says which of `adder` or `subber` is currently in use.
         which: Which,
-        /// The accumulator smart contract.
+        /// The `accumulator` smart contract.
         accumulator: Lazy<Accumulator>,
-        /// The adder smart contract.
+        /// The `adder` smart contract.
         adder: Lazy<Adder>,
-        /// The subber smart contract.
+        /// The `subber` smart contract.
         subber: Lazy<Subber>,
     }
 
@@ -113,7 +113,7 @@ mod delegator {
             }
         }
 
-        /// Returns the accumulator's value.
+        /// Returns the `accumulator` value.
         #[ink(message)]
         pub fn get(&self) -> i32 {
             self.accumulator.get()

--- a/examples/delegator/subber/lib.rs
+++ b/examples/delegator/subber/lib.rs
@@ -21,21 +21,21 @@ use ink_lang as ink;
 mod subber {
     use accumulator::Accumulator;
 
-    /// Decreases the underlying accumulator's value.
+    /// Decreases the underlying `accumulator` value.
     #[ink(storage)]
     pub struct Subber {
-        /// The accumulator to store the value.
+        /// The `accumulator` to store the value.
         accumulator: accumulator::Accumulator,
     }
 
     impl Subber {
-        /// Creates a new subber from the given accumulator.
+        /// Creates a new `subber` from the given `accumulator`.
         #[ink(constructor)]
         pub fn new(accumulator: Accumulator) -> Self {
             Self { accumulator }
         }
 
-        /// Decreases the accumulator's value by some amount.
+        /// Decreases the `accumulator` value by some amount.
         #[ink(message)]
         pub fn dec(&mut self, by: i32) {
             self.accumulator.inc(-by)

--- a/examples/dns/lib.rs
+++ b/examples/dns/lib.rs
@@ -46,7 +46,7 @@ mod dns {
         new_address: AccountId,
     }
 
-    /// Emitted whenver a name is being transferred.
+    /// Emitted whenever a name is being transferred.
     #[ink(event)]
     pub struct Transfer {
         #[ink(topic)]
@@ -70,8 +70,8 @@ mod dns {
     ///
     /// The main function of this contract is domain name resolution which
     /// refers to the retrieval of numeric values corresponding to readable
-    /// and easily memorable names such as “polka.dot” which can be used
-    /// to facilitate transfers, voting and dapp-related operations instead
+    /// and easily memorable names such as "polka.dot" which can be used
+    /// to facilitate transfers, voting and Dapp-related operations instead
     /// of resorting to long IP addresses that are hard to remember.
     #[ink(storage)]
     #[derive(Default)]
@@ -232,7 +232,7 @@ mod dns {
                 Err(Error::CallerIsNotOwner)
             );
 
-            // caller is owner, set_address will be successful
+            // Caller is owner, set_address will be successful
             set_next_caller(accounts.alice);
             assert_eq!(contract.set_address(name, accounts.bob), Ok(()));
             assert_eq!(contract.get_address(name), accounts.bob);

--- a/examples/dns/lib.rs
+++ b/examples/dns/lib.rs
@@ -71,7 +71,7 @@ mod dns {
     /// The main function of this contract is domain name resolution which
     /// refers to the retrieval of numeric values corresponding to readable
     /// and easily memorable names such as "polka.dot" which can be used
-    /// to facilitate transfers, voting and Dapp-related operations instead
+    /// to facilitate transfers, voting and DApp-related operations instead
     /// of resorting to long IP addresses that are hard to remember.
     #[ink(storage)]
     #[derive(Default)]

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # ERC721
+//! # ERC-721
 //!
-//! This is an ERC721 Token implementation.
+//! This is an ERC-721 Token implementation.
 //!
 //! ## Warning
 //!
@@ -27,9 +27,9 @@
 //!
 //! ## Error Handling
 //!
-//! Any function that modifies the state returns a Result type and does not changes the state
-//! if the Error occurs.
-//! The errors are defined as an Enum type. Any other error or invariant violation
+//! Any function that modifies the state returns a `Result` type and does not changes the state
+//! if the `Error` occurs.
+//! The errors are defined as an `Enum` type. Any other error or invariant violation
 //! triggers a panic and therefore rolls back the transaction.
 //!
 //! ## Token Management
@@ -54,7 +54,7 @@
 //! - An authorized operator of the current owner of a token
 //!
 //! The token owner can transfer a token by calling the `transfer` or `transfer_from` functions.
-//! An approved address can make a token transfer by calling the `transfer_from` funtion.
+//! An approved address can make a token transfer by calling the `transfer_from` function.
 //! Operators can transfer tokens on another account's behalf or can approve a token transfer
 //! for a different account.
 //!
@@ -141,7 +141,7 @@ mod erc721 {
     }
 
     impl Erc721 {
-        /// Creates a new ERC721 token contract.
+        /// Creates a new ERC-721 token contract.
         #[ink(constructor)]
         pub fn new() -> Self {
             Self {
@@ -259,7 +259,7 @@ mod erc721 {
             Ok(())
         }
 
-        /// Transfers token `id` `from` the sender to the `to` AccountId.
+        /// Transfers token `id` `from` the sender to the `to` `AccountId`.
         fn transfer_token_from(
             &mut self,
             from: &AccountId,
@@ -354,7 +354,7 @@ mod erc721 {
             }
         }
 
-        /// Approve the passed AccountId to transfer the specified token on behalf of the message's sender.
+        /// Approve the passed `AccountId` to transfer the specified token on behalf of the message's sender.
         fn approve_for(&mut self, to: &AccountId, id: TokenId) -> Result<(), Error> {
             let caller = self.env().caller();
             let owner = self.owner_of(id);
@@ -402,7 +402,7 @@ mod erc721 {
                 .unwrap_or(&false)
         }
 
-        /// Returns true if the AccountId `from` is the owner of token `id`
+        /// Returns true if the `AccountId` `from` is the owner of token `id`
         /// or it has been approved on behalf of the token `id` owner.
         fn approved_or_owner(&self, from: Option<AccountId>, id: TokenId) -> bool {
             let owner = self.owner_of(id);
@@ -430,7 +430,7 @@ mod erc721 {
         Ok(())
     }
 
-    /// Increase token counter from the `of` AccountId.
+    /// Increase token counter from the `of` `AccountId`.
     fn increase_counter_of(entry: Entry<AccountId, u32>) {
         entry.and_modify(|v| *v += 1).or_insert(1);
     }

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! Any function that modifies the state returns a `Result` type and does not changes the state
 //! if the `Error` occurs.
-//! The errors are defined as an `Enum` type. Any other error or invariant violation
+//! The errors are defined as an `enum` type. Any other error or invariant violation
 //! triggers a panic and therefore rolls back the transaction.
 //!
 //! ## Token Management

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -36,13 +36,13 @@ pub mod flipper {
             Self::new(Default::default())
         }
 
-        /// Flips the current value of the Flipper's bool.
+        /// Flips the current value of the Flipper's boolean.
         #[ink(message)]
         pub fn flip(&mut self) {
             self.value = !self.value;
         }
 
-        /// Returns the current value of the Flipper's bool.
+        /// Returns the current value of the Flipper's boolean.
         #[ink(message)]
         pub fn get(&self) -> bool {
             self.value

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -42,12 +42,12 @@
 //!
 //! The interface is modelled after the popular gnosis multisig wallet. However, there
 //! are subtle variations from the interface. For example the `confirm_transaction`
-//! will never trigger the execution of a `Transaction` even if the treshold is reached.
+//! will never trigger the execution of a `Transaction` even if the threshold is reached.
 //! A call of `execute_transaction` is always required. This can be called by anyone.
 //!
 //! All the messages that are declared as only callable by the wallet must go through
 //! the usual submit, confirm, execute cycle as any other transaction that should be
-//! called by the wallet. For example to add an owner you would submit a transaction
+//! called by the wallet. For example, to add an owner you would submit a transaction
 //! that calls the wallets own `add_owner` message through `submit_transaction`.
 //!
 //! ### Owner Management

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -107,7 +107,7 @@ mod multisig_plain {
 
     /// A wrapper that allows us to encode a blob of bytes.
     ///
-    /// We use this to pass the set of untyped (bytes) parameters to the `CallBuilder`.
+    /// We use this to pass the set of not typed (bytes) parameters to the `CallBuilder`.
     struct CallInput<'a>(&'a [u8]);
 
     impl<'a> scale::Encode for CallInput<'a> {

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! ## Error Handling
 //!
-//! With the exeception of `execute_transaction` no error conditions are signalled
+//! With the exception of `execute_transaction` no error conditions are signalled
 //! through return types. Any error or invariant violation triggers a panic and therefore
 //! rolls back the transaction.
 //!
@@ -143,7 +143,7 @@ mod multisig_plain {
         )
     )]
     pub struct Transaction {
-        /// The AccountId of the contract that is called in this transaction.
+        /// The `AccountId` of the contract that is called in this transaction.
         pub callee: AccountId,
         /// The selector bytes that identifies the function of the callee that should be called.
         pub selector: [u8; 4],
@@ -166,7 +166,7 @@ mod multisig_plain {
     #[ink(storage)]
     pub struct MultisigPlain {
         /// Every entry in this map represents the confirmation of an owner for a
-        /// transaction. This is effecively a set rather than a map.
+        /// transaction. This is effectively a set rather than a map.
         confirmations: StorageHashMap<(TransactionId, AccountId), ()>,
         /// The amount of confirmations for every transaction. This is a redundant
         /// information and is kept in order to prevent iterating through the
@@ -204,7 +204,7 @@ mod multisig_plain {
         /// The transaction that was revoked.
         #[ink(topic)]
         transaction: TransactionId,
-        /// The owner that sent the revokation.
+        /// The owner that sent the revocation.
         #[ink(topic)]
         from: AccountId,
     }
@@ -298,7 +298,7 @@ mod multisig_plain {
         /// # Examples
         ///
         /// Since this message must be send by the wallet itself it has to be build as a
-        /// `Transaction` and dispatched through `submit_transaction` + `invoke_transaction`:
+        /// `Transaction` and dispatched through `submit_transaction` and `invoke_transaction`:
         /// ```no_run
         /// use ink_env::{DefaultEnvironment as Env, AccountId, call::{CallParams, Selector}, test::CallData};
         /// use multisig_plain::{Transaction, ConfirmationStatus};
@@ -403,7 +403,7 @@ mod multisig_plain {
             self.env().emit_event(RequirementChange { new_requirement });
         }
 
-        /// Add a new transaction candiate to the contract.
+        /// Add a new transaction candidate to the contract.
         ///
         /// This also confirms the transaction for the caller. This can be called by any owner.
         #[ink(message)]

--- a/examples/rand-extension/lib.rs
+++ b/examples/rand-extension/lib.rs
@@ -25,8 +25,8 @@ use ink_lang as ink;
 pub trait FetchRandom {
     type ErrorCode = RandomReadErr;
 
-    /// Note: this gives the operation a corresponding func_id (1101 in this case),
-    /// and the chain-side chain_extension will get the func_id to do further operations.
+    /// Note: this gives the operation a corresponding `func_id` (1101 in this case),
+    /// and the chain-side chain extension will get the `func_id` to do further operations.
     #[ink(extension = 1101, returns_result = false)]
     fn fetch_random() -> [u8; 32];
 }

--- a/examples/trait-flipper/lib.rs
+++ b/examples/trait-flipper/lib.rs
@@ -22,11 +22,11 @@ pub trait Flip {
     #[ink(constructor)]
     fn new(init_value: bool) -> Self;
 
-    /// Flips the current value of the Flipper's bool.
+    /// Flips the current value of the Flipper's boolean.
     #[ink(message)]
     fn flip(&mut self);
 
-    /// Returns the current value of the Flipper's bool.
+    /// Returns the current value of the Flipper's boolean.
     #[ink(message)]
     fn get(&self) -> bool;
 }


### PR DESCRIPTION
Some miscellaneous improvements and fixes for the nightly clippy errors which currently make the CI fail on `master`.