### PR TITLE
[WIP] Use references instead of values in CallBuilder API

### DIFF
--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     call::{
         utils::ReturnType,
+        BalanceEncoder,
         CallParams,
         CreateParams,
     },
@@ -310,13 +311,16 @@ pub fn clear_contract_storage(key: &Key) {
 /// - If arguments passed to the called contract message are invalid.
 /// - If the called contract execution has trapped.
 /// - If the called contract ran out of gas upon execution.
-pub fn invoke_contract<T, Args>(params: &CallParams<T, Args, ()>) -> Result<()>
+pub fn invoke_contract<T, Balance, Args>(
+    params: &CallParams<T, Balance, Args, ()>,
+) -> Result<()>
 where
     T: Environment,
+    Balance: BalanceEncoder<T>,
     Args: scale::Encode,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        TypedEnvBackend::invoke_contract::<T, Args>(instance, params)
+        TypedEnvBackend::invoke_contract::<T, Balance, Args>(instance, params)
     })
 }
 
@@ -336,14 +340,17 @@ where
 /// - If the called contract execution has trapped.
 /// - If the called contract ran out of gas upon execution.
 /// - If the returned value failed to decode properly.
-pub fn eval_contract<T, Args, R>(params: &CallParams<T, Args, ReturnType<R>>) -> Result<R>
+pub fn eval_contract<T, Balance, Args, R>(
+    params: &CallParams<T, Balance, Args, ReturnType<R>>,
+) -> Result<R>
 where
     T: Environment,
+    Balance: BalanceEncoder<T>,
     Args: scale::Encode,
     R: scale::Decode,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        TypedEnvBackend::eval_contract::<T, Args, R>(instance, params)
