### PR TITLE
Temporarily remove `codecov` CI check

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,51 +186,6 @@ spellcheck:
         cargo spellcheck check -vvv --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 examples/delegator/${contract}/;
       done
 
-codecov:
-  stage:                           workspace
-  <<:                              *docker-env
-  <<:                              *test-refs
-  needs:
-    - job:                         check-std
-      artifacts:                   false
-  variables:
-    # For codecov it's sufficient to run the fuzz tests only once.
-    QUICKCHECK_TESTS:              1
-    # Variables partly came from https://github.com/mozilla/grcov/blob/master/README.md
-    CARGO_INCREMENTAL:             0
-    RUSTFLAGS:                     "-Zprofile -Zmir-opt-level=0 -Ccodegen-units=1
-                                      -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
-    # The `cargo-taurpalin` coverage reporting tool seems to have better code instrumentation and thus
-    # produces better results for Rust codebases in general. However, unlike `grcov` it requires
-    # running docker with `--security-opt seccomp=unconfined` which is why we use `grcov` instead.
-  before_script:
-    - *rust-info-script
-    - unset "CARGO_TARGET_DIR"
-    - cargo clean
-  script:
-    # RUSTFLAGS are the cause target cache can't be used here
-    - cargo build --verbose --all-features --workspace
-    - cargo test --verbose --all-features --no-fail-fast --workspace
-
-    # Just needed as long as we have the `ink-experimental-engine` feature.
-    # We must additionally run the coverage without `--all-features` here -- this
-    # would imply the feature `ink-experimental-engine`. So in order to still run
-    # the tests without the experimental engine feature we need this command.
-    - cargo test --verbose --features std --no-fail-fast --workspace
-
-    # coverage with branches
-    - grcov . --source-dir . --output-type lcov --llvm --branch --ignore-not-existing
-        --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
-    - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
-    # We'd like to not use a remote bash script for uploading the coverage reports,
-    # however this job seems to be more tricky than we hoped.
-    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_P_TOKEN" -f lcov-w-branch-fixed.info
-    # lines coverage
-    - grcov . --source-dir . --output-type lcov --llvm --ignore-not-existing
-        --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
-    - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
-    - bash <(curl -s https://codecov.io/bash) -f lcov-lines-fixed.info
-
 clippy-std:
   stage:                           workspace
   <<:                              *docker-env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,7 @@ workflow:
   - cargo --version
   - rustup +nightly show
   - cargo +nightly --version
+  - cargo spellcheck --version
   - bash --version
   - sccache -s
 


### PR DESCRIPTION
* There is some strange linker error in the `master` CI.
* We can't reproduce it locally.
* We suspect that it might have to do with an outdated docker image.
* The failing `master` CI blocks publishing a new `ink-ci-linux:production` image.
* The `codecov` check is broken since a few days anyway (due to some token issue). I created this ticket at the time: https://github.com/paritytech/ci_cd/issues/160.
* We can bring the check back as soon as we sorted the linker error out in a PR.