### PR TITLE
Changed the field `name` to `label`

### DIFF
--- a/crates/lang/codegen/src/generator/metadata.rs
+++ b/crates/lang/codegen/src/generator/metadata.rs
@@ -127,7 +127,7 @@ impl Metadata<'_> {
         let ident = constructor.ident();
         let args = constructor.inputs().map(Self::generate_dispatch_argument);
         quote_spanned!(span=>
-            ::ink_metadata::ConstructorSpec::from_name(::core::stringify!(#ident))
+            ::ink_metadata::ConstructorSpec::from_label(::core::stringify!(#ident))
                 .selector([
                     #( #selector_bytes ),*
                 ])
@@ -216,7 +216,7 @@ impl Metadata<'_> {
                 let args = message.inputs().map(Self::generate_dispatch_argument);
                 let ret_ty = Self::generate_return_type(message.output());
                 quote_spanned!(span =>
-                    ::ink_metadata::MessageSpec::from_name(::core::stringify!(#ident))
+                    ::ink_metadata::MessageSpec::from_label(::core::stringify!(#ident))
                         .selector([
                             #( #selector_bytes ),*
                         ])
@@ -275,11 +275,9 @@ impl Metadata<'_> {
                         as ::ink_lang::reflect::TraitMessageInfo<#local_id>>::SELECTOR
                 }};
                 let ret_ty = Self::generate_return_type(message.output());
+                let label = [trait_ident.to_string(), message_ident.to_string()].join("::");
                 quote_spanned!(message_span=>
-                    ::ink_metadata::MessageSpec::from_trait_and_name(
-                        ::core::stringify!(#trait_ident),
-                        ::core::stringify!(#message_ident)
-                    )
+                    ::ink_metadata::MessageSpec::from_label(#label)
                         .selector(#selector)
                         .args([
                             #( #message_args ),*

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -69,12 +69,14 @@ pub enum MetadataVersioned {
     /// Version 0 placeholder. Represents the original non-versioned metadata format.
     V0(MetadataVersionDeprecated),
     /// Version 1 of the contract metadata.
-    V1(InkProject),
+    V1(MetadataVersionDeprecated),
+    /// Version 2 of the contract metadata.
+    V2(InkProject),
 }
 
 impl From<InkProject> for MetadataVersioned {
     fn from(ink_project: InkProject) -> Self {
-        MetadataVersioned::V1(ink_project)
+        MetadataVersioned::v2(ink_project)
     }
 }
 

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -76,7 +76,7 @@ pub enum MetadataVersioned {
 
 impl From<InkProject> for MetadataVersioned {
     fn from(ink_project: InkProject) -> Self {
-        MetadataVersioned::v2(ink_project)
+        MetadataVersioned::V2(ink_project)
     }
 }
 

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -220,10 +220,10 @@ impl ContractSpec {
     deserialize = "F::Type: DeserializeOwned, F::String: DeserializeOwned"
 ))]
 pub struct ConstructorSpec<F: Form = MetaForm> {
-    /// The name of the message.
+    /// The label of the constructor.
     ///
-    /// In case of a trait provided constructor the trait name is prefixed.
-    pub name: Vec<F::String>,
+    /// In case of a trait provided constructor the label is prefixed with the trait label.
+    pub label: F::String,
     /// The selector hash of the message.
     pub selector: Selector,
     /// The parameters of the deployment handler.
@@ -237,7 +237,7 @@ impl IntoPortable for ConstructorSpec {
 
     fn into_portable(self, registry: &mut Registry) -> Self::Output {
         ConstructorSpec {
-            name: registry.map_into_portable(self.name),
+            label: self.label.into_portable(registry),
             selector: self.selector,
             args: self
                 .args
@@ -253,11 +253,11 @@ impl<F> ConstructorSpec<F>
 where
     F: Form,
 {
-    /// Returns the name of the message.
+    /// Returns the label of the constructor.
     ///
-    /// In case of a trait provided constructor the trait name is prefixed.
-    pub fn name(&self) -> &[F::String] {
-        &self.name
+    /// In case of a trait provided constructor the label is prefixed with the trait label.
+    pub fn label(&self) -> &F::String {
+        &self.label
     }
 
     /// Returns the selector hash of the message.
@@ -290,36 +290,18 @@ pub struct ConstructorSpecBuilder<Selector> {
 
 impl ConstructorSpec {
     /// Creates a new constructor spec builder.
-    fn from_name_segments<T>(
-        segments: T,
-    ) -> ConstructorSpecBuilder<Missing<state::Selector>>
-    where
-        T: IntoIterator<Item = &'static str>,
-    {
+    pub fn from_label(
+        label: &'static str,
+    ) -> ConstructorSpecBuilder<Missing<state::Selector>> {
         ConstructorSpecBuilder {
             spec: Self {
-                name: segments.into_iter().collect(),
+                label,
                 selector: Selector::default(),
                 args: Vec::new(),
                 docs: Vec::new(),
             },
             marker: PhantomData,
         }
-    }
-
-    /// Creates a new constructor spec builder.
-    pub fn from_name(
-        name: &'static str,
-    ) -> ConstructorSpecBuilder<Missing<state::Selector>> {
-        Self::from_name_segments([name])
-    }
-
-    /// Creates a new constructor spec builder for a trait provided constructor.
-    pub fn from_trait_and_name(
-        trait_name: &'static str,
-        constructor_name: &'static str,
-    ) -> ConstructorSpecBuilder<Missing<state::Selector>> {
-        Self::from_name_segments([trait_name, constructor_name])
     }
 }
 
@@ -375,11 +357,11 @@ impl ConstructorSpecBuilder<state::Selector> {
 ))]
 #[serde(rename_all = "camelCase")]
 pub struct MessageSpec<F: Form = MetaForm> {
-    /// The name of the message and some optional prefixes.
+    /// The label of the message.
     ///
     /// In case of trait provided messages and constructors the prefix
-    /// by convention in ink! is the name of the trait.
-    name: Vec<F::String>,
+    /// by convention in ink! is the label of the trait.
+    label: F::String,
     /// The selector hash of the message.
     selector: Selector,
     /// If the message is allowed to mutate the contract state.
@@ -413,9 +395,9 @@ mod state {
 }
 
 impl MessageSpec {
-    /// Creates a new message spec from the given name segments.
-    fn from_name_segments(
-        segments: Vec<&'static str>,
+    /// Creates a new message spec builder.
+    pub fn from_label(
+        label: &'static str,
     ) -> MessageSpecBuilder<
         Missing<state::Selector>,
         Missing<state::Mutates>,
@@ -424,7 +406,7 @@ impl MessageSpec {
     > {
         MessageSpecBuilder {
             spec: Self {
-                name: segments,
+                label,
                 selector: Selector::default(),
                 mutates: false,
                 payable: false,
@@ -435,43 +417,18 @@ impl MessageSpec {
             marker: PhantomData,
         }
     }
-
-    /// Creates a new message spec builder.
-    pub fn from_name(
-        name: &'static str,
-    ) -> MessageSpecBuilder<
-        Missing<state::Selector>,
-        Missing<state::Mutates>,
-        Missing<state::IsPayable>,
-        Missing<state::Returns>,
-    > {
-        Self::from_name_segments(vec![name])
-    }
-
-    /// Creates a new message spec builder for a trait provided message.
-    pub fn from_trait_and_name(
-        trait_name: &'static str,
-        message_name: &'static str,
-    ) -> MessageSpecBuilder<
-        Missing<state::Selector>,
-        Missing<state::Mutates>,
-        Missing<state::IsPayable>,
-        Missing<state::Returns>,
-    > {
-        Self::from_name_segments(vec![trait_name, message_name])
-    }
 }
 
 impl<F> MessageSpec<F>
 where
     F: Form,
 {
-    /// Returns the name of the message and some optional prefixes.
+    /// Returns the label of the message.
     ///
     /// In case of trait provided messages and constructors the prefix
-    /// by convention in ink! is the name of the trait.
-    pub fn name(&self) -> &[F::String] {
-        &self.name
+    /// by convention in ink! is the label of the trait.
+    pub fn label(&self) -> &F::String {
+        &self.label
     }
 
     /// Returns the selector hash of the message.
@@ -617,7 +574,7 @@ impl IntoPortable for MessageSpec {
 
     fn into_portable(self, registry: &mut Registry) -> Self::Output {
         MessageSpec {
-            name: registry.map_into_portable(self.name),
+            label: self.label.into_portable(registry),
             selector: self.selector,
             mutates: self.mutates,
             payable: self.payable,
@@ -639,8 +596,8 @@ impl IntoPortable for MessageSpec {
     deserialize = "F::Type: DeserializeOwned, F::String: DeserializeOwned"
 ))]
 pub struct EventSpec<F: Form = MetaForm> {
-    /// The name of the event.
-    name: F::String,
+    /// The label of the event.
+    label: F::String,
     /// The event arguments.
     args: Vec<EventParamSpec<F>>,
     /// The event documentation.
@@ -686,7 +643,7 @@ impl IntoPortable for EventSpec {
 
     fn into_portable(self, registry: &mut Registry) -> Self::Output {
         EventSpec {
-            name: self.name.into_portable(registry),
+            label: self.label.into_portable(registry),
             args: self
                 .args
                 .into_iter()
@@ -699,10 +656,10 @@ impl IntoPortable for EventSpec {
 
 impl EventSpec {
     /// Creates a new event specification builder.
-    pub fn new(name: &'static str) -> EventSpecBuilder {
+    pub fn new(label: &'static str) -> EventSpecBuilder {
         EventSpecBuilder {
             spec: Self {
-                name,
+                label,
                 args: Vec::new(),
                 docs: Vec::new(),
             },
@@ -714,9 +671,9 @@ impl<F> EventSpec<F>
 where
     F: Form,
 {
-    /// Returns the name of the event.
-    pub fn name(&self) -> &F::String {
-        &self.name
+    /// Returns the label of the event.
+    pub fn label(&self) -> &F::String {
+        &self.label
     }
 
     /// The event arguments.
@@ -892,15 +849,15 @@ where
     }
 }
 
-/// Describes a pair of parameter name and type.
+/// Describes a pair of parameter label and type.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(
     serialize = "F::Type: Serialize, F::String: Serialize",
     deserialize = "F::Type: DeserializeOwned, F::String: DeserializeOwned"
 ))]
 pub struct EventParamSpec<F: Form = MetaForm> {
-    /// The name of the parameter.
-    name: F::String,
+    /// The label of the parameter.
+    label: F::String,
     /// If the event parameter is indexed.
     indexed: bool,
     /// The type of the parameter.
@@ -915,7 +872,7 @@ impl IntoPortable for EventParamSpec {
 
     fn into_portable(self, registry: &mut Registry) -> Self::Output {
         EventParamSpec {
-            name: self.name.into_portable(registry),
+            label: self.label.into_portable(registry),
             indexed: self.indexed,
             ty: self.ty.into_portable(registry),
             docs: registry.map_into_portable(self.docs),
@@ -925,10 +882,10 @@ impl IntoPortable for EventParamSpec {
 
 impl EventParamSpec {
     /// Creates a new event parameter specification builder.
-    pub fn new(name: &'static str) -> EventParamSpecBuilder {
+    pub fn new(label: &'static str) -> EventParamSpecBuilder {
         EventParamSpecBuilder {
             spec: Self {
-                name,
+                label,
                 // By default event parameters are not indexed.
                 indexed: false,
                 // We initialize every parameter type as `()`.
@@ -944,9 +901,9 @@ impl<F> EventParamSpec<F>
 where
     F: Form,
 {
-    /// Returns the name of the parameter.
-    pub fn name(&self) -> &F::String {
-        &self.name
+    /// Returns the label of the parameter.
+    pub fn label(&self) -> &F::String {
+        &self.label
     }
 
     /// Returns true if the event parameter is indexed.
@@ -1060,15 +1017,15 @@ where
     }
 }
 
-/// Describes a pair of parameter name and type.
+/// Describes a pair of parameter label and type.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(
     serialize = "F::Type: Serialize, F::String: Serialize",
     deserialize = "F::Type: DeserializeOwned, F::String: DeserializeOwned"
 ))]
 pub struct MessageParamSpec<F: Form = MetaForm> {
-    /// The name of the parameter.
-    name: F::String,
+    /// The label of the parameter.
+    label: F::String,
     /// The type of the parameter.
     #[serde(rename = "type")]
     ty: TypeSpec<F>,
@@ -1079,7 +1036,7 @@ impl IntoPortable for MessageParamSpec {
 
     fn into_portable(self, registry: &mut Registry) -> Self::Output {
         MessageParamSpec {
-            name: self.name.into_portable(registry),
+            label: self.label.into_portable(registry),
             ty: self.ty.into_portable(registry),
         }
     }
@@ -1087,10 +1044,10 @@ impl IntoPortable for MessageParamSpec {
 
 impl MessageParamSpec {
     /// Constructs a new message parameter specification via builder.
-    pub fn new(name: &'static str) -> MessageParamSpecBuilder {
+    pub fn new(label: &'static str) -> MessageParamSpecBuilder {
         MessageParamSpecBuilder {
             spec: Self {
-                name,
+                label,
                 // Uses `()` type by default.
                 ty: TypeSpec::new::<()>(),
             },
@@ -1102,9 +1059,9 @@ impl<F> MessageParamSpec<F>
 where
     F: Form,
 {
-    /// Returns the name of the parameter.
-    pub fn name(&self) -> &F::String {
-        &self.name
+    /// Returns the label of the parameter.
+    pub fn label(&self) -> &F::String {
+        &self.label
     }
 
     /// Returns the type of the parameter.

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -114,7 +114,7 @@ fn spec_contract_json() {
                                 "displayName": [
                                     "i32"
                                 ],
-                                "type": 1
+                                "type": 0
                             }
                         }
                     ],
@@ -140,7 +140,7 @@ fn spec_contract_json() {
                                 "displayName": [
                                     "i32"
                                 ],
-                                "type": 1
+                                "type": 0
                             }
                         }
                     ],
@@ -161,7 +161,7 @@ fn spec_contract_json() {
                         "displayName": [
                             "i32"
                         ],
-                        "type": 1
+                        "type": 0
                     },
                     "selector": "0x25444afe"
                 }

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -23,8 +23,8 @@ use serde_json::json;
 #[test]
 fn spec_constructor_selector_must_serialize_to_hex() {
     // given
-    let name = "foo";
-    let cs = ConstructorSpec::from_name(name)
+    let label = "foo";
+    let cs = ConstructorSpec::from_label(label)
         .selector(123_456_789u32.to_be_bytes())
         .done();
     let mut registry = Registry::new();
@@ -39,7 +39,7 @@ fn spec_constructor_selector_must_serialize_to_hex() {
     assert_eq!(
         json,
         json!({
-            "name": ["foo"],
+            "label": "foo",
             "selector": "0x075bcd15",
             "args": [],
             "docs": []
@@ -53,7 +53,7 @@ fn spec_contract_json() {
     // given
     let contract: ContractSpec = ContractSpec::new()
         .constructors(vec![
-            ConstructorSpec::from_name("new")
+            ConstructorSpec::from_label("new")
                 .selector([94u8, 189u8, 136u8, 214u8])
                 .args(vec![MessageParamSpec::new("init_value")
                     .of_type(TypeSpec::with_name_segs::<i32, _>(
@@ -62,14 +62,14 @@ fn spec_contract_json() {
                     .done()])
                 .docs(Vec::new())
                 .done(),
-            ConstructorSpec::from_name("default")
+            ConstructorSpec::from_label("default")
                 .selector([2u8, 34u8, 255u8, 24u8])
                 .args(Vec::new())
                 .docs(Vec::new())
                 .done(),
         ])
         .messages(vec![
-            MessageSpec::from_name("inc")
+            MessageSpec::from_label("inc")
                 .selector([231u8, 208u8, 89u8, 15u8])
                 .mutates(true)
                 .payable(true)
@@ -81,7 +81,7 @@ fn spec_contract_json() {
                 .docs(Vec::new())
                 .returns(ReturnTypeSpec::new(None))
                 .done(),
-            MessageSpec::from_name("get")
+            MessageSpec::from_label("get")
                 .selector([37u8, 68u8, 74u8, 254u8])
                 .mutates(false)
                 .payable(false)
@@ -109,23 +109,23 @@ fn spec_contract_json() {
                 {
                     "args": [
                         {
-                            "name": "init_value",
+                            "label": "init_value",
                             "type": {
                                 "displayName": [
                                     "i32"
                                 ],
-                                "type": 0
+                                "type": 1
                             }
                         }
                     ],
                     "docs": [],
-                    "name": ["new"],
+                    "label": "new",
                     "selector": "0x5ebd88d6"
                 },
                 {
                     "args": [],
                     "docs": [],
-                    "name": ["default"],
+                    "label": "default",
                     "selector": "0x0222ff18"
                 }
             ],
@@ -135,19 +135,19 @@ fn spec_contract_json() {
                 {
                     "args": [
                         {
-                            "name": "by",
+                            "label": "by",
                             "type": {
                                 "displayName": [
                                     "i32"
                                 ],
-                                "type": 0
+                                "type": 1
                             }
                         }
                     ],
                     "docs": [],
                     "mutates": true,
                     "payable": true,
-                    "name": ["inc"],
+                    "label": "inc",
                     "returnType": null,
                     "selector": "0xe7d0590f"
                 },
@@ -156,12 +156,12 @@ fn spec_contract_json() {
                     "docs": [],
                     "mutates": false,
                     "payable": false,
-                    "name": ["get"],
+                    "label": "get",
                     "returnType": {
                         "displayName": [
                             "i32"
                         ],
-                        "type": 0
+                        "type": 1
                     },
                     "selector": "0x25444afe"
                 }
@@ -173,8 +173,8 @@ fn spec_contract_json() {
 #[test]
 fn trim_docs() {
     // given
-    let name = "foo";
-    let cs = ConstructorSpec::from_name(name)
+    let label = "foo";
+    let cs = ConstructorSpec::from_label(label)
         .selector(123_456_789u32.to_be_bytes())
         .docs(vec![" foobar      "])
         .done();
@@ -190,7 +190,7 @@ fn trim_docs() {
     assert_eq!(
         json,
         json!({
-            "name": ["foo"],
+            "label": "foo",
             "selector": "0x075bcd15",
             "args": [],
             "docs": ["foobar"]


### PR DESCRIPTION
Updated the code generation of ABI. Instead of "name" in messages, constructors, arguments, events we are using "label".
Changed the behavior of "label" for messages and constructors, now it is a string instead of an array. 
For trait's messages, we will use the "TRAIT_IDENT::MESSAGE_IDENT" format of representation.

This PR is related to https://github.com/paritytech/ink/issues/900.