### PR TITLE
Add `ink-waterfall`  to CI

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -57,6 +57,9 @@ unordered
 untyped
 validator
 variadic
+metadata
+timestamp
+prepend
 
 Django/S
 IP/S

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ stages:
   - check
   - workspace
   - examples
+  - ink-waterfall
   - fuzz
   - publish
 
@@ -344,6 +345,19 @@ examples-docs:
         - for contract in ${DELEGATOR_SUBCONTRACTS}; do
             cargo doc --manifest-path examples/delegator/${contract}/Cargo.toml --document-private-items --verbose --no-deps;
           done
+
+
+#### stage:                        ink-waterfall
+
+ink-waterfall:
+  stage:                           ink-waterfall
+  variables:
+    UPSTREAM_PR_ID:                $CI_COMMIT_REF_NAME
+  trigger:
+    project:                       parity/ink-waterfall
+    branch:                        master
+    strategy:                      depend
+
 
 #### stage:                        publish
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -353,6 +353,7 @@ ink-waterfall:
   stage:                           ink-waterfall
   variables:
     UPSTREAM_PR_ID:                $CI_COMMIT_REF_NAME
+    CI_IMAGE:                      "paritytech/ink-waterfall-ci:latest"
   trigger:
     project:                       parity/ink-waterfall
     branch:                        master

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -77,7 +77,7 @@ pub trait Environment {
         + AsRef<[u8]>
         + AsMut<[u8]>;
 
-    /// The type of timestamps.
+    /// The type of a timestamp.
     type Timestamp: 'static
         + scale::Codec
         + Copy

--- a/crates/lang/ir/src/ir/config.rs
+++ b/crates/lang/ir/src/ir/config.rs
@@ -48,12 +48,12 @@ where
 {
     format_err!(
         snd.span(),
-        "encountered duplicate ink! `{}` config argument",
+        "encountered duplicate ink! `{}` configuration argument",
         name,
     )
     .into_combine(format_err!(
         fst.span(),
-        "first `{}` config argument here",
+        "first `{}` configuration argument here",
         name
     ))
 }
@@ -170,7 +170,7 @@ impl Default for Environment {
 mod tests {
     use super::*;
 
-    /// Asserts that the given input config attribute argument are converted
+    /// Asserts that the given input configuration attribute argument are converted
     /// into the expected ink! configuration or yields the expected error message.
     fn assert_try_from(
         input: ast::AttributeArgs,
@@ -273,7 +273,7 @@ mod tests {
                 env = ::my::env::Types,
                 env = ::my::other::env::Types,
             },
-            Err("encountered duplicate ink! `env` config argument"),
+            Err("encountered duplicate ink! `env` configuration argument"),
         );
     }
 }


### PR DESCRIPTION
[`ink-waterfall`](https://github.com/paritytech/ink-waterfall/) is in a state now where I think we can add it to the ink! CI and see how it goes.

The project now runs complete End-to-End tests against all our ink! examples for the `canvas-ui` as well as the `polkadot-js` UI.

At the moment a complete run of the tests takes between 7-10 minutes, depending on CI workload.