### PR TITLE
Add Fuzz Testing to Bump Allocator

### DIFF
--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -26,3 +26,4 @@ quickcheck_macros = "1"
 default = ["std"]
 std = []
 wee-alloc = ["wee_alloc"]
+ink-fuzz-tests = ["std"]

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -18,6 +18,10 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 cfg-if = "1.0"
 wee_alloc = { version = "0.4", default-features = false, optional = true }
 
+[dev-dependencies]
+quickcheck = "1"
+quickcheck_macros = "1"
+
 [features]
 default = ["std"]
 std = []

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -285,9 +285,8 @@ mod fuzz_tests {
         TestResult,
     };
 
-    // #[ignore]
     #[quickcheck]
-    fn fuzz_should_allocate_random_bytes_that_do_not_overflow(n: usize) -> TestResult {
+    fn should_allocate_arbitrary_sized_bytes(n: usize) -> TestResult {
         // If `n` is going to overflow we don't want to check it here (we'll check the overflow
         // case in another test)
         if n.checked_add(PAGE_SIZE - 1).is_none() {
@@ -309,9 +308,8 @@ mod fuzz_tests {
         TestResult::passed()
     }
 
-    // #[ignore]
     #[quickcheck]
-    fn fuzz_should_not_allocate_if_it_overflows(n: usize) -> TestResult {
+    fn should_not_allocate_arbitrary_bytes_if_they_overflow(n: usize) -> TestResult {
         // In the last test we ignored the overflow case, now we ignore the valid cases
         if n.checked_add(PAGE_SIZE - 1).is_some() {
             return TestResult::discard()
@@ -337,10 +335,8 @@ mod fuzz_tests {
     //
     // Each of the Vec's represents one sequence of allocations. Within each sequence the
     // individual size of allocations will be randomly selected by `quickcheck`.
-    //
-    // #[ignore]
     #[quickcheck]
-    fn fuzz_variable_length_and_size_sequences_are_allocated(
+    fn should_allocate_arbitrary_byte_sequences(
         sequences: Vec<Vec<usize>>,
     ) -> TestResult {
         if sequences.is_empty() {
@@ -426,8 +422,13 @@ mod fuzz_tests {
         TestResult::passed()
     }
 
+    // For this test we have sequences of allocations which will eventually overflow the maximum
+    // amount of pages (in practice this means our heap will be OOM).
+    //
+    // We don't care about the allocations that succeed (those are checked in other tests), we just
+    // care that eventually an allocation doesn't success.
     #[quickcheck]
-    fn fuzz_variable_length_allocations_eventually_overflow_but_do_not_allocate(
+    fn should_not_allocate_arbitrary_byte_sequences_which_eventually_overflow(
         sequences: Vec<Vec<usize>>,
     ) -> TestResult {
         if sequences.is_empty() {
@@ -467,9 +468,7 @@ mod fuzz_tests {
                 results.push(inner.alloc(layout));
             }
 
-            // We don't care about the pointers returned during the valid allocations (those are
-            // checked by other tests), but we do want to ensure that at least one of those
-            // allocations overflowed our calculations.
+            // Ensure that at least one of the allocations ends up overflowing our calculations.
             assert!(results.iter().any(|r| r.is_none()));
         }
 

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -267,7 +267,7 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "ink-fuzz-tests"))]
 mod fuzz_tests {
     use super::*;
     use quickcheck::{

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -239,3 +239,23 @@ mod tests {
         assert_eq!(inner.next, expected_alloc_start);
     }
 }
+
+#[cfg(test)]
+mod fuzz_tests {
+    use super::*;
+    use quickcheck::quickcheck;
+
+    #[quickcheck]
+    fn allocate_random_vec(n: usize) {
+        let mut inner = InnerAlloc::new();
+
+        let layout = Layout::from_size_align(n, std::mem::size_of::<usize>()).unwrap();
+        assert_eq!(inner.alloc(layout), Some(0));
+
+        let expected_limit = PAGE_SIZE;
+        assert_eq!(inner.upper_limit, expected_limit);
+
+        let expected_alloc_start = n * std::mem::size_of::<u8>();
+        assert_eq!(inner.next, expected_alloc_start);
+    }
+}

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -137,6 +137,11 @@ impl InnerAlloc {
     }
 }
 
+/// Calculates the number of pages of memory needed for an allocation of `size` bytes.
+///
+/// This function rounds up to the next page. For example, if we have an allocation of
+/// `size = PAGE_SIZE / 2` this function will indicate that one page is required to satisfy
+/// the allocation.
 #[inline]
 fn required_pages(size: usize) -> Option<usize> {
     size.checked_add(PAGE_SIZE - 1)
@@ -301,7 +306,7 @@ mod fuzz_tests {
 
     #[quickcheck]
     fn should_not_allocate_arbitrary_bytes_if_they_overflow(n: usize) -> TestResult {
-        // In the last test we ignored the overflow case, now we ignore the valid cases
+        // In the previous test we ignored the overflow case, now we ignore the valid cases
         if n.checked_add(PAGE_SIZE - 1).is_some() {
             return TestResult::discard()
         }
@@ -346,15 +351,15 @@ mod fuzz_tests {
         TestResult::passed()
     }
 
-    // The idea behind this fuzz test is to check a series of allocation sequences. For
-    // example, we maybe have back to back runs as follows:
-    //
-    // 1. vec![1, 2, 3]
-    // 2. vec![4, 5, 6, 7]
-    // 3. vec![8]
-    //
-    // Each of the Vec's represents one sequence of allocations. Within each sequence the
-    // individual size of allocations will be randomly selected by `quickcheck`.
+    /// The idea behind this fuzz test is to check a series of allocation sequences. For
+    /// example, we maybe have back to back runs as follows:
+    ///
+    /// 1. `vec![1, 2, 3]`
+    /// 2. `vec![4, 5, 6, 7]`
+    /// 3. `vec![8]`
+    ///
+    /// Each of the vectors represents one sequence of allocations. Within each sequence the
+    /// individual size of allocations will be randomly selected by `quickcheck`.
     #[quickcheck]
     fn should_allocate_arbitrary_byte_sequences(sequence: Vec<usize>) -> TestResult {
         let mut inner = InnerAlloc::new();

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -293,13 +293,23 @@ mod fuzz_tests {
 
         let layout = Layout::from_size_align(n, size_of::<usize>()).unwrap();
         let size = layout.pad_to_align().size();
-        assert_eq!(inner.alloc(layout), Some(0));
+        assert_eq!(
+            inner.alloc(layout),
+            Some(0),
+            "The given pointer for the allocation doesn't match."
+        );
 
         let expected_alloc_start = size;
-        assert_eq!(inner.next, expected_alloc_start);
+        assert_eq!(
+            inner.next, expected_alloc_start,
+            "Our next allocation doesn't match where it should start."
+        );
 
         let expected_limit = PAGE_SIZE * required_pages(size).unwrap();
-        assert_eq!(inner.upper_limit, expected_limit);
+        assert_eq!(
+            inner.upper_limit, expected_limit,
+            "The upper bound of our heap doesn't match."
+        );
 
         TestResult::passed()
     }
@@ -313,7 +323,11 @@ mod fuzz_tests {
 
         if let Ok(layout) = Layout::from_size_align(n, size_of::<usize>()) {
             let mut inner = InnerAlloc::new();
-            assert_eq!(inner.alloc(layout), None);
+            assert_eq!(
+                inner.alloc(layout),
+                None,
+                "An allocation which overflows the heap was made."
+            );
 
             TestResult::passed()
         } else {
@@ -340,13 +354,23 @@ mod fuzz_tests {
 
         let layout = Layout::from_size_align(n, align).unwrap();
         let size = layout.pad_to_align().size();
-        assert_eq!(inner.alloc(layout), Some(0));
+        assert_eq!(
+            inner.alloc(layout),
+            Some(0),
+            "The given pointer for the allocation doesn't match."
+        );
 
         let expected_alloc_start = size;
-        assert_eq!(inner.next, expected_alloc_start);
+        assert_eq!(
+            inner.next, expected_alloc_start,
+            "Our next allocation doesn't match where it should start."
+        );
 
         let expected_limit = PAGE_SIZE * required_pages(size).unwrap();
-        assert_eq!(inner.upper_limit, expected_limit);
+        assert_eq!(
+            inner.upper_limit, expected_limit,
+            "The upper bound of our heap doesn't match."
+        );
 
         TestResult::passed()
     }
@@ -483,7 +507,10 @@ mod fuzz_tests {
         }
 
         // Ensure that at least one of the allocations ends up overflowing our calculations.
-        assert!(results.iter().any(|r| r.is_none()));
+        assert!(
+            results.iter().any(|r| r.is_none()),
+            "Expected an allocation to overflow our heap, but this didn't happen."
+        );
 
         TestResult::passed()
     }

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -510,7 +510,8 @@ mod fuzz_tests {
 
         let mut results = vec![];
         for alloc in sequence {
-            let layout = Layout::from_size_align(alloc, size_of::<usize>()).unwrap();
+            let layout = Layout::from_size_align(alloc, size_of::<usize>())
+                .expect(FROM_SIZE_ALIGN_EXPECT);
             results.push(inner.alloc(layout));
         }
 

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -264,6 +264,51 @@ mod tests {
         let expected_alloc_start = 2 * PAGE_SIZE + std::mem::size_of::<u8>();
         assert_eq!(inner.next, expected_alloc_start);
     }
+
+    // TODO: What I want to end up doing is turning this into a `quickcheck` test such that the
+    // random sized bytes and the number of allocations comes from `quickcheck`
+    #[test]
+    fn can_alloc_many_different_sized_chunks() {
+        let mut inner = InnerAlloc::new();
+
+        // let v = vec![16, 15, 3, 10, 10, 10, 5, 65];
+        let v = vec![32, 30, 6, 20, 20, 20, 10, 130];
+
+        let mut total_bytes_requested = 0;
+        let mut expected_alloc_start = 0;
+        let mut total_bytes_fragmented = 0;
+
+        for alloc in v {
+            let n = alloc * 1024;
+
+            let layout =
+                Layout::from_size_align(n, std::mem::size_of::<usize>()).unwrap();
+            let size = layout.pad_to_align().size();
+
+            let current_page_limit = required_pages(inner.next).unwrap() * PAGE_SIZE;
+            let is_too_big_for_current_page = inner.next + size > current_page_limit;
+
+            if is_too_big_for_current_page && inner.next != 0 {
+                let fragmented_in_current_page = current_page_limit % inner.next;
+                total_bytes_fragmented += fragmented_in_current_page;
+
+                // We expect our next allocation to be aligned to the start of the next page
+                // boundary
+                expected_alloc_start = inner.upper_limit;
+            }
+
+            assert_eq!(inner.alloc(layout), Some(expected_alloc_start));
+            total_bytes_requested += size;
+
+            let pages_required =
+                required_pages(total_bytes_requested + total_bytes_fragmented).unwrap();
+            let expected_limit = pages_required * PAGE_SIZE;
+            assert_eq!(inner.upper_limit, expected_limit);
+
+            expected_alloc_start = total_bytes_requested + total_bytes_fragmented;
+            assert_eq!(inner.next, expected_alloc_start);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -395,12 +395,13 @@ mod fuzz_tests {
     // #[ignore]
     #[quickcheck]
     fn fuzz_buzz(bytes: Vec<Vec<usize>>) -> TestResult {
-        let mut inner = InnerAlloc::new();
         if bytes.is_empty() {
             return TestResult::discard()
         }
 
         for v in bytes.into_iter() {
+            let mut inner = InnerAlloc::new();
+
             // TODO: Remove limit
             if v.is_empty() {
                 return TestResult::discard()

--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -39,6 +39,6 @@ mod bump;
 #[cfg(not(feature = "std"))]
 mod handlers;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std", feature = "ink-fuzz-tests"))]
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;

--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -38,3 +38,7 @@ mod bump;
 
 #[cfg(not(feature = "std"))]
 mod handlers;
+
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;


### PR DESCRIPTION
This closes #860, which is a follow up to #831.

~~Still a draft since I'm trying to figure out my way around `quickcheck` and the right
allocator properties to test.~~
