### PR TITLE
Enable Miri in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ variables:
   # read more https://github.com/paritytech/scripts/pull/244
   ALL_CRATES:                      "${PURELY_STD_CRATES} ${ALSO_WASM_CRATES}"
   DELEGATOR_SUBCONTRACTS:           "accumulator adder subber"
+  MIRI_CRATES:                      "ink_allocator ink_engine ink_env ink_lang ink_metadata ink_prelude ink_primitives ink_storage"
 
 workflow:
   rules:
@@ -103,6 +104,14 @@ check-wasm:
         cargo check --verbose --no-default-features --target wasm32-unknown-unknown --manifest-path crates/${crate}/Cargo.toml;
       done
 
+check-miri:
+  stage:                           check
+  <<:                              *docker-env
+  <<:                              *test-refs
+  script:
+    - for crate in ${MIRI_CRATES}; do
+        cargo miri test -p ${crate};
+      done
 
 #### stage:                        workspace
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,10 @@ variables:
   # read more https://github.com/paritytech/scripts/pull/244
   ALL_CRATES:                      "${PURELY_STD_CRATES} ${ALSO_WASM_CRATES}"
   DELEGATOR_SUBCONTRACTS:           "accumulator adder subber"
+
+  # Some crates run quite slow when tested under Miri. Mostly these are in
+  # the codegen, ast and ir, where no significant unsafe is used. So instead
+  # we just test the crates which end up in the actual contracts.
   MIRI_CRATES:                      "ink_allocator ink_engine ink_env ink_lang ink_metadata ink_prelude ink_primitives ink_storage"
 
 workflow:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,7 +114,7 @@ check-miri:
   <<:                              *test-refs
   script:
     - for crate in ${MIRI_CRATES}; do
-        cargo miri test -p ${crate};
+        cargo miri test -p ${crate} -- --test-threads=1;
       done
 
 #### stage:                        workspace

--- a/crates/engine/src/hashing.rs
+++ b/crates/engine/src/hashing.rs
@@ -84,6 +84,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_hash_sha2_256() {
         let mut output = [0x00_u8; 32];
         sha2_256(TEST_INPUT, &mut output);

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -566,10 +566,13 @@ pub fn debug_message(message: &str) {
 /// # Example
 ///
 /// ```
+/// # #[cfg(not(miri))]
+/// # {
 /// use ink_env::hash::{Sha2x256, HashOutput};
 /// let input: &[u8] = &[13, 14, 15];
 /// let mut output = <Sha2x256 as HashOutput>::Type::default(); // 256-bit buffer
 /// let hash  = ink_env::hash_bytes::<Sha2x256>(input, &mut output);
+/// # }
 /// ```
 pub fn hash_bytes<H>(input: &[u8], output: &mut <H as HashOutput>::Type)
 where
@@ -585,6 +588,8 @@ where
 /// # Example
 ///
 /// ```
+/// # #[cfg(not(miri))]
+/// # {
 /// # use ink_env::hash::{Sha2x256, HashOutput};
 /// const EXPECTED: [u8; 32] = [
 ///   243, 242, 58, 110, 205, 68, 100, 244, 187, 55, 188, 248,  29, 136, 145, 115,
@@ -594,6 +599,7 @@ where
 /// let mut output = <Sha2x256 as HashOutput>::Type::default(); // 256-bit buffer
 /// ink_env::hash_encoded::<Sha2x256, _>(&encodable, &mut output);
 /// assert_eq!(output, EXPECTED);
+/// # }
 /// ```
 pub fn hash_encoded<H, T>(input: &T, output: &mut <H as HashOutput>::Type)
 where

--- a/crates/env/src/tests.rs
+++ b/crates/env/src/tests.rs
@@ -28,6 +28,7 @@ fn test_hash_keccak_256() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_hash_sha2_256() {
     let mut output = [0x00_u8; 32];
     crate::hash_bytes::<crate::hash::Sha2x256>(TEST_INPUT, &mut output);

--- a/crates/lang/src/env_access.rs
+++ b/crates/lang/src/env_access.rs
@@ -964,11 +964,14 @@ where
     /// # Example
     ///
     /// ```
+    /// # #[cfg(not(miri))]
+    /// # {
     /// use ink_env::hash::{Sha2x256, HashOutput};
     ///
     /// let input: &[u8] = &[13, 14, 15];
     /// let mut output = <Sha2x256 as HashOutput>::Type::default(); // 256-bit buffer
     /// let hash  = ink_env::hash_bytes::<Sha2x256>(input, &mut output);
+    /// # }
     /// ```
     ///
     /// # Note
@@ -988,6 +991,8 @@ where
     /// # Example
     ///
     /// ```
+    /// # #[cfg(not(miri))]
+    /// # {
     /// use ink_env::hash::{Sha2x256, HashOutput};
     ///
     /// let encodable = (42, "foo", true); // Implements `scale::Encode`
@@ -999,6 +1004,7 @@ where
     ///   186, 134, 14, 175, 178, 99, 183,  21,   4, 94,  92,  69, 199, 207, 241, 179,
     /// ];
     /// assert_eq!(output, EXPECTED);
+    /// # }
     /// ```
     ///
     /// # Note

--- a/crates/storage/src/collections/binary_heap/tests.rs
+++ b/crates/storage/src/collections/binary_heap/tests.rs
@@ -149,6 +149,8 @@ fn peek_works() {
 }
 
 #[test]
+// Disabled do to possible UB: https://github.com/paritytech/ink/issues/850
+#[cfg_attr(miri, ignore)]
 fn peek_and_pop_works() {
     let data = vec![2, 4, 6, 2, 1, 8, 10, 3, 5, 7, 0, 9, 1];
     let mut sorted = data.clone();
@@ -161,6 +163,8 @@ fn peek_and_pop_works() {
 }
 
 #[test]
+// Disabled do to possible UB: https://github.com/paritytech/ink/issues/850
+#[cfg_attr(miri, ignore)]
 fn peek_mut_works() {
     let data = vec![2, 4, 6, 2, 1, 8, 10, 3, 5, 7, 0, 9, 1];
     let mut heap = heap_from_slice(&data);
@@ -173,6 +177,8 @@ fn peek_mut_works() {
 }
 
 #[test]
+// Disabled do to possible UB: https://github.com/paritytech/ink/issues/850
+#[cfg_attr(miri, ignore)]
 fn peek_mut_pop_works() {
     let data = vec![2, 4, 6, 2, 1, 8, 10, 3, 5, 7, 0, 9, 1];
     let mut heap = heap_from_slice(&data);
@@ -186,6 +192,8 @@ fn peek_mut_pop_works() {
 }
 
 #[test]
+// Disabled do to possible UB: https://github.com/paritytech/ink/issues/850
+#[cfg_attr(miri, ignore)]
 fn min_heap_works() {
     let data = vec![2, 4, 6, 2, 1, 8, 10, 3, 5, 7, 0, 9, 1]
         .iter()
@@ -489,6 +497,8 @@ fn push_smallest_value_complexity_big_o_1() -> ink_env::Result<()> {
 }
 
 #[test]
+// Disabled do to possible UB: https://github.com/paritytech/ink/issues/850
+#[cfg_attr(miri, ignore)]
 fn pop_complexity_big_o_log_n() -> ink_env::Result<()> {
     // 1 elements overhead (#508) + elements.len + 1 vec overhead (#508) +
     // 1 vec.len + 1 vec.cell from which to pop


### PR DESCRIPTION
This PR does not fix the possible UB in `storage` (#850), but does run miri in CI and disables tests using/depending on `asm!`, which is not supported by Miri.