### PR TITLE
Migrate wasm32 `unreachable` to safe

### DIFF
--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -50,12 +50,10 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     // This code gets removed in release builds where the macro will expand into nothing.
     debug_print!("{}\n", info);
 
-    // SAFETY: We only use this operation if we are guaranteed to be in Wasm32 compilation.
-    //         This is used in order to make any panic a direct abort avoiding Rust's general
-    //         panic infrastructure.
-    unsafe {
-        core::arch::wasm32::unreachable();
-    }
+    // We only use this operation if we are guaranteed to be in Wasm32 compilation.
+    // This is used in order to make any panic a direct abort avoiding Rust's general
+    // panic infrastructure.
+    core::arch::wasm32::unreachable();
 }
 
 // This extern crate definition is required since otherwise rustc


### PR DESCRIPTION
Fixes the currently failing `clippy` on `master`.