### PR TITLE
Remove `Salt` in code generation during build_create

### DIFF
--- a/crates/lang/codegen/src/generator/cross_calling.rs
+++ b/crates/lang/codegen/src/generator/cross_calling.rs
@@ -685,7 +685,7 @@ impl CrossCalling<'_> {
             fn #ident(
                 #( #input_bindings : #input_types ),*
             ) -> Self::#output_ident {
-                ::ink_env::call::build_create::<Environment, Salt, Self>()
+                ::ink_env::call::build_create::<Environment, Self>()
                     .exec_input(
                         ::ink_env::call::ExecutionInput::new(
                             ::ink_env::call::Selector::new([ #( #composed_selector ),* ])


### PR DESCRIPTION
[build_create](https://github.com/paritytech/ink/blob/master/crates/env/src/call/create_builder.rs#L198) method supports only 2 generic parameters. But code [here](https://github.com/paritytech/ink/blob/master/crates/lang/codegen/src/generator/cross_calling.rs#L688) is passing 3 parametrs.
It causes a compilation error.