### PR TITLE
Follow-up: SpreadLayout

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -102,3 +102,4 @@ wildcard/S
 natively
 payability
 unpayable
+initializer

--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -511,7 +511,7 @@ impl Dispatch<'_> {
                 .is_dynamic_storage_allocator_enabled();
             quote_spanned!(constructor_span=>
                 Self::#constructor_ident(input) => {
-                    ::ink_lang::codegen::execute_constructor::<#storage_ident, _>(
+                    ::ink_lang::codegen::execute_constructor::<#storage_ident, _, _>(
                         ::ink_lang::codegen::ExecuteConstructorConfig {
                             dynamic_storage_alloc: #is_dynamic_storage_allocation_enabled
                         },

--- a/crates/lang/codegen/src/generator/storage.rs
+++ b/crates/lang/codegen/src/generator/storage.rs
@@ -106,6 +106,9 @@ impl Storage<'_> {
                 impl ::ink_lang::reflect::ContractName for #ident {
                     const NAME: &'static str = ::core::stringify!(#ident);
                 }
+                impl ::ink_lang::codegen::ContractRootKey for #ident {
+                    const ROOT_KEY: ::ink_primitives::Key = ::ink_primitives::Key::new([0x00; 32]);
+                }
             };
         )
     }

--- a/crates/lang/codegen/src/generator/storage.rs
+++ b/crates/lang/codegen/src/generator/storage.rs
@@ -33,14 +33,16 @@ impl GenerateCode for Storage<'_> {
         let storage_span = self.contract.module().storage().span();
         let access_env_impls = self.generate_access_env_trait_impls();
         let storage_struct = self.generate_storage_struct();
+        let allocate_spread_impl = self.generate_spread_allocate_trait_impl();
         let use_emit_event =
             self.contract.module().events().next().is_some().then(|| {
                 // Required to allow for `self.env().emit_event(..)` in messages and constructors.
                 quote! { use ::ink_lang::codegen::EmitEvent as _; }
             });
         quote_spanned!(storage_span =>
-            #access_env_impls
             #storage_struct
+            #access_env_impls
+            #allocate_spread_impl
 
             const _: () = {
                 // Used to make `self.env()` and `Self::env()` available in message code.
@@ -83,6 +85,57 @@ impl Storage<'_> {
         }
     }
 
