### PR TITLE
CI: fix coverage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -182,6 +182,52 @@ spellcheck:
     - cargo spellcheck check -vvvv --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive .
     - cargo spellcheck check -vvvv --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive examples/
 
+codecov:
+  stage:                           workspace
+  <<:                              *docker-env
+  <<:                              *test-refs
+  needs:
+    - job:                         check-std
+      artifacts:                   false
+  variables:
+    # For codecov it's sufficient to run the fuzz tests only once.
+    QUICKCHECK_TESTS:              1
+    CARGO_INCREMENTAL:             0
+    # Variables partly came from https://github.com/mozilla/grcov/blob/master/README.md
+    RUSTFLAGS:                     "-Zprofile -Zmir-opt-level=0 -Ccodegen-units=1
+                                      -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
+    # The `cargo-taurpalin` coverage reporting tool seems to have better code instrumentation and thus
+    # produces better results for Rust codebases in general. However, unlike `grcov` it requires
+    # running docker with `--security-opt seccomp=unconfined` which is why we use `grcov` instead.
+  before_script:
+    - *rust-info-script
+    # RUSTFLAGS are the cause target cache can't be used here
+    # FIXME: cust-covfix doesn't support the external target dir
+    # https://github.com/Kogia-sima/rust-covfix/issues/7
+    - unset "CARGO_TARGET_DIR"
+    - cargo clean
+    # make sure there's no stale coverage artifacts
+    - find . -name "*.profraw" -type f -delete
+  script:
+    # RUSTFLAGS are the cause target cache can't be used here
+    - cargo build --verbose --all-features --workspace
+    - cargo test --verbose --all-features --no-fail-fast --workspace
+    # Just needed as long as we have the `ink-experimental-engine` feature.
+    # We must additionally run the coverage without `--all-features` here -- this
+    # would imply the feature `ink-experimental-engine`. So in order to still run
+    # the tests without the experimental engine feature we need this command.
+    - cargo test --verbose --features std --no-fail-fast --workspace
+    # coverage with branches
+    - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm --branch
+        --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
+    - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
+    - codecov --token "$CODECOV_P_TOKEN" --file lcov-w-branch-fixed.info --nonZero
+    # lines coverage
+    - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm
+        --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
+    - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
+    - codecov --token "$CODECOV_TOKEN" --file lcov-lines-fixed.info --nonZero
+
 clippy-std:
   stage:                           workspace
   <<:                              *docker-env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -353,8 +353,8 @@ ink-waterfall:
 
 publish-docs:
   stage:                           publish
-  <<:                              *docker-env
-  <<:                              *test-refs
+  <<:                              *kubernetes-env
+  image:                           paritytech/tools:latest
   needs:
     - job:                         docs
       artifacts:                   true
@@ -365,10 +365,7 @@ publish-docs:
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
-  # need to overwrite `before_script` from `*docker-env` here,
-  # this branch does not have a `./scripts/.ci/pre_cache.sh`
   before_script:
-    - *rust-info-script
     - unset CARGO_TARGET_DIR
   script:
     - rm -rf /tmp/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -478,7 +478,6 @@ publish-docs:
 fuzz-tests:
   stage:                           fuzz
   <<:                              *docker-env
-  <<:                              *test-refs
   <<:                              *vault-secrets
   variables:
     # The QUICKCHECK_TESTS default is 100

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,7 +195,7 @@ codecov:
     CARGO_INCREMENTAL:             0
     # Variables partly came from https://github.com/mozilla/grcov/blob/master/README.md
     RUSTFLAGS:                     "-Zprofile -Zmir-opt-level=0 -Ccodegen-units=1
-                                      -Copt-level=0 -Clink-dead-code -Coverflow-checks=off"
+                                      -Copt-level=0 -Coverflow-checks=off"
     # The `cargo-taurpalin` coverage reporting tool seems to have better code instrumentation and thus
     # produces better results for Rust codebases in general. However, unlike `grcov` it requires
     # running docker with `--security-opt seccomp=unconfined` which is why we use `grcov` instead.


### PR DESCRIPTION
- restores code coverage how it used to measure previously - with an old-style instrumentation (but with branch coverage)
- some chore

CC: https://github.com/paritytech/ink/pull/857
Closes: paritytech/ci_cd#160 https://github.com/paritytech/ink/pull/863 https://github.com/paritytech/ci_cd/issues/13