### PR TITLE
Fix `cargo spellcheck` failure in CI

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -72,7 +72,7 @@ accessor/S
 allocator/S
 backend/S
 blockchain/S
-callable/S
+callable/MS
 defragment/SD
 encoding/S
 endian/P

--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -1,4 +1,4 @@
-80
+90
 
 ABI
 AST
@@ -65,11 +65,14 @@ prepend
 
 Django/S
 IP/S
+ink!/S
 NFT/S
+SCALE/S
 accessor/S
 allocator/S
 backend/S
 blockchain/S
+callable/S
 defragment/SD
 encoding/S
 endian/P

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -100,7 +100,7 @@ pub trait Erc1155 {
 
     /// Perform a batch transfer of `token_ids` to the `to` account from the `from` account.
     ///
-    /// The number of `values` specified to be transfer must match the number of `token_ids`,
+    /// The number of `values` specified to be transferred must match the number of `token_ids`,
     /// otherwise this call will revert.
     ///
     /// Note that the call does not have to originate from the `from` account, and may originate


### PR DESCRIPTION
See https://gitlab.parity.io/parity/ink/-/jobs/1010416.