### PR TITLE
CI: remove gcda files from cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,6 +237,7 @@ codecov:
     - cargo clean
     # make sure there's no stale coverage artifacts
     - find . -name "*.profraw" -type f -delete
+    - find . -name "*.gcda" -type f -delete
   script:
     # RUSTFLAGS are the cause target cache can't be used here
     - cargo build --verbose --all-features --workspace


### PR DESCRIPTION
To address this kind of behavior https://gitlab.parity.io/parity/ink/-/jobs/1144704#L1789 when `.gcda` profiling files remain in the cache from the previous job.