### PR TITLE
Implemented ECDSA recover function.

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -22,6 +22,9 @@ sha2 = { version = "0.9" }
 sha3 = { version = "0.9" }
 blake2 = { version = "0.9" }
 
+# ECDSA for the off-chain environment.
+libsecp256k1 = { version = "0.3.5", default-features = false }
+
 [features]
 default = ["std"]
 std = [

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -35,6 +35,9 @@ sha2 = { version = "0.9", optional = true }
 sha3 = { version = "0.9", optional = true }
 blake2 = { version = "0.9", optional = true }
 
+# ECDSA for the off-chain environment.
+libsecp256k1 = { version = "0.3.5", default-features = false }
+
 # Only used in the off-chain environment.
 #
 # Sadly couldn't be marked as dev-dependency.

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -604,3 +604,34 @@ where
         instance.hash_encoded::<H, T>(input, output)
     })
 }
+
+/// Recovers the compressed ecdsa public key for given `signature` and `message_hash`, and stores the result in `output`.
+///
+/// # Example
+///
+/// ```
+/// const signature: [u8; 65] = [
+///     161, 234, 203,  74, 147, 96,  51, 212,   5, 174, 231,   9, 142,  48, 137, 201,
+///     162, 118, 192,  67, 239, 16,  71, 216, 125,  86, 167, 139,  70,   7,  86, 241,
+///      33,  87, 154, 251,  81, 29, 160,   4, 176, 239,  88, 211, 244, 232, 232,  52,
+///     211, 234, 100, 115, 230, 47,  80,  44, 152, 166,  62,  50,   8,  13,  86, 175,
+///      28,
+/// ];
+/// const message_hash: [u8; 32] = [
+///     162, 28, 244, 179, 96, 76, 244, 178, 188,  83, 230, 248, 143, 106,  77, 117,
+///     239, 95, 244, 171, 65, 95,  62, 153, 174, 166, 182,  28, 130,  73, 196, 208
+/// ];
+/// const EXPECTED_COMPRESSED_PUBLIC_KEY: [u8; 33] = [
+///       2, 121, 190, 102, 126, 249, 220, 187, 172, 85, 160,  98, 149, 206, 135, 11,
+///       7,   2, 155, 252, 219,  45, 206,  40, 217, 89, 242, 129,  91,  22, 248, 23,
+///     152,
+/// ];
+/// let mut output = [0; 33];
+/// ink_env::ecdsa_recover(&signature, &message_hash, &mut output);
+/// assert_eq!(output, EXPECTED_COMPRESSED_PUBLIC_KEY);
+/// ```
+pub fn ecdsa_recover(signature: &[u8; 65], message_hash: &[u8; 32], output: &mut [u8; 33]) -> Result<()> {
+    <EnvInstance as OnInstance>::on_instance(|instance| {
+        instance.ecdsa_recover(signature, message_hash, output)
+    })
+}

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -140,6 +140,9 @@ pub trait EnvBackend {
         H: CryptoHash,
         T: scale::Encode;
 
+    /// Recovers the compressed ecdsa public key for given `signature` and `message_hash`, and stores the result in `output`.
+    fn ecdsa_recover(&mut self, signature: &[u8; 65], message_hash: &[u8; 32], output: &mut [u8; 33]) -> Result<()>;
+
     /// Low-level interface to call a chain extension method.
     ///
     /// Returns the output of the chain extension of the specified type.

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -195,6 +195,25 @@ impl EnvBackend for EnvInstance {
         self.hash_bytes::<H>(&encoded[..], output)
     }
 
+    fn ecdsa_recover(&mut self, signature: &[u8; 65], message_hash: &[u8; 32], output: &mut [u8; 33]) -> Result<()> {
+        use secp256k1::{Signature, RecoveryId, Message, recover};
+
+        let recovery_byte =  if signature[64] > 27 { signature[64] - 27 } else { signature[64] };
+        let message = Message::parse(message_hash);
+        let signature = Signature::parse_slice(&signature[0..64]).unwrap();
+
+        let recovery_id = RecoveryId::parse(recovery_byte).unwrap();
+
+        let pub_key = recover(&message, &signature, &recovery_id);
+        match pub_key {
+            Ok(pub_key) => {
+                *output = pub_key.serialize_compressed();
+                Ok(())
+            },
+            Err(_) => Err(Error::EcdsaRecoverFailed)
+        }
+    }
+
     fn call_chain_extension<I, T, E, ErrorCode, F, D>(
         &mut self,
         func_id: u32,

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -111,6 +111,7 @@ impl From<ext::Error> for Error {
             ext::Error::CodeNotFound => Self::CodeNotFound,
             ext::Error::NotCallable => Self::NotCallable,
             ext::Error::LoggingDisabled => Self::LoggingDisabled,
+            ext::Error::EcdsaRecoverFailed => Self::EcdsaRecoverFailed,
         }
     }
 }
