### PR TITLE
Fix `env::block_timestamp` example

### DIFF
--- a/crates/lang/src/env_access.rs
+++ b/crates/lang/src/env_access.rs
@@ -517,25 +517,32 @@ where
     /// # Example
     ///
     /// ```
-    /// # use ink_lang as ink;
-    /// # #[ink::contract]
-    /// # pub mod my_contract {
-    /// #     #[ink(storage)]
-    /// #     pub struct MyContract { }
-    /// #
-    /// #     impl MyContract {
-    /// #         #[ink(constructor)]
-    /// #         pub fn new() -> Self {
-    /// #             Self {}
-    /// #         }
-    /// #
-    /// #[ink(message)]
-    /// pub fn block_number(&self) -> BlockNumber {
-    ///     self.env().block_number()
+    /// use ink_lang as ink;
+    ///
+    /// #[ink::contract]
+    /// pub mod my_contract {
+    ///     #[ink(storage)]
+    ///     pub struct MyContract {
+    ///         last_invocation: BlockNumber
+    ///     }
+    ///
+    ///     impl MyContract {
+    ///         #[ink(constructor)]
+    ///         pub fn new() -> Self {
+    ///             Self {
+    ///                 last_invocation: Self::env().block_number()
+    ///             }
+    ///         }
+    ///
+    ///         /// The function can be executed at most once every 100 blocks.
+    ///         #[ink(message)]
+    ///         pub fn execute_me(&mut self) {
+    ///             let now = self.env().block_number();
+    ///             assert!(now - self.last_invocation > 100);
+    ///             self.last_invocation = now;
+    ///         }
+    ///     }
     /// }
-    /// #
-    /// #     }
-    /// # }
     /// ```
     ///
     /// # Note

--- a/crates/lang/src/env_access.rs
+++ b/crates/lang/src/env_access.rs
@@ -297,6 +297,10 @@ where
     ///
     /// # Note
     ///
+    /// The Substrate default for the timestamp type is the milliseconds since the
+    /// Unix epoch. However, this is not guaranteed: the specific timestamp is
+    /// defined by the chain environment on which this contract runs.
+    ///
     /// For more details visit: [`ink_env::block_timestamp`]
     pub fn block_timestamp(self) -> T::Timestamp {
         ink_env::block_timestamp::<T>().expect("couldn't decode block time stamp")

--- a/crates/lang/src/env_access.rs
+++ b/crates/lang/src/env_access.rs
@@ -286,12 +286,10 @@ where
     ///             }
     ///         }
     ///
-    ///         /// The function can be executed at most once every 100 blocks.
+    ///         /// Records the last time the message was invoked.
     ///         #[ink(message)]
     ///         pub fn execute_me(&mut self) {
-    ///             let now = self.env().block_timestamp();
-    ///             assert!(now - self.last_invocation > 100);
-    ///             self.last_invocation = now;
+    ///             self.last_invocation = self.env().block_timestamp();
     ///         }
     ///     }
     /// }


### PR DESCRIPTION
I noticed that the example contains a mistake. The comment says
```
/// The function can be executed at most once every 100 blocks.
```
But the `env` function used there is actually `block_timestamp()`.

I first thought about just modifying the comment to 
```
/// The function can be executed at most once every 100 milliseconds.
```
But since we don't know if the environment `Timestamp` actually counts in milliseconds we can't do that.