+    /// Generates a default implementation of `SpreadAllocate` for the ink! storage struct.
+    ///
+    /// # Note
+    ///
+    /// Unlike with `SpreadLayout` it is unfortunately not possible to use the derive macro
+    /// in order to implement this trait. This is due to the fact that `SpreadAllocate` shall
+    /// only be implemented on the ink! storage struct if and only if all of its fields
+    /// implement the trait.
+    /// Therefore having `SpreadAllocate` implemented on the ink! storage struct is optional
+    /// whereas having `SpreadLayout` implemented is mandatory.
+    fn generate_spread_allocate_trait_impl(&self) -> TokenStream2 {
+        let storage = self.contract.module().storage();
+        let span = storage.span();
+        let storage_ident = storage.ident();
+        let bounds = storage.fields().map(|field| {
+            let field_span = field.span();
+            let field_ty = &field.ty;
+            quote_spanned!(field_span=>
+                #field_ty: ::ink_storage::traits::SpreadAllocate
+            )
+        });
+        let body = storage.fields().enumerate().map(|(index, field)| {
+            let field_span = field.span();
+            let field_ident = field
+                .ident
+                .as_ref()
+                .map(|ident| quote! { #ident })
+                .unwrap_or_else(|| quote! { #index });
+            let field_ty = &field.ty;
+            quote_spanned!(field_span=>
+                #field_ident: <#field_ty as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr)
+            )
+        });
+        quote_spanned!(span=>
+            impl ::ink_storage::traits::SpreadAllocate for #storage_ident
+            where
+                #(
+                    #bounds
+                ),*
+            {
+                fn allocate_spread(__key_ptr: &mut ::ink_primitives::KeyPtr) -> Self {
+                    Self {
+                        #(
+                            #body
+                        ),*
+                    }
+                }
+            }
+        )
+    }
+
     /// Generates the storage struct definition.
     fn generate_storage_struct(&self) -> TokenStream2 {
         let storage = self.contract.module().storage();
@@ -106,6 +159,7 @@ impl Storage<'_> {
                 impl ::ink_lang::reflect::ContractName for #ident {
                     const NAME: &'static str = ::core::stringify!(#ident);
                 }
+
                 impl ::ink_lang::codegen::ContractRootKey for #ident {
                     const ROOT_KEY: ::ink_primitives::Key = ::ink_primitives::Key::new([0x00; 32]);
                 }

--- a/crates/lang/src/codegen/dispatch/execution.rs
+++ b/crates/lang/src/codegen/dispatch/execution.rs
@@ -189,10 +189,30 @@ pub trait ConstructorReturnType<C>: private::Sealed {
     /// For infallible constructors this is `core::convert::Infallible`.
     type Error;
 
+    /// The type of the return value of the constructor.
+    ///
+    /// # Note
+    ///
+    /// For infallible constructors this is `()` whereas for fallible
+    /// constructors this is the actual return value. Since we only ever
+    /// return a value in case of `Result::Err` the `Result::Ok` value
+    /// does not matter.
     type ReturnValue;
 
+    /// Converts the return value into a `Result` instance.
+    ///
+    /// # Note
+    ///
+    /// For infallible constructor returns this always yields `Ok`.
     fn as_result(&self) -> Result<&C, &Self::Error>;
 
+    /// Returns the actual return value of the constructor.
+    ///
+    /// # Note
+    ///
+    /// For infallible constructor returns this always yields `()`
+    /// and is basically ignored since this does not get called
+    /// if the constructor did not fail.
     fn return_value(&self) -> &Self::ReturnValue;
 }
 

--- a/crates/lang/src/codegen/dispatch/execution.rs
+++ b/crates/lang/src/codegen/dispatch/execution.rs
@@ -108,7 +108,7 @@ where
             //
             // This requires us to sync back the changes of the contract storage.
             let root_key = <Contract as ContractRootKey>::ROOT_KEY;
-            push_spread_root::<Contract>(&contract, &root_key);
+            push_spread_root::<Contract>(contract, &root_key);
             if config.dynamic_storage_alloc {
                 alloc::finalize();
             }

--- a/crates/lang/src/codegen/dispatch/execution.rs
+++ b/crates/lang/src/codegen/dispatch/execution.rs
@@ -88,7 +88,7 @@ pub fn execute_constructor<S, F>(
     f: F,
 ) -> Result<(), DispatchError>
 where
-    S: ink_storage::traits::SpreadLayout,
+    S: SpreadLayout,
     F: FnOnce() -> S,
 {
     if config.dynamic_storage_alloc {

--- a/crates/lang/src/codegen/dispatch/execution.rs
+++ b/crates/lang/src/codegen/dispatch/execution.rs
@@ -35,6 +35,19 @@ use ink_storage::{
     },
 };
 
+/// The root key of the ink! smart contract.
+///
+/// # Note
+///
+/// - This is the key where storage allocation, pushing and pulling is rooted
+///   using the `SpreadLayout` and `SpreadAllocate` traits primarily.
+/// - This trait is automatically implemented by the ink! codegen.
+/// - The existence of this trait allows to customize the root key in future
+///   versions of ink! if needed.
+pub trait ContractRootKey {
+    const ROOT_KEY: Key;
+}
+
 /// Returns `Ok` if the caller did not transfer additional value to the callee.
 ///
 /// # Errors

--- a/crates/lang/src/codegen/dispatch/mod.rs
+++ b/crates/lang/src/codegen/dispatch/mod.rs
@@ -21,6 +21,7 @@ pub use self::{
         deny_payment,
         execute_constructor,
         execute_message,
+        initialize_contract,
         ContractRootKey,
         ExecuteConstructorConfig,
         ExecuteMessageConfig,

--- a/crates/lang/src/codegen/dispatch/mod.rs
+++ b/crates/lang/src/codegen/dispatch/mod.rs
@@ -20,10 +20,10 @@ pub use self::{
     execution::{
         deny_payment,
         execute_constructor,
-        initialize_contract,
-        ContractRootKey,
         finalize_message,
+        initialize_contract,
         initiate_message,
+        ContractRootKey,
         ExecuteConstructorConfig,
         ExecuteMessageConfig,
     },

--- a/crates/lang/src/codegen/dispatch/mod.rs
+++ b/crates/lang/src/codegen/dispatch/mod.rs
@@ -21,6 +21,7 @@ pub use self::{
         deny_payment,
         execute_constructor,
         execute_message,
+        ContractRootKey,
         ExecuteConstructorConfig,
         ExecuteMessageConfig,
     },

--- a/crates/lang/src/codegen/mod.rs
+++ b/crates/lang/src/codegen/mod.rs
@@ -25,8 +25,8 @@ pub use self::{
     dispatch::{
         deny_payment,
         execute_constructor,
-        initialize_contract,
         finalize_message,
+        initialize_contract,
         initiate_message,
         ContractCallBuilder,
         ContractRootKey,

--- a/crates/lang/src/codegen/mod.rs
+++ b/crates/lang/src/codegen/mod.rs
@@ -26,6 +26,7 @@ pub use self::{
         deny_payment,
         execute_constructor,
         execute_message,
+        initialize_contract,
         ContractCallBuilder,
         ContractRootKey,
         DispatchInput,

--- a/crates/lang/src/codegen/mod.rs
+++ b/crates/lang/src/codegen/mod.rs
@@ -27,6 +27,7 @@ pub use self::{
         execute_constructor,
         execute_message,
         ContractCallBuilder,
+        ContractRootKey,
         DispatchInput,
         DispatchOutput,
         ExecuteConstructorConfig,

--- a/crates/lang/tests/ui/contract/fail/message-returns-non-codec.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-returns-non-codec.stderr
@@ -6,9 +6,9 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
    |
    = note: required because of the requirements on the impl of `Encode` for `NonCodecType`
 note: required by a bound in `DispatchOutput`
-  --> src/codegen/dispatch/type_check.rs:69:8
+  --> src/codegen/dispatch/type_check.rs
    |
-69 |     T: scale::Encode + 'static;
+   |     T: scale::Encode + 'static;
    |        ^^^^^^^^^^^^^ required by this bound in `DispatchOutput`
 
 error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
@@ -21,9 +21,9 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
     |
     = note: required because of the requirements on the impl of `Encode` for `NonCodecType`
 note: required by a bound in `execute_message`
-   --> src/codegen/dispatch/execution.rs:131:13
+   --> src/codegen/dispatch/execution.rs
     |
-131 |     Output: scale::Encode + 'static,
+    |     Output: scale::Encode + 'static,
     |             ^^^^^^^^^^^^^ required by this bound in `execute_message`
 
 error[E0599]: the method `fire` exists for struct `ink_env::call::CallBuilder<DefaultEnvironment, Set<ink_env::AccountId>, Unset<u64>, Unset<u128>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodecType>>>`, but its trait bounds were not satisfied

--- a/crates/primitives/src/key.rs
+++ b/crates/primitives/src/key.rs
@@ -46,10 +46,23 @@ use scale_info::{
 #[repr(transparent)]
 pub struct Key([u8; 32]);
 
+impl Key {
+    /// Creates a new key instance from the given bytes.
+    ///
+    /// # Note
+    ///
+    /// This constructor only exists since it is not yet possible to define
+    /// the `From` trait implementation as const.
+    #[inline]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
 impl From<[u8; 32]> for Key {
     #[inline]
     fn from(bytes: [u8; 32]) -> Self {
-        Self(bytes)
+        Self::new(bytes)
     }
 }
 

--- a/crates/storage/derive/src/lib.rs
+++ b/crates/storage/derive/src/lib.rs
@@ -51,6 +51,7 @@
 extern crate proc_macro;
 
 mod packed_layout;
+mod spread_allocate;
 mod spread_layout;
 mod storage_layout;
 
@@ -59,6 +60,7 @@ mod tests;
 
 use self::{
     packed_layout::packed_layout_derive,
+    spread_allocate::spread_allocate_derive,
     spread_layout::spread_layout_derive,
     storage_layout::storage_layout_derive,
 };
@@ -132,6 +134,44 @@ synstructure::decl_derive!(
     /// ```
     packed_layout_derive
 );
+
+synstructure::decl_derive!(
+    [SpreadAllocate] =>
+    /// Derives `ink_storage`'s `SpreadAllocate` trait for the given `struct`.
+    ///
+    /// # Note
+    ///
+    /// As of now `enum` types are not supported!
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ink_primitives::Key;
+    /// use ink_storage::traits::{
+    ///     SpreadAllocate,
+    ///     SpreadLayout,
+    ///     allocate_spread_root,
+    ///};
+    ///
+    /// #[derive(SpreadAllocate, SpreadLayout)]
+    /// # #[derive(Debug, PartialEq)]
+    /// struct NamedFields {
+    ///     a: u32,
+    ///     b: [u32; 32],
+    /// }
+    ///
+    /// let allocated: NamedFields = allocate_spread_root(&Key::from([0x42; 32]));
+    /// assert_eq!(
+    ///     allocated,
+    ///     NamedFields {
+    ///         a: 0,
+    ///         b: [0; 32],
+    ///     }
+    /// );
+    /// ```
+    spread_allocate_derive
+);
+
 synstructure::decl_derive!(
     [StorageLayout] =>
     /// Derives `ink_storage`'s `StorageLayout` trait for the given `struct` or `enum`.

--- a/crates/storage/derive/src/spread_allocate.rs
+++ b/crates/storage/derive/src/spread_allocate.rs
@@ -33,10 +33,7 @@ pub fn spread_allocate_derive(mut s: synstructure::Structure) -> TokenStream2 {
 
 /// Derives `ink_storage`'s `SpreadAllocate` trait for the given `struct`.
 fn derive_struct(s: synstructure::Structure) -> TokenStream2 {
-    assert!(
-        s.variants().len() == 1,
-        "can only operate on structs"
-    );
+    assert!(s.variants().len() == 1, "can only operate on structs");
     let variant = &s.variants()[0];
     let allocate_body = variant.construct(|field, _index| {
         let ty = &field.ty;

--- a/crates/storage/derive/src/spread_allocate.rs
+++ b/crates/storage/derive/src/spread_allocate.rs
@@ -31,11 +31,11 @@ pub fn spread_allocate_derive(mut s: synstructure::Structure) -> TokenStream2 {
     }
 }
 
-/// Derives `ink_storage`'s `SpreadAllocate` trait for the given `struct` or `enum`.
+/// Derives `ink_storage`'s `SpreadAllocate` trait for the given `struct`.
 fn derive_struct(s: synstructure::Structure) -> TokenStream2 {
     assert!(
         s.variants().len() == 1,
-        "can only operate on structs or enums with 1 variant"
+        "can only operate on structs"
     );
     let variant = &s.variants()[0];
     let allocate_body = variant.construct(|field, _index| {

--- a/crates/storage/derive/src/spread_allocate.rs
+++ b/crates/storage/derive/src/spread_allocate.rs
@@ -1,0 +1,54 @@
+// Copyright 2018-2021 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+/// Derives `ink_storage`'s `SpreadAllocate` trait for the given type.
+pub fn spread_allocate_derive(mut s: synstructure::Structure) -> TokenStream2 {
+    s.bind_with(|_| synstructure::BindStyle::Move)
+        .add_bounds(synstructure::AddBounds::Generics)
+        .underscore_const(true);
+    match s.ast().data {
+        syn::Data::Struct(_) => derive_struct(s),
+        syn::Data::Enum(_) => {
+            panic!("cannot derive `SpreadAllocate` for `enum` types")
+        }
+        syn::Data::Union(_) => {
+            panic!("cannot derive `SpreadAllocate` for `union` types")
+        }
+    }
+}
+
+/// Derives `ink_storage`'s `SpreadAllocate` trait for the given `struct` or `enum`.
+fn derive_struct(s: synstructure::Structure) -> TokenStream2 {
+    assert!(
+        s.variants().len() == 1,
+        "can only operate on structs or enums with 1 variant"
+    );
+    let variant = &s.variants()[0];
+    let allocate_body = variant.construct(|field, _index| {
+        let ty = &field.ty;
+        quote! {
+            <#ty as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr)
+        }
+    });
+    s.gen_impl(quote! {
+        gen impl ::ink_storage::traits::SpreadAllocate for @Self {
+            fn allocate_spread(__key_ptr: &mut ::ink_primitives::KeyPtr) -> Self {
+                #allocate_body
+            }
+        }
+    })
+}

--- a/crates/storage/derive/src/tests/mod.rs
+++ b/crates/storage/derive/src/tests/mod.rs
@@ -13,5 +13,6 @@
 // limitations under the License.
 
 mod packed_layout;
+mod spread_allocate;
 mod spread_layout;
 mod storage_layout;

--- a/crates/storage/derive/src/tests/spread_allocate.rs
+++ b/crates/storage/derive/src/tests/spread_allocate.rs
@@ -64,7 +64,7 @@ fn struct_works() {
             struct NamedFields {
                 a: i32,
                 b: [u8; 32],
-                d: Box<i32>,
+                c: Box<i32>,
             }
         }
         expands to {
@@ -74,7 +74,7 @@ fn struct_works() {
                         NamedFields {
                             a: <i32 as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr),
                             b: <[u8; 32] as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr),
-                            d: <Box<i32> as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr),
+                            c: <Box<i32> as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr),
                         }
                     }
                 }

--- a/crates/storage/derive/src/tests/spread_allocate.rs
+++ b/crates/storage/derive/src/tests/spread_allocate.rs
@@ -1,0 +1,114 @@
+// Copyright 2018-2021 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The `synstructure` crate currently expands to code that has a single
+// `panic` inside an `if` block. We have to allow the following `clippy`
+// lint until the fixing PR has been merged:
+// PR: https://github.com/mystor/synstructure/pull/50
+#![allow(clippy::if_then_panic)]
+
+use crate::spread_allocate_derive;
+use syn::parse_quote;
+
+#[test]
+#[should_panic(expected = "cannot derive `SpreadAllocate` for `enum` types")]
+fn enum_fails() {
+    spread_allocate_derive(synstructure::Structure::new(&parse_quote! {
+        enum Enum { A, B, C }
+    }));
+}
+
+#[test]
+#[should_panic(expected = "Unable to create synstructure::Structure: \
+                           Error(\"unexpected unsupported untagged union\")")]
+fn union_fails() {
+    spread_allocate_derive(synstructure::Structure::new(&parse_quote! {
+        union Union { a: i32, b: u32 }
+    }));
+}
+
+#[test]
+fn unit_struct_works() {
+    synstructure::test_derive! {
+        spread_allocate_derive {
+            struct UnitStruct;
+        }
+        expands to {
+            const _: () = {
+                impl ::ink_storage::traits::SpreadAllocate for UnitStruct {
+                    fn allocate_spread(__key_ptr: &mut ::ink_primitives::KeyPtr) -> Self {
+                        UnitStruct
+                    }
+                }
+            };
+        }
+        no_build
+    }
+}
+
+#[test]
+fn struct_works() {
+    synstructure::test_derive! {
+        spread_allocate_derive {
+            struct NamedFields {
+                a: i32,
+                b: [u8; 32],
+                d: Box<i32>,
+            }
+        }
+        expands to {
+            const _: () = {
+                impl ::ink_storage::traits::SpreadAllocate for NamedFields {
+                    fn allocate_spread(__key_ptr: &mut ::ink_primitives::KeyPtr) -> Self {
+                        NamedFields {
+                            a: <i32 as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr),
+                            b: <[u8; 32] as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr),
+                            d: <Box<i32> as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr),
+                        }
+                    }
+                }
+            };
+        }
+        no_build
+    }
+}
+
+#[test]
+fn generic_struct_works() {
+    synstructure::test_derive! {
+        spread_allocate_derive {
+            struct GenericStruct<T1, T2> {
+                a: T1,
+                b: (T1, T2),
+            }
+        }
+        expands to {
+            const _: () = {
+                impl<T1, T2> ::ink_storage::traits::SpreadAllocate for GenericStruct<T1, T2>
+                where
+                    T1: ::ink_storage::traits::SpreadAllocate,
+                    T2: ::ink_storage::traits::SpreadAllocate
+                {
+                    fn allocate_spread(__key_ptr: &mut ::ink_primitives::KeyPtr) -> Self {
+                        GenericStruct {
+                            a: <T1 as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr),
+                            b: <(T1, T2) as ::ink_storage::traits::SpreadAllocate>::allocate_spread(__key_ptr),
+                        }
+                    }
+                }
+            };
+        }
+        no_build
+    }
+}

--- a/crates/storage/derive/src/tests/spread_allocate.rs
+++ b/crates/storage/derive/src/tests/spread_allocate.rs
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The `synstructure` crate currently expands to code that has a single
-// `panic` inside an `if` block. We have to allow the following `clippy`
-// lint until the fixing PR has been merged:
-// PR: https://github.com/mystor/synstructure/pull/50
-#![allow(clippy::if_then_panic)]
-
 use crate::spread_allocate_derive;
 use syn::parse_quote;
 

--- a/crates/storage/src/traits/mod.rs
+++ b/crates/storage/src/traits/mod.rs
@@ -68,6 +68,7 @@ pub use self::{
 use ink_primitives::Key;
 pub use ink_storage_derive::{
     PackedLayout,
+    SpreadAllocate,
     SpreadLayout,
     StorageLayout,
 };


### PR DESCRIPTION
Implements
- https://github.com/paritytech/ink/issues/993
- https://github.com/paritytech/ink/issues/992
- https://github.com/paritytech/ink/issues/991

Also partially implements https://github.com/paritytech/ink/issues/988 .
Note: Only partial since fallible ink! constructors remain artificially forbidden as of now. Another follow-up PR might change that soon.

All in all this heavily simplifies working with the new `SpreadLayout` traits in ink! smart contracts. As a consequence we can further simplify https://github.com/paritytech/ink/pull/979 after merging this PR.