@@ -275,6 +276,10 @@ impl EnvBackend for EnvInstance {
         let mut scope = self.scoped_buffer();
         let enc_input = scope.take_encoded(input);
         <H as CryptoHash>::hash(enc_input, output)
+    }
+
+    fn ecdsa_recover(&mut self, signature: &[u8; 65], message_hash: &[u8; 32], output: &mut [u8; 33]) -> Result<()> {
+        ext::ecdsa_recover(signature, message_hash, output).map_err(Into::into)
     }
 
     fn call_chain_extension<I, T, E, ErrorCode, F, D>(

--- a/crates/env/src/error.rs
+++ b/crates/env/src/error.rs
@@ -49,6 +49,8 @@ pub enum Error {
     /// The call to `seal_debug_message` had no effect because debug message
     /// recording was disabled.
     LoggingDisabled,
+    /// ECDSA pubkey recovery failed. Most probably wrong recovery id or signature.
+    EcdsaRecoverFailed,
 }
 
 /// A result of environmental operations.

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -25,6 +25,7 @@ ink_lang_macro = { version = "3.0.0-rc5", path = "macro", default-features = fal
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 static_assertions = "1.1"
+libsecp256k1 = { version = "0.3.5", default-features = false }
 
 [dev-dependencies]
 # required for the doctest of `env_access::EnvAccess::instantiate_contract`

--- a/crates/lang/src/lib.rs
+++ b/crates/lang/src/lib.rs
@@ -74,6 +74,8 @@ pub use self::{
         MessageMut,
         MessageRef,
         True,
+        ECDSAPublicKey,
+        EthereumAddress,
     },
 };
 pub use ::static_assertions;

--- a/crates/lang/src/traits.rs
+++ b/crates/lang/src/traits.rs
@@ -23,6 +23,7 @@ use ink_env::{
         Selector,
     },
     Environment,
+    DefaultEnvironment,
 };
 use ink_storage::traits::SpreadLayout;
 
@@ -120,3 +121,64 @@ pub trait MessageMut: FnInput + FnOutput + FnSelector + FnState {
 /// Indicates that some compile time expression is expected to be `true`.
 #[doc(hidden)]
 pub trait True {}
+
+/// The ECDSA compressed public key.
+#[derive(Debug, Copy, Clone)]
+pub struct ECDSAPublicKey(pub [u8; 33]);
+
+impl Default for ECDSAPublicKey {
+    fn default() -> Self {
+        Self {
+            0: [0; 33]
+        }
+    }
+}
+
+impl core::ops::Deref for ECDSAPublicKey {
+    type Target = [u8; 33];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl core::ops::DerefMut for ECDSAPublicKey {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// Address of ethereum account
+pub type EthereumAddress = [u8; 20];
+
+impl ECDSAPublicKey {
+    pub fn to_eth_address(&self) -> EthereumAddress {
+        use secp256k1::PublicKey;
+        use ink_env::hash;
+
+        // Transform compressed public key into uncompressed.
+        let pub_key = PublicKey::parse_compressed(&self.0).expect("Unable to parse the compressed ecdsa public key");
+        let uncompressed = pub_key.serialize();
+
+        // Hash the uncompressed public key without first byte by Keccak256 algorithm.
+        let mut hash = <hash::Keccak256 as hash::HashOutput>::Type::default();
+        ink_env::hash_bytes::<hash::Keccak256>(&uncompressed[1..], &mut hash);
+
+        // Take the last 20 bytes as an Address
+        let mut result = EthereumAddress::default();
+        result.copy_from_slice(&hash[12..]);
+
+        result
+    }
+
+    pub fn to_account_id(&self) -> <DefaultEnvironment as Environment>::AccountId {
+        use ink_env::hash;
+
+        let mut output = <hash::Blake2x256 as hash::HashOutput>::Type::default();
+        ink_env::hash_bytes::<hash::Blake2x256>(&self.0[..], &mut output);
+
+        output.into()
+    }
+}

--- a/crates/lang/tests/traits.rs
+++ b/crates/lang/tests/traits.rs
@@ -1,0 +1,40 @@
+use ink_lang::{ECDSAPublicKey, EthereumAddress};
+
+#[test]
+fn correct_to_eth_address() {
+    #[rustfmt::skip]
+    let pub_key: ECDSAPublicKey = ECDSAPublicKey {
+        0: [
+            2, 121, 190, 102, 126, 249, 220, 187, 172, 85, 160,  98, 149, 206, 135, 11,
+            7,   2, 155, 252, 219,  45, 206,  40, 217, 89, 242, 129,  91,  22, 248, 23,
+            152,
+        ]
+    };
+
+    #[rustfmt::skip]
+    const EXPECTED_ETH_ADDRESS: EthereumAddress = [
+        126, 95, 69, 82, 9, 26, 105, 18, 93, 93, 252, 183, 184, 194, 101, 144, 41, 57, 91, 223
+    ];
+
+    assert_eq!(pub_key.to_eth_address(), EXPECTED_ETH_ADDRESS);
+}
+
+#[test]
+fn correct_to_account_id() {
+    #[rustfmt::skip]
+    let pub_key: ECDSAPublicKey = ECDSAPublicKey {
+        0: [
+            2, 121, 190, 102, 126, 249, 220, 187, 172, 85, 160,  98, 149, 206, 135, 11,
+            7,   2, 155, 252, 219,  45, 206,  40, 217, 89, 242, 129,  91,  22, 248, 23,
+            152,
+        ]
+    };
+
+    #[rustfmt::skip]
+    const EXPECTED_ACCOUNT_ID: [u8; 32] = [
+        41, 117, 241, 210, 139, 146, 182, 232,  68, 153, 184, 59,   7, 151, 239, 82,
+        53,  85,  62, 235, 126, 218, 160, 206, 162,  67, 193, 18, 140,  47, 231, 55,
+    ];
+
+    assert_eq!(pub_key.to_account_id(), EXPECTED_ACCOUNT_ID.into());
+}


### PR DESCRIPTION
Added support of `seal_ecdsa_recover` from the https://github.com/paritytech/substrate/pull/9686.
This function allows to recover the ecdsa compressed public key from the signature and message hash. It will return `ECDSAPublicKey` which has two methods `to_eth_address` and `to_account_id`.