### PR TITLE
Fix Codecov measuring and Publishing

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -59,15 +59,16 @@ unordered
 untyped
 validator
 variadic
+Verbatim
 metadata
 timestamp
 prepend
 
 Django/S
 IP/S
-ink!/S
+ink!/MS
 NFT/S
-SCALE/S
+SCALE/MS
 accessor/S
 allocator/S
 backend/S

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,6 +187,51 @@ spellcheck:
         cargo spellcheck check -vvv --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 examples/delegator/${contract}/;
       done
 
+codecov:
+  stage:                           workspace
+  <<:                              *docker-env
+  <<:                              *test-refs
+  needs:
+    - job:                         check-std
+      artifacts:                   false
+  variables:
+    # For codecov it's sufficient to run the fuzz tests only once.
+    QUICKCHECK_TESTS:              1
+    # Variables partly came from https://github.com/mozilla/grcov/blob/master/README.md
+    CARGO_INCREMENTAL:             0
+    RUSTFLAGS:                     "-Zprofile -Zmir-opt-level=0 -Ccodegen-units=1
+                                      -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
+    # The `cargo-taurpalin` coverage reporting tool seems to have better code instrumentation and thus
+    # produces better results for Rust codebases in general. However, unlike `grcov` it requires
+    # running docker with `--security-opt seccomp=unconfined` which is why we use `grcov` instead.
+  before_script:
+    - *rust-info-script
+    - unset "CARGO_TARGET_DIR"
+    - cargo clean
+  script:
+    # RUSTFLAGS are the cause target cache can't be used here
+    - cargo build --verbose --all-features --workspace
+    - cargo test --verbose --all-features --no-fail-fast --workspace
+
+    # Just needed as long as we have the `ink-experimental-engine` feature.
+    # We must additionally run the coverage without `--all-features` here -- this
+    # would imply the feature `ink-experimental-engine`. So in order to still run
+    # the tests without the experimental engine feature we need this command.
+    - cargo test --verbose --features std --no-fail-fast --workspace
+
+    # coverage with branches
+    - grcov . --source-dir . --output-type lcov --llvm --branch --ignore-not-existing
+        --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
+    - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
+    # We'd like to not use a remote bash script for uploading the coverage reports,
+    # however this job seems to be more tricky than we hoped.
+    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_P_TOKEN" -f lcov-w-branch-fixed.info
+    # lines coverage
+    - grcov . --source-dir . --output-type lcov --llvm --ignore-not-existing
+        --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
+    - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
+    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_P_TOKEN" -f lcov-lines-fixed.info
+
 clippy-std:
   stage:                           workspace
   <<:                              *docker-env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,12 +225,15 @@ codecov:
     - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
     # We'd like to not use a remote bash script for uploading the coverage reports,
     # however this job seems to be more tricky than we hoped.
-    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_P_TOKEN" -f lcov-w-branch-fixed.info
+    # -t TOKEN     Set the private repository token
+    # -f FILE     Target file(s) to upload
+    # -Z           Exit with 1 if not successful. Default will Exit with 0
+    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_P_TOKEN" -f lcov-w-branch-fixed.info -Z
     # lines coverage
     - grcov . --source-dir . --output-type lcov --llvm --ignore-not-existing
         --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
     - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
-    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" -f lcov-lines-fixed.info
+    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" -f lcov-lines-fixed.info -Z
 
 clippy-std:
   stage:                           workspace

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,7 @@ workflow:
   - cargo --version
   - rustup +nightly show
   - cargo +nightly --version
+  - cargo spellcheck --version
   - bash --version
   - sccache -s
 
@@ -185,51 +186,6 @@ spellcheck:
     - for contract in ${DELEGATOR_SUBCONTRACTS}; do
         cargo spellcheck check -vvv --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 examples/delegator/${contract}/;
       done