+        TypedEnvBackend::eval_contract::<T, Balance, Args, R>(instance, params)
     })
 }
 

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -15,6 +15,7 @@
 use crate::{
     call::{
         utils::ReturnType,
+        BalanceEncoder,
         CallParams,
         CreateParams,
     },
@@ -299,12 +300,13 @@ pub trait TypedEnvBackend: EnvBackend {
     /// # Note
     ///
     /// For more details visit: [`invoke_contract`][`crate::invoke_contract`]
-    fn invoke_contract<T, Args>(
+    fn invoke_contract<T, Balance, Args>(
         &mut self,
-        call_data: &CallParams<T, Args, ()>,
+        call_data: &CallParams<T, Balance, Args, ()>,
     ) -> Result<()>
     where
         T: Environment,
+        Balance: BalanceEncoder<T>,
         Args: scale::Encode;
 
     /// Evaluates a contract message and returns its result.
@@ -312,12 +314,13 @@ pub trait TypedEnvBackend: EnvBackend {
     /// # Note
     ///
     /// For more details visit: [`eval_contract`][`crate::eval_contract`]
-    fn eval_contract<T, Args, R>(
+    fn eval_contract<T, Balance, Args, R>(
         &mut self,
-        call_data: &CallParams<T, Args, ReturnType<R>>,
+        call_data: &CallParams<T, Balance, Args, ReturnType<R>>,
     ) -> Result<R>
     where
         T: Environment,
+        Balance: BalanceEncoder<T>,
         Args: scale::Encode,
         R: scale::Decode;
 

--- a/crates/env/src/call/mod.rs
+++ b/crates/env/src/call/mod.rs
@@ -46,6 +46,7 @@ pub use self::{
         CallBuilder,
         CallParams,
     },
+    common::BalanceEncoder,
     create_builder::{
         build_create,
         state,

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -20,6 +20,7 @@ use super::{
 use crate::{
     call::{
         utils::ReturnType,
+        BalanceEncoder,
         CallParams,
         CreateParams,
     },
@@ -479,9 +480,13 @@ impl TypedEnvBackend for EnvInstance {
             .expect("could not encode rent allowance")
     }
 
-    fn invoke_contract<T, Args>(&mut self, params: &CallParams<T, Args, ()>) -> Result<()>
+    fn invoke_contract<T, Balance, Args>(
+        &mut self,
+        params: &CallParams<T, Balance, Args, ()>,
+    ) -> Result<()>
     where
         T: Environment,
+        Balance: BalanceEncoder<T>,
         Args: scale::Encode,
     {
         let _gas_limit = params.gas_limit();
@@ -491,12 +496,13 @@ impl TypedEnvBackend for EnvInstance {
         unimplemented!("off-chain environment does not support contract invocation")
     }
 
-    fn eval_contract<T, Args, R>(
+    fn eval_contract<T, Balance, Args, R>(
         &mut self,
-        _call_params: &CallParams<T, Args, ReturnType<R>>,
+        _call_params: &CallParams<T, Balance, Args, ReturnType<R>>,
     ) -> Result<R>
     where
         T: Environment,
+        Balance: BalanceEncoder<T>,
         Args: scale::Encode,
         R: scale::Decode,
     {

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -59,6 +59,7 @@ pub trait Environment {
     /// The type of balances.
     type Balance: 'static
         + scale::Codec
+        + Default
         + Copy
         + Clone
         + PartialEq

--- a/crates/lang/codegen/src/generator/cross_calling.rs
+++ b/crates/lang/codegen/src/generator/cross_calling.rs
@@ -170,10 +170,10 @@ impl CrossCalling<'_> {
                     }
                 }
 
-                impl ::ink_lang::ToAccountId<Environment> for #ident {
+                impl ::core::convert::AsRef<AccountId> for #ident {
                     #[inline]
-                    fn to_account_id(&self) -> AccountId {
-                        self.account_id
+                    fn as_ref(&self) -> &AccountId {
+                        &self.account_id
                     }
                 }
             };
@@ -312,7 +312,7 @@ impl CrossCalling<'_> {
             #[allow(clippy::type_complexity)]
             type #output_ident = ::ink_env::call::CallBuilder<
                 Environment,
-                ::ink_env::call::utils::Set<AccountId>,
+                ::ink_env::call::utils::Set<&'a AccountId>,
                 ::ink_env::call::utils::Unset<u64>,
                 ::ink_env::call::utils::Unset<Balance>,
                 ::ink_env::call::utils::Set<::ink_env::call::ExecutionInput<#arg_list>>,
@@ -325,7 +325,7 @@ impl CrossCalling<'_> {
                 #receiver #(, #input_bindings : #input_types )*
             ) -> Self::#output_ident {
                 ::ink_env::call::build_call::<Environment>()
-                    .callee(::ink_lang::ToAccountId::to_account_id(self.contract))
+                    .callee(<_ as ::core::convert::AsRef<AccountId>>::as_ref(self.contract))
                     .exec_input(
                         ::ink_env::call::ExecutionInput::new(
                             ::ink_env::call::Selector::new([ #( #composed_selector ),* ])
@@ -516,14 +516,14 @@ impl CrossCalling<'_> {
                 #( #input_bindings : #input_types ),*
             ) -> ::ink_env::call::CallBuilder<
                 Environment,
-                ::ink_env::call::utils::Set<AccountId>,
+                ::ink_env::call::utils::Set<&'a AccountId>,
                 ::ink_env::call::utils::Unset<u64>,
                 ::ink_env::call::utils::Unset<Balance>,
                 ::ink_env::call::utils::Set<::ink_env::call::ExecutionInput<#arg_list>>,
                 ::ink_env::call::utils::Set<#output_sig>,
             > {
                 ::ink_env::call::build_call::<Environment>()
-                    .callee(::ink_lang::ToAccountId::to_account_id(self.contract))
+                    .callee(<_ as ::core::convert::AsRef<AccountId>>::as_ref(self.contract))
                     .exec_input(
                         ::ink_env::call::ExecutionInput::new(
                             ::ink_env::call::Selector::new([ #( #composed_selector ),* ])

--- a/crates/lang/src/cross_calling.rs
+++ b/crates/lang/src/cross_calling.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ink_env::Environment;
-
 /// The type that can never be returned because it is not possible to craft an instance of it.
 #[doc(hidden)]
 pub enum NeverReturns {}
@@ -42,15 +40,4 @@ pub trait ForwardCallMut {
 
     /// Instantiates a call forwarder to forward `&mut self` messages.
     fn call_mut(self) -> Self::Forwarder;
-}
-
-/// Implemented by contracts that are compiled as dependencies.
-///
-/// Allows them to return their underlying account identifier.
-pub trait ToAccountId<T>
-where
-    T: Environment,
-{
-    /// Returns the underlying account identifier of the instantiated contract.
-    fn to_account_id(&self) -> <T as Environment>::AccountId;
 }

--- a/crates/lang/src/env_access.rs
+++ b/crates/lang/src/env_access.rs
@@ -16,6 +16,7 @@ use core::marker::PhantomData;
 use ink_env::{
     call::{
         utils::ReturnType,
+        BalanceEncoder,
         CallParams,
         CreateParams,
     },
@@ -750,11 +751,15 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_env::invoke_contract`]
-    pub fn invoke_contract<Args>(self, params: &CallParams<T, Args, ()>) -> Result<()>
+    pub fn invoke_contract<Balance, Args>(
+        self,
+        params: &CallParams<T, Balance, Args, ()>,
+    ) -> Result<()>
     where
+        Balance: BalanceEncoder<T>,
         Args: scale::Encode,
     {
-        ink_env::invoke_contract::<T, Args>(params)
+        ink_env::invoke_contract::<T, Balance, Args>(params)
     }
 
     /// Evaluates a contract message and returns its result.
@@ -805,15 +810,16 @@ where
     /// # Note
     ///
     /// For more details visit: [`ink_env::eval_contract`]
-    pub fn eval_contract<Args, R>(
+    pub fn eval_contract<Balance, Args, R>(
         self,
-        params: &CallParams<T, Args, ReturnType<R>>,
+        params: &CallParams<T, Balance, Args, ReturnType<R>>,
     ) -> Result<R>
     where
+        Balance: BalanceEncoder<T>,
         Args: scale::Encode,
         R: scale::Decode,
     {
-        ink_env::eval_contract::<T, Args, R>(params)
+        ink_env::eval_contract::<T, Balance, Args, R>(params)
     }
 
     /// Restores a smart contract from its tombstone state.

--- a/crates/lang/src/lib.rs
+++ b/crates/lang/src/lib.rs
@@ -36,7 +36,6 @@ pub use self::{
         ForwardCall,
         ForwardCallMut,
         NeverReturns,
-        ToAccountId,
     },
     dispatcher::{
         deny_payment,


### PR DESCRIPTION
- [x] `CallBuilder` API
- [ ] `CreateBuilder` API

Seen improvements so far with the Delegator example contract:

| Contract | Before PR | After PR | Reason |
|:--|--:|--:|:--|
| Accumulator | 8.8 kB | 8.8 kB | Expected since it does not use the `CallBuilder` API |
| Adder | 13.0 kB | 12.9 kB | Just minor improvement, need to find out why not more. |
| Subber | 13.0 kB | 12.9 kB | Same as with Adder. |
| Delegator | 10.8 kB | 10.5 kB | Minor improvements in WIP state. Expected to improve further. |

Note, that the numbers do not yet include the full change so they are WIP.
Also I am sure we can do better in some places.

A problem will be how this will work out after #665 has been merged since the ink! codegen will be changed significantly through it and won't allow as easily to be adjusted than with the current codegen (which is unfortunate in this case, however, in general the new codegen is far superior).