### PR TITLE
Remove unknown lint

### DIFF
--- a/crates/storage/derive/src/tests/packed_layout.rs
+++ b/crates/storage/derive/src/tests/packed_layout.rs
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The `synstructure` crate currently expands to code that has a single
-// `panic` inside an `if` block. We have to allow the following `clippy`
-// lint until the fixing PR has been merged:
-// PR: https://github.com/mystor/synstructure/pull/50
-#![allow(clippy::if_then_panic)]
-
 use crate::packed_layout_derive;
 
 #[test]

--- a/crates/storage/derive/src/tests/spread_layout.rs
+++ b/crates/storage/derive/src/tests/spread_layout.rs
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The `synstructure` crate currently expands to code that has a single
-// `panic` inside an `if` block. We have to allow the following `clippy`
-// lint until the fixing PR has been merged:
-// PR: https://github.com/mystor/synstructure/pull/50
-#![allow(clippy::if_then_panic)]
 // These tests are partly testing if code is expanded correctly.
 // Hence the syntax contains a number of verbose statements which
 // are not properly cleaned up.

--- a/crates/storage/derive/src/tests/storage_layout.rs
+++ b/crates/storage/derive/src/tests/storage_layout.rs
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The `synstructure` crate currently expands to code that has a single
-// `panic` inside an `if` block. We have to allow the following `clippy`
-// lint until the fixing PR has been merged:
-// PR: https://github.com/mystor/synstructure/pull/50
-#![allow(clippy::if_then_panic)]
-
 use crate::storage_layout_derive;
 
 #[test]


### PR DESCRIPTION
The `if_then_panic` lint has been moved to the linting level `pedantic`: https://github.com/rust-lang/rust-clippy/commit/d8fcfd7d64f102402819aba3ac91954a7a6888cc.

We currently use the default linting level, thus the `clippy` CI currently fails with `unknown lint`.