### PR TITLE
Spellchecking fixes for failed `master` CI

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -59,15 +59,16 @@ unordered
 untyped
 validator
 variadic
+Verbatim
 metadata
 timestamp
 prepend
 
 Django/S
 IP/S
-ink!/S
+ink!/MS
 NFT/S
-SCALE/S
+SCALE/MS
 accessor/S
 allocator/S
 backend/S


### PR DESCRIPTION
Fixes the errors from https://gitlab.parity.io/parity/ink/-/jobs/1019096.