### PR TITLE
Specify minor version for `parity-scale-codec` in TOML files

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 
 sha2 = { version = "0.9" }

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -20,7 +20,7 @@ ink_allocator = { version = "3.0.0-rc6", path = "../allocator/", default-feature
 ink_primitives = { version = "3.0.0-rc6", path = "../primitives/", default-features = false }
 ink_prelude = { version = "3.0.0-rc6", path = "../prelude/", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 num-traits = { version = "0.2", default-features = false, features = ["i128"] }
 cfg-if = "1.0"

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -23,7 +23,7 @@ ink_prelude = { version = "3.0.0-rc6", path = "../prelude", default-features = f
 ink_eth_compatibility = { version = "3.0.0-rc6", path = "../eth_compatibility", default-features = false }
 ink_lang_macro = { version = "3.0.0-rc6", path = "macro", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 
 [dev-dependencies]

--- a/crates/lang/codegen/Cargo.toml
+++ b/crates/lang/codegen/Cargo.toml
@@ -27,7 +27,7 @@ itertools = "0.10"
 either = { version = "1.5", default-features = false }
 blake2 = "0.9"
 heck = "0.3.1"
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive", "full"] }
 impl-serde = "0.3.1"
 
 [features]

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -19,7 +19,7 @@ ink_lang_ir = { version = "3.0.0-rc6", path = "../ir", default-features = false 
 ink_lang_codegen = { version = "3.0.0-rc6", path = "../codegen", default-features = false }
 ink_primitives = { version = "3.0.0-rc6", path = "../../primitives/", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive"] }
 syn = "1"
 proc-macro2 = "1"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -16,7 +16,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 ink_prelude = { version = "3.0.0-rc6", path = "../prelude/", default-features = false }
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1"
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -21,7 +21,7 @@ ink_primitives = { version = "3.0.0-rc6", path = "../primitives/", default-featu
 ink_storage_derive = { version = "3.0.0-rc6", path = "derive", default-features = false }
 ink_prelude = { version = "3.0.0-rc6", path = "../prelude/", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 scale-info = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1.0"

--- a/crates/storage/derive/Cargo.toml
+++ b/crates/storage/derive/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro2 = "1"
 synstructure = "0.12.4"
 
 [dev-dependencies]
-scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive", "full"] }
 ink_env = { version = "3.0.0-rc6", path = "../../env" }
 ink_primitives = { version = "3.0.0-rc6", path = "../../primitives" }
 ink_metadata = { version = "3.0.0-rc6", path = "../../metadata" }


### PR DESCRIPTION
I just spent some time trying to figure out why my UI tests were failing locally but
passing on the CI. I realized that it was because my local repo was using
`parity-scale-codec` `v2.1.1`. This was totally file as far as Cargo was concerned since
we only specified `2` in our TOML files. However, for our test this was not fine, and
`v2.3.1` was required. Since `ink!` doesn't have a Lockfile I figured I'd manually bump
the required version ([`cargo-upgrade`](https://github.com/killercup/cargo-edit#cargo-upgrade) made this a breeze FYI).
