### PR TITLE
Change CI variables source to Vault

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,6 +84,32 @@ workflow:
   tags:
     - kubernetes-parity-build
 
+#### Vault secrets
+.vault-secrets:                    &vault-secrets
+  variables:
+    VAULT_SERVER_URL:                "https://vault.parity-mgmt-vault.parity.io"
+    VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
+    VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
+  secrets:
+    CODECOV_P_TOKEN:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/CODECOV_P_TOKEN@kv
+      file:                        false
+    CODECOV_TOKEN:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/CODECOV_TOKEN@kv
+      file:                        false
+    GITHUB_EMAIL:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/GITHUB_EMAIL@kv
+      file:                        false
+    GITHUB_USER:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/GITHUB_USER@kv
+      file:                        false
+    GITHUB_TOKEN:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/GITHUB_TOKEN@kv
+      file:                        false
+    PIPELINE_TOKEN:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/PIPELINE_TOKEN@kv
+      file:                        false
+
 #### stage:                        check
 
 check-std:
@@ -343,6 +369,7 @@ ink-waterfall:
     TRGR_REF:                      ${CI_COMMIT_REF_NAME}
     # The `ink-waterfall` project id in GitLab
     DWNSTRM_ID:                    409
+  <<:                              *vault-secrets
   script:
     - ./scripts/.ci/trigger_pipeline.sh
   allow_failure:                   true
@@ -354,6 +381,7 @@ publish-docs:
   stage:                           publish
   <<:                              *docker-env
   <<:                              *test-refs
+  <<:                              *vault-secrets
   needs:
     - job:                         docs
       artifacts:                   true
@@ -408,6 +436,7 @@ fuzz-tests:
   stage:                           fuzz
   <<:                              *docker-env
   <<:                              *test-refs
+  <<:                              *vault-secrets
   variables:
     # The QUICKCHECK_TESTS default is 100
     QUICKCHECK_TESTS:              5000

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,9 @@ variables:
   # read more https://github.com/paritytech/scripts/pull/244
   ALL_CRATES:                      "${PURELY_STD_CRATES} ${ALSO_WASM_CRATES}"
   DELEGATOR_SUBCONTRACTS:          "accumulator adder subber"
+  VAULT_SERVER_URL:                "https://vault.parity-mgmt-vault.parity.io"
+  VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
+  VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
 
 workflow:
   rules:
@@ -86,10 +89,6 @@ workflow:
 
 #### Vault secrets
 .vault-secrets:                    &vault-secrets
-  variables:
-    VAULT_SERVER_URL:                "https://vault.parity-mgmt-vault.parity.io"
-    VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
-    VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
   secrets:
     CODECOV_P_TOKEN:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/CODECOV_P_TOKEN@kv
@@ -364,12 +363,12 @@ ink-waterfall:
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-env
   <<:                              *test-refs
+  <<:                              *vault-secrets
   variables:
     TRGR_PROJECT:                  ${CI_PROJECT_NAME}
     TRGR_REF:                      ${CI_COMMIT_REF_NAME}
     # The `ink-waterfall` project id in GitLab
     DWNSTRM_ID:                    409
-  <<:                              *vault-secrets
   script:
     - ./scripts/.ci/trigger_pipeline.sh
   allow_failure:                   true


### PR DESCRIPTION
Change behavior of the CI pipeline to use Vault secrets instead of project variables.