### PR TITLE
Fixed `is_result_type` and `is_result_err` for generics

### DIFF
--- a/crates/lang/src/lib.rs
+++ b/crates/lang/src/lib.rs
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#![allow(incomplete_features)]
+#![feature(specialization)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]

--- a/crates/lang/src/result_info.rs
+++ b/crates/lang/src/result_info.rs
@@ -96,6 +96,27 @@ mod tests {
     }
 
     #[test]
+    fn is_result_type_works_for_generic() {
+        #[allow(dead_code)]
+        fn execute_message<Output, F>(
+            f: F,
+        ) -> Output
+            where
+                F: FnOnce() -> Output,
+        {
+            assert!(is_result_type!(Output));
+            f()
+        }
+
+        // Check that type aliases work, too.
+        type MyResult = Result<(), ()>;
+        assert!(is_result_type!(MyResult));
+        assert!(execute_message(|| -> MyResult {
+            Ok(())
+        }).is_ok());
+    }
+
+    #[test]
     fn is_result_err_works() {
         assert!(!is_result_err!(true));
         assert!(!is_result_err!(42));


### PR DESCRIPTION
I tried different construction to resolve the issue https://github.com/paritytech/ink/issues/985 but seems it is not possible to resolve it with default rust. Rust doesn't use inherent implementation. Maybe it is a bug in the rust and we need to create an issue.

As a solution, we can use `specialization` feature. It resolves the problem and it is clear how it works=)