### PR TITLE
Reworked message dispatch logic. Moved common parts upper.

### DIFF
--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -526,6 +526,17 @@ where
     })
 }
 
+/// Returns the buffer back to the caller of the executed contract.
+///
+/// # Note
+///
+/// This function  stops the execution of the contract immediately.
+pub fn return_value_scoped(return_flags: ReturnFlags, return_value: &[u8]) -> ! {
+    <EnvInstance as OnInstance>::on_instance(|instance| {
+        EnvBackend::return_value_scoped(instance, return_flags, return_value)
+    })
+}
+
 /// Returns a random hash seed and the block number since which it was determinable
 /// by chain observers.
 ///

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -220,6 +220,17 @@ pub trait EnvBackend {
     where
         R: scale::Encode;
 
+    /// Returns the buffer to the caller of the executed contract.
+    ///
+    /// # Note
+    ///
+    /// Calling this method will end contract execution immediately.
+    /// It will return the given return value back to its caller.
+    ///
+    /// The `flags` parameter can be used to revert the state changes of the
+    /// entire execution if necessary.
+    fn return_value_scoped(&mut self, flags: ReturnFlags, return_value: &[u8]) -> !;
+
     /// Emit a custom debug message.
     ///
     /// The message is appended to the debug buffer which is then supplied to the calling RPC

--- a/crates/env/src/buffer.rs
+++ b/crates/env/src/buffer.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Utilities to encode value into buffer
+
 /// A static buffer with 16 kB of capacity.
 pub struct StaticBuffer {
     /// The static buffer with a total capacity of 16 kB.
@@ -170,7 +172,7 @@ impl<'a> ScopedBuffer<'a> {
     /// Appends the encoding of `value` to the scoped buffer.
     ///
     /// Does not return the buffer immediately so that other values can be appended
-    /// afterwards. The [`take_appended`] method shall be used to return the buffer
+    /// afterwards. The `take_appended` method shall be used to return the buffer
     /// that includes all appended encodings as a single buffer.
     pub fn append_encoded<T>(&mut self, value: &T)
     where
@@ -185,7 +187,7 @@ impl<'a> ScopedBuffer<'a> {
         let _ = core::mem::replace(&mut self.buffer, buffer);
     }
 
-    /// Returns the buffer containing all encodings appended via [`append_encoded`]
+    /// Returns the buffer containing all encodings appended via `append_encoded`
     /// in a single byte buffer.
     pub fn take_appended(&mut self) -> &'a mut [u8] {
         debug_assert_ne!(self.offset, 0);

--- a/crates/env/src/engine/experimental_off_chain/impls.rs
+++ b/crates/env/src/engine/experimental_off_chain/impls.rs
@@ -227,6 +227,12 @@ impl EnvBackend for EnvInstance {
         )
     }
 
+    fn return_value_scoped(&mut self, _flags: ReturnFlags, _return_value: &[u8]) -> ! {
+        unimplemented!(
+            "the experimental off chain env does not implement `seal_return_value`"
+        )
+    }
+
     fn debug_message(&mut self, message: &str) {
         self.engine.debug_message(message)
     }

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -175,6 +175,12 @@ impl EnvBackend for EnvInstance {
         std::process::exit(flags.into_u32() as i32)
     }
 
+    fn return_value_scoped(&mut self, flags: ReturnFlags, return_value: &[u8]) -> ! {
+        let ctx = self.exec_context_mut().expect(UNINITIALIZED_EXEC_CONTEXT);
+        ctx.output = Some(return_value.to_vec());
+        std::process::exit(flags.into_u32() as i32)
+    }
+
     fn debug_message(&mut self, message: &str) {
         self.debug_buf.debug_message(message)
     }

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -298,6 +298,10 @@ impl EnvBackend for EnvInstance {
         ext::return_value(flags, enc_return_value);
     }
 
+    fn return_value_scoped(&mut self, flags: ReturnFlags, return_value: &[u8]) -> ! {
+        ext::return_value(flags, return_value);
+    }
+
     fn debug_message(&mut self, content: &str) {
         ext::debug_message(content)
     }

--- a/crates/env/src/engine/on_chain/mod.rs
+++ b/crates/env/src/engine/on_chain/mod.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod buffer;
 mod ext;
 mod impls;
 
@@ -24,6 +23,7 @@ use self::{
     ext::Error,
 };
 use super::OnInstance;
+use crate::buffer;
 
 /// The on-chain environment.
 pub struct EnvInstance {

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -64,6 +64,7 @@ extern crate ink_allocator;
 mod api;
 mod arithmetic;
 mod backend;
+pub mod buffer;
 pub mod call;
 pub mod chain_extension;
 mod engine;

--- a/crates/lang/src/codegen/dispatch/mod.rs
+++ b/crates/lang/src/codegen/dispatch/mod.rs
@@ -20,9 +20,7 @@ pub use self::{
     execution::{
         deny_payment,
         execute_constructor,
-        finalize_message,
         initialize_contract,
-        initiate_message,
         ContractRootKey,
         ExecuteConstructorConfig,
         ExecuteMessageConfig,

--- a/crates/lang/src/codegen/mod.rs
+++ b/crates/lang/src/codegen/mod.rs
@@ -25,9 +25,7 @@ pub use self::{
     dispatch::{
         deny_payment,
         execute_constructor,
-        finalize_message,
         initialize_contract,
-        initiate_message,
         ContractCallBuilder,
         ContractRootKey,
         DispatchInput,

--- a/crates/lang/tests/ui/contract/fail/constructor-input-non-codec.stderr
+++ b/crates/lang/tests/ui/contract/fail/constructor-input-non-codec.stderr
@@ -6,9 +6,9 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeDecode` is not satisfied
    |
    = note: required because of the requirements on the impl of `parity_scale_codec::Decode` for `NonCodecType`
 note: required by a bound in `DispatchInput`
-  --> src/codegen/dispatch/type_check.rs:41:8
+  --> src/codegen/dispatch/type_check.rs
    |
-41 |     T: scale::Decode + 'static;
+   |     T: scale::Decode + 'static;
    |        ^^^^^^^^^^^^^ required by this bound in `DispatchInput`
 
 error[E0277]: the trait bound `NonCodecType: WrapperTypeDecode` is not satisfied

--- a/crates/lang/tests/ui/contract/fail/message-returns-non-codec.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-returns-non-codec.stderr
@@ -12,19 +12,14 @@ note: required by a bound in `DispatchOutput`
    |        ^^^^^^^^^^^^^ required by this bound in `DispatchOutput`
 
 error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
-   --> tests/ui/contract/fail/message-returns-non-codec.rs:18:9
-    |
-18  | /         pub fn message(&self) -> NonCodecType {
-19  | |             NonCodecType
-20  | |         }
-    | |_________^ the trait `WrapperTypeEncode` is not implemented for `NonCodecType`
-    |
-    = note: required because of the requirements on the impl of `Encode` for `NonCodecType`
-note: required by a bound in `finalize_message`
-   --> src/codegen/dispatch/execution.rs
-    |
-    |     R: scale::Encode + 'static,
-    |        ^^^^^^^^^^^^^ required by this bound in `finalize_message`
+  --> tests/ui/contract/fail/message-returns-non-codec.rs:18:9
+   |
+18 | /         pub fn message(&self) -> NonCodecType {
+19 | |             NonCodecType
+20 | |         }
+   | |_________^ the trait `WrapperTypeEncode` is not implemented for `NonCodecType`
+   |
+   = note: required because of the requirements on the impl of `Encode` for `NonCodecType`
 
 error[E0599]: the method `fire` exists for struct `ink_env::call::CallBuilder<DefaultEnvironment, Set<ink_env::AccountId>, Unset<u64>, Unset<u128>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodecType>>>`, but its trait bounds were not satisfied
    --> tests/ui/contract/fail/message-returns-non-codec.rs:18:9


### PR DESCRIPTION
It is PR for the change https://github.com/paritytech/ink/pull/998. With this change `Erc20` has size:
Original wasm size: 64.4K, Optimized: 28.3K