### PR TITLE
Update to `scale-info` `0.9`

### DIFF
--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -40,7 +40,7 @@ blake2 = { version = "0.9", optional = true }
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside the off-chain environment!
 rand = { version = "0.8", default-features = false, features = ["alloc"], optional = true }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [features]
 default = ["std"]

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -28,7 +28,7 @@ static_assertions = "1.1"
 
 [dev-dependencies]
 # required for the doctest of `env_access::EnvAccess::instantiate_contract`
-scale-info = { version = "0.6", default-features = false, features = ["derive"] }
+scale-info = { version = "0.9", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -31,7 +31,7 @@ ink_lang = { version = "3.0.0-rc3", path = ".." }
 ink_prelude = { version = "3.0.0-rc3", path = "../../prelude/" }
 
 trybuild = "1.0.24"
-scale-info = { version = "0.6", default-features = false, features = ["derive"] }
+scale-info = { version = "0.9", default-features = false, features = ["derive"] }
 
 [lib]
 name = "ink_lang_macro"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -21,7 +21,7 @@ ink_primitives = { version = "3.0.0-rc3", path = "../primitives/", default-featu
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.3.1"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "0.9", default-features = false, features = ["derive", "serde"] }
 
 [dev-dependencies]
 pretty_assertions = "0.7.1"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -21,7 +21,7 @@ ink_primitives = { version = "3.0.0-rc3", path = "../primitives/", default-featu
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.3.1"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
-scale-info = { version = "0.9", default-features = false, features = ["derive", "serde"] }
+scale-info = { version = "0.9", default-features = false, features = ["derive", "serde", "decode"] }
 
 [dev-dependencies]
 pretty_assertions = "0.7.1"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -17,7 +17,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 [dependencies]
 ink_prelude = { version = "3.0.0-rc3", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive", "full"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3.1"

--- a/crates/primitives/src/key.rs
+++ b/crates/primitives/src/key.rs
@@ -241,7 +241,9 @@ const _: () = {
         fn type_info() -> Type {
             Type::builder()
                 .path(Path::new("Key", "ink_primitives"))
-                .composite(Fields::unnamed().field_of::<[u8; 32]>("[u8; 32]"))
+                .composite(
+                    Fields::unnamed().field(|f| f.ty::<[u8; 32]>().type_name("[u8; 32]")),
+                )
         }
     }
 };

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -23,7 +23,7 @@ ink_prelude = { version = "3.0.0-rc3", path = "../prelude/", default-features = 
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1.0"
 array-init = { version = "2.0", default-features = false }
 

--- a/crates/storage/src/alloc/boxed/storage.rs
+++ b/crates/storage/src/alloc/boxed/storage.rs
@@ -68,8 +68,11 @@ const _: () = {
                 // .type_params(vec![scale_info::MetaType::new::<T>()])
                 .composite(
                     scale_info::build::Fields::named()
-                        .field_of::<DynamicAllocation>("allocation", "DynamicAllocation"),
-                )
+                        .field(|f| f
+                            .name("allocation")
+                            .ty::<DynamicAllocation>()
+                            .type_name("DynamicAllocation"),
+                ))
         }
     }
 };

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "contract_terminate"

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -13,7 +13,7 @@ ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features
 ink_prelude = { version = "3.0.0-rc3", path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "contract_transfer"

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -16,7 +16,7 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 adder = { version = "3.0.0-rc3", path = "adder", default-features = false, features = ["ink-as-dependency"] }
 subber = { version = "3.0.0-rc3", path = "subber", default-features = false, features = ["ink-as-dependency"] }
 accumulator = { version = "3.0.0-rc3", path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "delegator"

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc3", path = "../../../crates/storage", default
 ink_lang = { version = "3.0.0-rc3", path = "../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "accumulator"

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -14,7 +14,7 @@ ink_lang = { version = "3.0.0-rc3", path = "../../../crates/lang", default-featu
 accumulator = { version = "3.0.0-rc3", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "adder"

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -14,7 +14,7 @@ ink_lang = { version = "3.0.0-rc3", path = "../../../crates/lang", default-featu
 accumulator = { version = "3.0.0-rc3", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "subber"

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "dns"

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "erc20"

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "erc721"

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 [dependencies]
 ink_primitives = { version = "3.0.0-rc3", path = "../../crates/primitives", default-features = false }
 ink_metadata = { version = "3.0.0-rc3", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc3", path = "../../crates/env", default-features = false }
+ink_env = { version = "3.0.0-rc3", path = "../../crates/env", default-features = false, features = ["ink-debug"] }
 ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-features = false }
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "flipper"

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "incrementer"

--- a/examples/multisig_plain/Cargo.toml
+++ b/examples/multisig_plain/Cargo.toml
@@ -13,7 +13,7 @@ ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features
 ink_prelude = { version = "3.0.0-rc3", path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "multisig_plain"

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { path = "../../crates/storage", default-features = false }
 ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "rand_extension"

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "trait_erc20"

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc3", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc3", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.9", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "trait_flipper"


### PR DESCRIPTION
*WIP*

# todo

- [ ] Update `cargo-contract`
- [ ] Esnure `polkadot-js/api` is updated to handle the new metadata format for Canvas UI and polkadot.js/apps