### PR TITLE
Fix script which triggers downstream pipelines

### DIFF
--- a/scripts/.ci/trigger_pipeline.sh
+++ b/scripts/.ci/trigger_pipeline.sh
@@ -57,3 +57,5 @@ for i in $(seq 1 360); do
     fi
 sleep 5;
 done
+
+exit 1

--- a/scripts/.ci/trigger_pipeline.sh
+++ b/scripts/.ci/trigger_pipeline.sh
@@ -65,4 +65,5 @@ for i in $(seq 1 $SEQ_END); do
 sleep 5;
 done
 
+echo "Timeout! The pipeline didn't return in time."
 exit 1

--- a/scripts/.ci/trigger_pipeline.sh
+++ b/scripts/.ci/trigger_pipeline.sh
@@ -43,7 +43,14 @@ function get_status() {
 
 echo "Waiting on ${PIPELINE_ID} status..."
 
-for i in $(seq 1 360); do
+# How long to sleep in between polling the pipeline status.
+POLL_SLEEP=5
+
+# Time until the script exits with 1, if the pipeline isn't finished until then.
+TIMEOUT_MINUTES=60
+
+SEQ_END=$(( (TIMEOUT_MINUTES * 60) / POLL_SLEEP ))
+for i in $(seq 1 $SEQ_END); do
     STATUS=$(get_status);
     echo "Triggered pipeline status is ${STATUS}";
     if [[ ${STATUS} =~ ^(pending|running|created)$ ]]; then


### PR DESCRIPTION
The reason why the `ink-waterfall` yesterday mistakenly displayed a successful run for the `scale-info` PR is that the script currently exits with 0 after the timeout. So the script timed out and exited with 0, marking the CI stage as success.

This PR fixes this behavior and increases the timeout from the previous 30 mins to 1h.