### PR TITLE
Fix bugs in two examples + Fix `master` CI

### DIFF
--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -50,7 +50,7 @@ macro_rules! define_error_codes {
                 $name = $discr,
             )*
             /// Returns if an unknown error was received from the host module.
-            UnknownError,
+            Unknown,
         }
 
         impl From<ReturnCode> for Result {
@@ -61,7 +61,7 @@ macro_rules! define_error_codes {
                     $(
                         $discr => Err(Error::$name),
                     )*
-                    _ => Err(Error::UnknownError),
+                    _ => Err(Error::Unknown),
                 }
             }
         }

--- a/crates/env/src/engine/experimental_off_chain/impls.rs
+++ b/crates/env/src/engine/experimental_off_chain/impls.rs
@@ -102,7 +102,7 @@ impl CryptoHash for Keccak256 {
 impl From<ext::Error> for crate::Error {
     fn from(ext_error: ext::Error) -> Self {
         match ext_error {
-            ext::Error::UnknownError => Self::UnknownError,
+            ext::Error::Unknown => Self::Unknown,
             ext::Error::CalleeTrapped => Self::CalleeTrapped,
             ext::Error::CalleeReverted => Self::CalleeReverted,
             ext::Error::KeyNotFound => Self::KeyNotFound,

--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -35,7 +35,7 @@ macro_rules! define_error_codes {
                 $name = $discr,
             )*
             /// Returns if an unknown error was received from the host module.
-            UnknownError,
+            Unknown,
         }
 
         impl From<ReturnCode> for Result {
@@ -46,7 +46,7 @@ macro_rules! define_error_codes {
                     $(
                         $discr => Err(Error::$name),
                     )*
-                    _ => Err(Error::UnknownError),
+                    _ => Err(Error::Unknown),
                 }
             }
         }

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -101,7 +101,7 @@ impl CryptoHash for Keccak256 {
 impl From<ext::Error> for Error {
     fn from(ext_error: ext::Error) -> Self {
         match ext_error {
-            ext::Error::UnknownError => Self::UnknownError,
+            ext::Error::Unknown => Self::Unknown,
             ext::Error::CalleeTrapped => Self::CalleeTrapped,
             ext::Error::CalleeReverted => Self::CalleeReverted,
             ext::Error::KeyNotFound => Self::KeyNotFound,

--- a/crates/env/src/error.rs
+++ b/crates/env/src/error.rs
@@ -45,7 +45,7 @@ pub enum Error {
     /// The account that was called is either no contract (e.g. user account) or is a tombstone.
     NotCallable,
     /// An unknown error has occurred.
-    UnknownError,
+    Unknown,
     /// The call to `seal_debug_message` had no effect because debug message
     /// recording was disabled.
     LoggingDisabled,

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 ink_primitives = { version = "3.0.0-rc3", path = "../../crates/primitives", default-features = false }
 ink_metadata = { version = "3.0.0-rc3", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc3", path = "../../crates/env", default-features = false, features = [ "ink-debug" ] }
+ink_env = { version = "3.0.0-rc3", path = "../../crates/env", default-features = false }
 ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-features = false }
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 ink_prelude = { version = "3.0.0-rc3", path = "../../crates/prelude", default-features = false }
@@ -21,7 +21,7 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [features]
-default = ["std"]
+default = ["std", "ink-debug"]
 std = [
     "ink_primitives/std",
     "ink_metadata",
@@ -35,3 +35,4 @@ std = [
 ]
 ink-as-dependency = []
 ink-experimental-engine = ["ink_env/ink-experimental-engine"]
+ink-debug = ["ink_env/ink-debug"]

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 ink_primitives = { version = "3.0.0-rc3", path = "../../crates/primitives", default-features = false }
 ink_metadata = { version = "3.0.0-rc3", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc3", path = "../../crates/env", default-features = false }
+ink_env = { version = "3.0.0-rc3", path = "../../crates/env", default-features = false, features = [ "ink-debug" ] }
 ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-features = false }
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 ink_prelude = { version = "3.0.0-rc3", path = "../../crates/prelude", default-features = false }

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 ink_primitives = { version = "3.0.0-rc3", path = "../../crates/primitives", default-features = false }
 ink_metadata = { version = "3.0.0-rc3", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc3", path = "../../crates/env", default-features = false }
+ink_env = { version = "3.0.0-rc3", path = "../../crates/env", default-features = false, features = [ "ink-debug" ] }
 ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-features = false }
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 ink_prelude = { version = "3.0.0-rc3", path = "../../crates/prelude", default-features = false }
@@ -21,7 +21,7 @@ path = "lib.rs"
 crate-type = ["cdylib"]
 
 [features]
-default = ["std", "ink-debug"]
+default = ["std"]
 std = [
     "ink_primitives/std",
     "ink_metadata",
@@ -35,4 +35,3 @@ std = [
 ]
 ink-as-dependency = []
 ink-experimental-engine = ["ink_env/ink-experimental-engine"]
-ink-debug = ["ink_env/ink-debug"]

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -486,7 +486,7 @@ mod multisig_plain {
         ///
         /// Its return value indicates whether the called transaction was successful.
         /// This can be called by anyone.
-        #[ink(message, payable)]
+        #[ink(message)]
         pub fn invoke_transaction(
             &mut self,
             trans_id: TransactionId,

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -484,7 +484,7 @@ mod multisig_plain {
 
         /// Invoke a confirmed execution without getting its output.
         ///
-        /// If the transaction which is invoked transfers value this value has
+        /// If the transaction which is invoked transfers value, this value has
         /// to be sent as payment with this call. The method will fail otherwise,
         /// and the transaction would then be reverted.
         ///

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -484,15 +484,20 @@ mod multisig_plain {
 
         /// Invoke a confirmed execution without getting its output.
         ///
+        /// If the transaction which is invoked transfers value this value has
+        /// to be sent as payment with this call. The method will fail otherwise,
+        /// and the transaction would then be reverted.
+        ///
         /// Its return value indicates whether the called transaction was successful.
         /// This can be called by anyone.
-        #[ink(message)]
+        #[ink(message, payable)]
         pub fn invoke_transaction(
             &mut self,
             trans_id: TransactionId,
         ) -> Result<(), Error> {
             self.ensure_confirmed(trans_id);
             let t = self.take_transaction(trans_id).expect(WRONG_TRANSACTION_ID);
+            assert!(self.env().transferred_balance() == t.transferred_value);
             let result = build_call::<<Self as ::ink_lang::ContractEnv>::Env>()
                 .callee(t.callee)
                 .gas_limit(t.gas_limit)

--- a/examples/multisig_plain/lib.rs
+++ b/examples/multisig_plain/lib.rs
@@ -486,7 +486,7 @@ mod multisig_plain {
         ///
         /// Its return value indicates whether the called transaction was successful.
         /// This can be called by anyone.
-        #[ink(message)]
+        #[ink(message, payable)]
         pub fn invoke_transaction(
             &mut self,
             trans_id: TransactionId,


### PR DESCRIPTION
* Fixes the broken `master` CI (clippy).
* Fixes two bugs in our examples, which I discovered while adding [`ink-waterfall`](https://github.com/paritytech/ink-waterfall) tests for those examples.
  In the case of `contract-transfer` I added a waterfall test which also checks if the `debug_println!` in that contract example actually appears on the console.