### PR TITLE
Flip the `DEBUG_ENABLED` conditional

### DIFF
--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -649,13 +649,14 @@ pub fn random(subject: &[u8], output: &mut &mut [u8]) {
     extract_from_slice(output, output_len as usize);
 }
 
-/// Return the same value as passed in but hide the ouput value from the optimizer.
+/// Return the same value as passed in but hide the output value from the optimizer.
 ///
 /// # Note
 ///
-/// This contains wasm inline assembly. Since the on_chain module is never compiled
+/// This contains Wasm inline assembly. Since the this module is never compiled
 /// to something else that should be fine.
 #[allow(unused_assignments)]
+#[cfg(feature = "ink-debug")]
 fn is_true(is_true: bool) -> bool {
     // Inline assembly cannot operate on booleans. Only primitives.
     let mut dummy: u32 = if is_true { 1 } else { 0 };

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -21,6 +21,7 @@
 //! emulator for simple off-chain testing.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(asm))]
 #![deny(
     missing_docs,
     bad_style,

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -21,7 +21,6 @@
 //! emulator for simple off-chain testing.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(asm))]
 #![deny(
     missing_docs,
     bad_style,


### PR DESCRIPTION
Fixes https://github.com/paritytech/substrate/issues/9334

When implementing the new debug print code we introduced a feature that stops trying to print debug messages when it failed once (when executing as transaction). However, this led to the situation that the code executed on-chain is a tiny bit larger than the off-chain executed code (used for estimation) when only one message was ever tried to be printed. Check my response on the linked issue for more information.

This PR fixes the situation by flipping the conditional so the extra assignment is executed in the "logging enabled" (RPC) case. This requires an additional variable but I think it is still simple enough.