### PR TITLE
Import quickcheck macro only for bump allocator

### DIFF
--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -39,6 +39,6 @@ mod bump;
 #[cfg(not(feature = "std"))]
 mod handlers;
 
-#[cfg(all(test, feature = "std", feature = "ink-fuzz-tests"))]
+#[cfg(all(test, feature = "std", feature = "ink-fuzz-tests", not(feature = "wee-alloc")))]
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;

--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -39,6 +39,11 @@ mod bump;
 #[cfg(not(feature = "std"))]
 mod handlers;
 
-#[cfg(all(test, feature = "std", feature = "ink-fuzz-tests", not(feature = "wee-alloc")))]
+#[cfg(all(
+    test,
+    feature = "std",
+    feature = "ink-fuzz-tests",
+    not(feature = "wee-alloc")
+))]
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;


### PR DESCRIPTION
Fixes the failing `master` CI.

The fuzz tests exist only in the bump allocator, but due to clippy being run with `--all-features` the `wee-alloc` feature is enabled. This results in the bump allocator not being used, but the quickcheck macro is still imported. 