### PR TITLE
Print panic message to debug buffer

### DIFF
--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -44,8 +44,12 @@
 )]
 
 #[cfg(all(not(feature = "std"), target_arch = "wasm32"))]
+#[allow(unused_variables)]
 #[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    // This code gets removed in release builds where the macro will expand into nothing.
+    debug_print!("{}\n", info);
+
     // SAFETY: We only use this operation if we are guaranteed to be in Wasm32 compilation.
     //         This is used in order to make any panic a direct abort avoiding Rust's general
     //         panic infrastructure.


### PR DESCRIPTION
We should print panic messages to the debug buffer when logging is enabled. This will print useful messages to the console and UIs (once they implement it). It looks like this:
```
panicked at 'encountered error while querying transferred balance: Decode(Error)', /Users/alexander/Developer/parity/ink/crates/lang/src/dispatcher.rs:145:10
```

Before we consider merging this we must stabilize `seal_debug_message`. 

Depends on: https://github.com/paritytech/cargo-contract/pull/326

