### PR TITLE
Release ink! 3.0.0-rc5

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,17 @@
+# Version 3.0-rc5 (2021-09-08)
+
+This is the 5th release candidate for ink! 3.0.
+
+The list below shows the additions, changes and fixes that are visible to users of ink!.
+
+## Added
+- Added example for mocking chain extensions in off-chain tests ‒ [#882](https://github.com/paritytech/ink/pull/882).
+- Panic messages are now printed to debug buffer ‒ [#894](https://github.com/paritytech/ink/pull/894).
+
+## Changed
+- Unlicensed smart contract examples ‒ [#888](https://github.com/paritytech/ink/pull/888).
+- Stabilized `seal_debug_message` ‒ [#902](https://github.com/paritytech/ink/pull/902).
+
 # Version 3.0-rc4 (2021-07-19)
 
 This is the 4th release candidate for ink! 3.0.

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_allocator"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_engine"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Michael Müller <michi@parity.io>"]
 edition = "2018"
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_env"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_engine = { version = "3.0.0-rc4", path = "../engine/", default-features = false, optional = true }
-ink_metadata = { version = "3.0.0-rc4", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_allocator = { version = "3.0.0-rc4", path = "../allocator/", default-features = false }
-ink_primitives = { version = "3.0.0-rc4", path = "../primitives/", default-features = false }
-ink_prelude = { version = "3.0.0-rc4", path = "../prelude/", default-features = false }
+ink_engine = { version = "3.0.0-rc5", path = "../engine/", default-features = false, optional = true }
+ink_metadata = { version = "3.0.0-rc5", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_allocator = { version = "3.0.0-rc5", path = "../allocator/", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../primitives/", default-features = false }
+ink_prelude = { version = "3.0.0-rc5", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 
@@ -15,12 +15,12 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "3.0.0-rc4", path = "../env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../storage", default-features = false }
-ink_primitives = { version = "3.0.0-rc4", path = "../primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../metadata", default-features = false, optional = true }
-ink_prelude = { version = "3.0.0-rc4", path = "../prelude", default-features = false }
-ink_lang_macro = { version = "3.0.0-rc4", path = "macro", default-features = false }
+ink_env = { version = "3.0.0-rc5", path = "../env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../storage", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../metadata", default-features = false, optional = true }
+ink_prelude = { version = "3.0.0-rc5", path = "../prelude", default-features = false }
+ink_lang_macro = { version = "3.0.0-rc5", path = "macro", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }

--- a/crates/lang/codegen/Cargo.toml
+++ b/crates/lang/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_codegen"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 
@@ -18,7 +18,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 name = "ink_lang_codegen"
 
 [dependencies]
-ir = { version = "3.0.0-rc4", package = "ink_lang_ir", path = "../ir", default-features = false }
+ir = { version = "3.0.0-rc5", package = "ink_lang_ir", path = "../ir", default-features = false }
 quote = "1"
 syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = "1.0"

--- a/crates/lang/ir/Cargo.toml
+++ b/crates/lang/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_ir"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_macro"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 
@@ -15,20 +15,20 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_lang_ir = { version = "3.0.0-rc4", path = "../ir", default-features = false }
-ink_lang_codegen = { version = "3.0.0-rc4", path = "../codegen", default-features = false }
-ink_primitives = { version = "3.0.0-rc4", path = "../../primitives/", default-features = false }
+ink_lang_ir = { version = "3.0.0-rc5", path = "../ir", default-features = false }
+ink_lang_codegen = { version = "3.0.0-rc5", path = "../codegen", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../primitives/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 syn = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-ink_metadata = { version = "3.0.0-rc4", path = "../../metadata/" }
-ink_env = { version = "3.0.0-rc4", path = "../../env/" }
-ink_storage = { version = "3.0.0-rc4", path = "../../storage/" }
-ink_lang = { version = "3.0.0-rc4", path = ".." }
-ink_prelude = { version = "3.0.0-rc4", path = "../../prelude/" }
+ink_metadata = { version = "3.0.0-rc5", path = "../../metadata/" }
+ink_env = { version = "3.0.0-rc5", path = "../../env/" }
+ink_storage = { version = "3.0.0-rc5", path = "../../storage/" }
+ink_lang = { version = "3.0.0-rc5", path = ".." }
+ink_prelude = { version = "3.0.0-rc5", path = "../../prelude/" }
 
 trybuild = "1.0.24"
 scale-info = { version = "0.6", default-features = false, features = ["derive"] }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_metadata"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 
@@ -15,8 +15,8 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "3.0.0-rc4", path = "../prelude/", default-features = false }
-ink_primitives = { version = "3.0.0-rc4", path = "../primitives/", default-features = false }
+ink_prelude = { version = "3.0.0-rc5", path = "../prelude/", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../primitives/", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.3.1"

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_prelude"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_primitives"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "3.0.0-rc4", path = "../prelude/", default-features = false }
+ink_prelude = { version = "3.0.0-rc5", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "3.0.0-rc4", path = "../env/", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "3.0.0-rc4", path = "../primitives/", default-features = false }
-ink_storage_derive = { version = "3.0.0-rc4", path = "derive", default-features = false }
-ink_prelude = { version = "3.0.0-rc4", path = "../prelude/", default-features = false }
+ink_env = { version = "3.0.0-rc5", path = "../env/", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "3.0.0-rc5", path = "../primitives/", default-features = false }
+ink_storage_derive = { version = "3.0.0-rc5", path = "derive", default-features = false }
+ink_prelude = { version = "3.0.0-rc5", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }

--- a/crates/storage/derive/Cargo.toml
+++ b/crates/storage/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage_derive"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2018"
 
@@ -25,7 +25,7 @@ synstructure = "0.12.4"
 
 [dev-dependencies]
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive", "full"] }
-ink_env = { version = "3.0.0-rc4", path = "../../env" }
-ink_primitives = { version = "3.0.0-rc4", path = "../../primitives" }
-ink_metadata = { version = "3.0.0-rc4", path = "../../metadata" }
-ink_storage = { version = "3.0.0-rc4", path = ".." }
+ink_env = { version = "3.0.0-rc5", path = "../../env" }
+ink_primitives = { version = "3.0.0-rc5", path = "../../primitives" }
+ink_metadata = { version = "3.0.0-rc5", path = "../../metadata" }
+ink_storage = { version = "3.0.0-rc5", path = ".." }

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "contract_terminate"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "contract_transfer"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false, features = [ "ink-debug" ] }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
-ink_prelude = { version = "3.0.0-rc4", path = "../../crates/prelude", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false, features = [ "ink-debug" ] }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
+ink_prelude = { version = "3.0.0-rc5", path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "delegator"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 
-adder = { version = "3.0.0-rc4", path = "adder", default-features = false, features = ["ink-as-dependency"] }
-subber = { version = "3.0.0-rc4", path = "subber", default-features = false, features = ["ink-as-dependency"] }
-accumulator = { version = "3.0.0-rc4", path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
+adder = { version = "3.0.0-rc5", path = "adder", default-features = false, features = ["ink-as-dependency"] }
+subber = { version = "3.0.0-rc5", path = "subber", default-features = false, features = ["ink-as-dependency"] }
+accumulator = { version = "3.0.0-rc5", path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 [lib]

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "accumulator"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "adder"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../../crates/lang", default-features = false }
 
-accumulator = { version = "3.0.0-rc4", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
+accumulator = { version = "3.0.0-rc5", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "subber"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../../crates/lang", default-features = false }
 
-accumulator = { version = "3.0.0-rc4", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
+accumulator = { version = "3.0.0-rc5", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "dns"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "erc1155"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false, features = ["ink-debug"] }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
-ink_prelude = { version = "3.0.0-rc4", path = "../../crates/prelude", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false, features = ["ink-debug"] }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
+ink_prelude = { version = "3.0.0-rc5", path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "erc20"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "erc721"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "flipper"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "incrementer"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/multisig_plain/Cargo.toml
+++ b/examples/multisig_plain/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "multisig_plain"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
-ink_prelude = { version = "3.0.0-rc4", path = "../../crates/prelude", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
+ink_prelude = { version = "3.0.0-rc5", path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "trait_erc20"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "trait_flipper"
-version = "3.0.0-rc4"
+version = "3.0.0-rc5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc4", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.0-rc4", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc4", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.0-rc4", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.0-rc4", path = "../../crates/lang", default-features = false }
+ink_primitives = { version = "3.0.0-rc5", path = "../../crates/primitives", default-features = false }
+ink_metadata = { version = "3.0.0-rc5", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc5", path = "../../crates/env", default-features = false }
+ink_storage = { version = "3.0.0-rc5", path = "../../crates/storage", default-features = false }
+ink_lang = { version = "3.0.0-rc5", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
I would have liked to wait with the release until we have the state rent stuff removed completely as well, but  a couple users have now run into https://github.com/paritytech/ink/pull/902 and it makes sense to do a release now. Due to semver they will automatically receive the fix.