### PR TITLE
Fix spellchecking CI

### DIFF
--- a/crates/lang/ir/src/ir/chain_extension.rs
+++ b/crates/lang/ir/src/ir/chain_extension.rs
@@ -326,7 +326,7 @@ impl ChainExtension {
     ///     - associated constants (`const`)
     ///     - associated types (`type`)
     ///     - macros definitions or usages
-    ///     - unknown token sequences (`Verbatim`'s)
+    ///     - unknown token sequences (`Verbatim`s)
     ///     - methods with default implementations
     /// - If the trait contains methods which do not respect the ink! trait definition requirements:
     ///     - All trait methods must not have a `self` receiver.

--- a/crates/lang/ir/src/ir/trait_def.rs
+++ b/crates/lang/ir/src/ir/trait_def.rs
@@ -357,7 +357,7 @@ impl InkTrait {
     ///     - associated constants (`const`)
     ///     - associated types (`type`)
     ///     - macros definitions or usages
-    ///     - unknown token sequences (`Verbatim`'s)
+    ///     - unknown token sequences (`Verbatim`s)
     ///     - methods with default implementations
     /// - If the trait contains methods which do not respect the ink! trait definition requirements:
     ///     - All trait methods need to be declared as either `#[ink(message)]` or `#[ink(constructor)]`


### PR DESCRIPTION
Fix for https://gitlab.parity.io/parity/ink/-/jobs/1019721 in `master` CI.