### PR TITLE
Fix `clippy::self-named-constructor`

### DIFF
--- a/crates/storage/src/alloc/boxed/mod.rs
+++ b/crates/storage/src/alloc/boxed/mod.rs
@@ -72,7 +72,7 @@ where
     fn lazy(allocation: DynamicAllocation) -> Self {
         Self {
             allocation,
-            value: Lazy::lazy(allocation.key()),
+            value: Lazy::from_key(allocation.key()),
         }
     }
 

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -118,7 +118,7 @@ where
 
     /// Creates a true lazy storage value for the given key.
     #[must_use]
-    pub(crate) fn lazy(key: Key) -> Self {
+    pub(crate) fn from_key(key: Key) -> Self {
         Self {
             cell: LazyCell::lazy(key),
         }


### PR DESCRIPTION
The `master` CI currently fails because of this:
https://gitlab.parity.io/parity/ink/-/jobs/1021277