### PR TITLE
Check namespace argument is identifier

### DIFF
--- a/crates/lang/ir/src/ir/attrs.rs
+++ b/crates/lang/ir/src/ir/attrs.rs
@@ -766,11 +766,16 @@ impl TryFrom<syn::NestedMeta> for AttributeFrag {
                         }
                         if name_value.path.is_ident("namespace") {
                             if let syn::Lit::Str(lit_str) = &name_value.lit {
-                                let bytes = lit_str.value().into_bytes();
+                                let argument = lit_str.value();
+                                syn::parse_str::<syn::Ident>(&argument)
+                                    .map_err(|_error| format_err!(
+                                        lit_str,
+                                        "encountered invalid non-Rust identifier for namespace argument",
+                                    ))?;
                                 return Ok(AttributeFrag {
                                     ast: meta,
                                     arg: AttributeArg::Namespace(
-                                        Namespace::from(bytes),
+                                        Namespace::from(argument.into_bytes()),
                                     ),
                                 })
                             }
@@ -1087,6 +1092,16 @@ mod tests {
             Ok(test::Attribute::Ink(vec![AttributeArg::Namespace(
                 Namespace::from("my_namespace".to_string().into_bytes()),
             )])),
+        );
+    }
+
+    #[test]
+    fn namespace_invalid_identifier() {
+        assert_attribute_try_from(
+            syn::parse_quote! {
+                #[ink(namespace = "::invalid_identifier")]
+            },
+            Err("encountered invalid non-Rust identifier for namespace argument"),
         );
     }
 

--- a/crates/lang/ir/src/ir/attrs.rs
+++ b/crates/lang/ir/src/ir/attrs.rs
@@ -770,7 +770,7 @@ impl TryFrom<syn::NestedMeta> for AttributeFrag {
                                 syn::parse_str::<syn::Ident>(&argument)
                                     .map_err(|_error| format_err!(
                                         lit_str,
-                                        "encountered invalid non-Rust identifier for namespace argument",
+                                        "encountered invalid Rust identifier for namespace argument",
                                     ))?;
                                 return Ok(AttributeFrag {
                                     ast: meta,
@@ -1101,7 +1101,7 @@ mod tests {
             syn::parse_quote! {
                 #[ink(namespace = "::invalid_identifier")]
             },
-            Err("encountered invalid non-Rust identifier for namespace argument"),
+            Err("encountered invalid Rust identifier for namespace argument"),
         );
     }
 

--- a/crates/lang/macro/tests/compile_tests.rs
+++ b/crates/lang/macro/tests/compile_tests.rs
@@ -60,5 +60,9 @@ fn compile_tests() {
     t.compile_fail("tests/ui/fail/S-05-storage-as-event.rs");
     t.compile_fail("tests/ui/fail/S-06-event-as-storage.rs");
 
+    t.compile_fail("tests/ui/fail/N-01-namespace-invalid-identifier.rs");
+    t.compile_fail("tests/ui/fail/N-02-namespace-invalid-type.rs");
+    t.compile_fail("tests/ui/fail/N-03-namespace-missing-argument.rs");
+
     t.pass("tests/ui/chain_extension/E-01-simple.rs");
 }

--- a/crates/lang/macro/tests/ui/fail/N-01-namespace-invalid-identifier.rs
+++ b/crates/lang/macro/tests/ui/fail/N-01-namespace-invalid-identifier.rs
@@ -1,0 +1,20 @@
+use ink_lang as ink;
+
+#[ink::contract]
+mod invalid_namespace_identifier {
+    #[ink(storage)]
+    pub struct MyStorage {}
+
+    #[ink(namespace = "::invalid_identifier")]
+    impl MyStorage {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn message(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/lang/macro/tests/ui/fail/N-01-namespace-invalid-identifier.stderr
+++ b/crates/lang/macro/tests/ui/fail/N-01-namespace-invalid-identifier.stderr
@@ -1,4 +1,4 @@
-error: encountered invalid non-Rust identifier for namespace argument
+error: encountered invalid Rust identifier for namespace argument
  --> $DIR/N-01-namespace-invalid-identifier.rs:8:23
   |
 8 |     #[ink(namespace = "::invalid_identifier")]

--- a/crates/lang/macro/tests/ui/fail/N-01-namespace-invalid-identifier.stderr
+++ b/crates/lang/macro/tests/ui/fail/N-01-namespace-invalid-identifier.stderr
@@ -1,0 +1,5 @@
+error: encountered invalid non-Rust identifier for namespace argument
+ --> $DIR/N-01-namespace-invalid-identifier.rs:8:23
+  |
+8 |     #[ink(namespace = "::invalid_identifier")]
+  |                       ^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/lang/macro/tests/ui/fail/N-02-namespace-invalid-type.rs
+++ b/crates/lang/macro/tests/ui/fail/N-02-namespace-invalid-type.rs
@@ -1,0 +1,20 @@
+use ink_lang as ink;
+
+#[ink::contract]
+mod invalid_namespace_identifier {
+    #[ink(storage)]
+    pub struct MyStorage {}
+
+    #[ink(namespace = true)]
+    impl MyStorage {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn message(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/lang/macro/tests/ui/fail/N-02-namespace-invalid-type.stderr
+++ b/crates/lang/macro/tests/ui/fail/N-02-namespace-invalid-type.stderr
@@ -1,0 +1,5 @@
+error: expecteded string type for `namespace` argument, e.g. #[ink(namespace = "hello")]
+ --> $DIR/N-02-namespace-invalid-type.rs:8:11
+  |
+8 |     #[ink(namespace = true)]
+  |           ^^^^^^^^^^^^^^^^

--- a/crates/lang/macro/tests/ui/fail/N-03-namespace-missing-argument.rs
+++ b/crates/lang/macro/tests/ui/fail/N-03-namespace-missing-argument.rs
@@ -1,0 +1,20 @@
+use ink_lang as ink;
+
+#[ink::contract]
+mod invalid_namespace_identifier {
+    #[ink(storage)]
+    pub struct MyStorage {}
+
+    #[ink(namespace)]
+    impl MyStorage {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn message(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/lang/macro/tests/ui/fail/N-03-namespace-missing-argument.stderr
+++ b/crates/lang/macro/tests/ui/fail/N-03-namespace-missing-argument.stderr
@@ -1,0 +1,5 @@
+error: encountered #[ink(namespace)] that is missing its string parameter. Did you mean #[ink(namespace = name: str)] ?
+ --> $DIR/N-03-namespace-missing-argument.rs:8:11
+  |
+8 |     #[ink(namespace)]
+  |           ^^^^^^^^^


### PR DESCRIPTION
Just checks that `argument` in `#[ink(namespace = "argument")]` is a valid Rust identifier and adds tests for it.