-
-codecov:
-  stage:                           workspace
-  <<:                              *docker-env
-  <<:                              *test-refs
-  needs:
-    - job:                         check-std
-      artifacts:                   false
-  variables:
-    # For codecov it's sufficient to run the fuzz tests only once.
-    QUICKCHECK_TESTS:              1
-    # Variables partly came from https://github.com/mozilla/grcov/blob/master/README.md
-    CARGO_INCREMENTAL:             0
-    RUSTFLAGS:                     "-Zprofile -Zmir-opt-level=0 -Ccodegen-units=1
-                                      -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
-    # The `cargo-taurpalin` coverage reporting tool seems to have better code instrumentation and thus
-    # produces better results for Rust codebases in general. However, unlike `grcov` it requires
-    # running docker with `--security-opt seccomp=unconfined` which is why we use `grcov` instead.
-  before_script:
-    - *rust-info-script
-    - unset "CARGO_TARGET_DIR"
-    - cargo clean
-  script:
-    # RUSTFLAGS are the cause target cache can't be used here
-    - cargo build --verbose --all-features --workspace
-    - cargo test --verbose --all-features --no-fail-fast --workspace
-
-    # Just needed as long as we have the `ink-experimental-engine` feature.
-    # We must additionally run the coverage without `--all-features` here -- this
-    # would imply the feature `ink-experimental-engine`. So in order to still run
-    # the tests without the experimental engine feature we need this command.
-    - cargo test --verbose --features std --no-fail-fast --workspace
-
-    # coverage with branches
-    - grcov . --source-dir . --output-type lcov --llvm --branch --ignore-not-existing
-        --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
-    - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
-    # We'd like to not use a remote bash script for uploading the coverage reports,
-    # however this job seems to be more tricky than we hoped.
-    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_P_TOKEN" -f lcov-w-branch-fixed.info
-    # lines coverage
-    - grcov . --source-dir . --output-type lcov --llvm --ignore-not-existing
-        --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
-    - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
-    - bash <(curl -s https://codecov.io/bash) -f lcov-lines-fixed.info
 
 clippy-std:
   stage:                           workspace

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -218,20 +218,15 @@ codecov:
   script:
     - cargo build --verbose --all-features --workspace
     - cargo test --verbose --all-features --no-fail-fast --workspace
-
     # Just needed as long as we have the `ink-experimental-engine` feature.
     # We must additionally run the coverage without `--all-features` here -- this
     # would imply the feature `ink-experimental-engine`. So in order to still run
     # the tests without the experimental engine feature we need this command.
     - cargo test --verbose --features std --no-fail-fast --workspace
-
     # coverage with branches
     - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm --branch
         --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
     - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
-    # We'd like to not use a remote bash script for uploading the coverage reports,
-    # binary named `codecov` is already installed in the CI image, just doesn't work
-    # https://github.com/codecov/uploader/issues/217 https://github.com/codecov/uploader/issues/222
     - codecov --token "$CODECOV_P_TOKEN" --file lcov-w-branch-fixed.info --nonZero
     # lines coverage
     - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -230,7 +230,7 @@ codecov:
     - grcov . --source-dir . --output-type lcov --llvm --ignore-not-existing
         --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
     - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
-    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_P_TOKEN" -f lcov-lines-fixed.info
+    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" -f lcov-lines-fixed.info
 
 clippy-std:
   stage:                           workspace

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,19 +197,21 @@ codecov:
   variables:
     # For codecov it's sufficient to run the fuzz tests only once.
     QUICKCHECK_TESTS:              1
-    # Variables partly came from https://github.com/mozilla/grcov/blob/master/README.md
+    # Now we're using the MIR source-based Rust test coverage, the setup assumes that default
+    # toolchain is nightly and both `grcov` and `rustup component add llvm-tools-preview` are
+    # installed on it.
+    RUSTFLAGS:                     "-Zinstrument-coverage"
+    LLVM_PROFILE_FILE:             "llvmcoveragedata-%p-%m.profraw"
     CARGO_INCREMENTAL:             0
-    RUSTFLAGS:                     "-Zprofile -Zmir-opt-level=0 -Ccodegen-units=1
-                                      -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
     # The `cargo-taurpalin` coverage reporting tool seems to have better code instrumentation and thus
     # produces better results for Rust codebases in general. However, unlike `grcov` it requires
     # running docker with `--security-opt seccomp=unconfined` which is why we use `grcov` instead.
   before_script:
     - *rust-info-script
+    # RUSTFLAGS are the cause target cache can't be used here
     - unset "CARGO_TARGET_DIR"
     - cargo clean
   script:
-    # RUSTFLAGS are the cause target cache can't be used here
     - cargo build --verbose --all-features --workspace
     - cargo test --verbose --all-features --no-fail-fast --workspace
 
@@ -220,17 +222,18 @@ codecov:
     - cargo test --verbose --features std --no-fail-fast --workspace
 
     # coverage with branches
-    - grcov . --source-dir . --output-type lcov --llvm --branch --ignore-not-existing
-        --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
+    - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm --branch
+        --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
     - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
     # We'd like to not use a remote bash script for uploading the coverage reports,
-    # however this job seems to be more tricky than we hoped.
-    - codecov --token "$CODECOV_P_TOKEN" --file lcov-w-branch-fixed.info --nonZero
+    # binary named `codecov` is already installed in the CI image, just doesn't work
+    # https://github.com/codecov/uploader/issues/217 https://github.com/codecov/uploader/issues/222
+    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_P_TOKEN" -f lcov-w-branch-fixed.info -Z
     # lines coverage
-    - grcov . --source-dir . --output-type lcov --llvm --ignore-not-existing
-        --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
+    - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm
+        --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
     - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
-    - codecov --token "$CODECOV_TOKEN" --file lcov-lines-fixed.info --nonZero
+    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" -f lcov-lines-fixed.info -Z
 
 clippy-std:
   stage:                           workspace

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,8 +209,11 @@ codecov:
   before_script:
     - *rust-info-script
     # RUSTFLAGS are the cause target cache can't be used here
-    - unset "CARGO_TARGET_DIR"
-    - cargo clean
+    # FIXME: try with cache
+    # - unset "CARGO_TARGET_DIR"
+    # - cargo clean
+    # make sure there's no stale coverage artifacts
+    - find . -name "*.profraw" -type f -delete
   script:
     - cargo build --verbose --all-features --workspace
     - cargo test --verbose --all-features --no-fail-fast --workspace
@@ -228,12 +231,12 @@ codecov:
     # We'd like to not use a remote bash script for uploading the coverage reports,
     # binary named `codecov` is already installed in the CI image, just doesn't work
     # https://github.com/codecov/uploader/issues/217 https://github.com/codecov/uploader/issues/222
-    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_P_TOKEN" -f lcov-w-branch-fixed.info -Z
+    - codecov --token "$CODECOV_P_TOKEN" --file lcov-w-branch-fixed.info --nonZero
     # lines coverage
     - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm
         --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
     - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
-    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" -f lcov-lines-fixed.info -Z
+    - codecov --token "$CODECOV_TOKEN" --file lcov-lines-fixed.info --nonZero
 
 clippy-std:
   stage:                           workspace

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,9 +209,10 @@ codecov:
   before_script:
     - *rust-info-script
     # RUSTFLAGS are the cause target cache can't be used here
-    # FIXME: try with cache
-    # - unset "CARGO_TARGET_DIR"
-    # - cargo clean
+    # FIXME: cust-covfix doesn't support the external target dir
+    # https://github.com/Kogia-sima/rust-covfix/issues/7
+    - unset "CARGO_TARGET_DIR"
+    - cargo clean
     # make sure there's no stale coverage artifacts
     - find . -name "*.profraw" -type f -delete
   script:
@@ -225,7 +226,7 @@ codecov:
     - cargo test --verbose --features std --no-fail-fast --workspace
 
     # coverage with branches
-    - grcov . --binary-path ${CARGO_TARGET_DIR}/debug/ --source-dir . --output-type lcov --llvm --branch
+    - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm --branch
         --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
     - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
     # We'd like to not use a remote bash script for uploading the coverage reports,
@@ -233,7 +234,7 @@ codecov:
     # https://github.com/codecov/uploader/issues/217 https://github.com/codecov/uploader/issues/222
     - codecov --token "$CODECOV_P_TOKEN" --file lcov-w-branch-fixed.info --nonZero
     # lines coverage
-    - grcov . --binary-path ${CARGO_TARGET_DIR}/debug/ --source-dir . --output-type lcov --llvm
+    - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm
         --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
     - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
     - codecov --token "$CODECOV_TOKEN" --file lcov-lines-fixed.info --nonZero

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,7 +225,7 @@ codecov:
     - cargo test --verbose --features std --no-fail-fast --workspace
 
     # coverage with branches
-    - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm --branch
+    - grcov . --binary-path ${CARGO_TARGET_DIR}/debug/ --source-dir . --output-type lcov --llvm --branch
         --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
     - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
     # We'd like to not use a remote bash script for uploading the coverage reports,
@@ -233,7 +233,7 @@ codecov:
     # https://github.com/codecov/uploader/issues/217 https://github.com/codecov/uploader/issues/222
     - codecov --token "$CODECOV_P_TOKEN" --file lcov-w-branch-fixed.info --nonZero
     # lines coverage
-    - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm
+    - grcov . --binary-path ${CARGO_TARGET_DIR}/debug/ --source-dir . --output-type lcov --llvm
         --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
     - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
     - codecov --token "$CODECOV_TOKEN" --file lcov-lines-fixed.info --nonZero

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,15 +225,12 @@ codecov:
     - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
     # We'd like to not use a remote bash script for uploading the coverage reports,
     # however this job seems to be more tricky than we hoped.
-    # -t TOKEN     Set the private repository token
-    # -f FILE     Target file(s) to upload
-    # -Z           Exit with 1 if not successful. Default will Exit with 0
-    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_P_TOKEN" -f lcov-w-branch-fixed.info -Z
+    - codecov --token "$CODECOV_P_TOKEN" --file lcov-w-branch-fixed.info --nonZero
     # lines coverage
     - grcov . --source-dir . --output-type lcov --llvm --ignore-not-existing
         --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
     - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
-    - bash <(curl -s https://codecov.io/bash) -t "$CODECOV_TOKEN" -f lcov-lines-fixed.info -Z
+    - codecov --token "$CODECOV_TOKEN" --file lcov-lines-fixed.info --nonZero
 
 clippy-std:
   stage:                           workspace


### PR DESCRIPTION
Apparently, after their security issue, Codecov decided to fix up some security. Now they require tokens even for public projects.
As for failing after the script, it used to before, but it's on their side, so now it does :-1: . This is fixed with `-Z` option.

UPD: in fact, they've released a safer option to upload the test cov results, a binary. https://github.com/paritytech/scripts/pull/318
UPD2: which does not actually work so far.

CC: https://github.com/paritytech/ink/pull/857 
Closes: https://github.com/paritytech/ci_cd/issues/160