### PR TITLE
Actually add `refcount` as word

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -43,6 +43,7 @@ invariants
 kB
 layed
 multisig
+multi
 postfix
 prefilled
 recurse
@@ -58,6 +59,7 @@ validator
 variadic
 
 Django/S
+IP/S
 NFT/S
 accessor/S
 allocator/S

--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -26,6 +26,7 @@ cryptographic
 deallocate
 deallocation
 decodable
+decrement
 defrag
 defragmentation
 deploy
@@ -42,6 +43,7 @@ invariants
 kB
 layed
 multisig
+parameterize
 postfix
 prefilled
 recurse
@@ -50,10 +52,13 @@ scalability
 scalable
 stdin
 stdout
+tuple
+unordered
 untyped
 validator
 variadic
 
+Django/S
 NFT/S
 accessor/S
 allocator/S

--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -43,7 +43,6 @@ invariants
 kB
 layed
 multisig
-parameterize
 postfix
 prefilled
 recurse
@@ -73,6 +72,7 @@ hashmap/S
 instantiation/S
 layout/JG
 namespace/S
+parameterize/SD
 runtime/S
 struct/S
 vec/S

--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -45,6 +45,7 @@ multisig
 postfix
 prefilled
 recurse
+refcount
 scalability
 scalable
 stdin

--- a/.config/cargo_spellcheck.toml
+++ b/.config/cargo_spellcheck.toml
@@ -3,6 +3,16 @@ lang = "en_US"
 search_dirs = ["."]
 extra_dictionaries = ["cargo_spellcheck.dic"]
 
+# If set to `true`, the OS specific default search paths are skipped and only explicitly
+# specified ones are used.
+skip_os_lookups = true
+
+# Use the builtin dictionaries if none were found in in the configured lookup paths.
+# Usually combined with `skip_os_lookups=true` to enforce the `builtin` usage for
+# consistent results across distributions and CI runs.  Setting this will still use the
+# dictionaries specified in `extra_dictionaries = [..]` for topic specific lingo.
+use_builtin = true
+
 [Hunspell.quirks]
 allow_concatenation = true
 allow_dashes = true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,12 +153,12 @@ spellcheck:
     stage:                           workspace
     <<:                              *docker-env
     script:
-        - cargo spellcheck check --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1
+        - cargo spellcheck check -vvv --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1
         - for example in examples/*/; do
-            cargo spellcheck check --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 ${example};
+            cargo spellcheck check -vvv --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 ${example};
           done
         - for contract in ${DELEGATOR_SUBCONTRACTS}; do
-            cargo spellcheck check --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 examples/delegator/${contract}/;
+            cargo spellcheck check -vvv --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 examples/delegator/${contract}/;
           done
 
 codecov:


### PR DESCRIPTION
Looks like I made a pretty embarassing mistake in #828 since I didn't actually add
`refcount` to the dictionary list.

However, the curious thing is that the CI didn't complain as part of the PR. When the CI
re-ran after having the PR land on `master` it failed. 

Given that the CI jobs are the same between PRs and `master` (as far as I can tell
anyways) this suggests a spurrious failure of `cargo-spellcheck`.
`cargo-spellcheck`.
