### PR TITLE
Remove `always` from `inline` to allow compiler decide that to do

### DIFF
--- a/crates/env/src/chain_extension.rs
+++ b/crates/env/src/chain_extension.rs
@@ -83,7 +83,7 @@ pub struct ChainExtensionMethod<I, O, ErrorCode> {
 
 impl ChainExtensionMethod<(), (), ()> {
     /// Creates a new chain extension method instance.
-    #[inline(always)]
+    #[inline]
     pub fn build(func_id: u32) -> Self {
         Self {
             func_id,
@@ -100,7 +100,7 @@ impl<O, ErrorCode> ChainExtensionMethod<(), O, ErrorCode> {
     /// `I` represents the input type of the chain extension method.
     /// All tuple types that may act as input parameters for the chain extension method are valid.
     /// Examples include `()`, `i32`, `(u8, [u8; 5], i32)`, etc.
-    #[inline(always)]
+    #[inline]
     pub fn input<I>(self) -> ChainExtensionMethod<I, O, ErrorCode>
     where
         I: scale::Encode,
@@ -118,7 +118,7 @@ impl<I, ErrorCode> ChainExtensionMethod<I, (), ErrorCode> {
     /// # Note
     ///
     /// This indicates that the chain extension method return value might represent a failure.
-    #[inline(always)]
+    #[inline]
     pub fn output_result<T, E>(self) -> ChainExtensionMethod<I, Result<T, E>, ErrorCode>
     where
         Result<T, E>: scale::Decode,
@@ -138,7 +138,7 @@ impl<I, ErrorCode> ChainExtensionMethod<I, (), ErrorCode> {
     /// When using the `#[ink::chain_extension]` procedural macro to define
     /// this chain extension method the above constraint is enforced at
     /// compile time.
-    #[inline(always)]
+    #[inline]
     pub fn output<O>(self) -> ChainExtensionMethod<I, state::NoResult<O>, ErrorCode>
     where
         O: scale::Decode,
@@ -160,7 +160,7 @@ impl<I, O> ChainExtensionMethod<I, O, ()> {
     /// code that represents failure.
     ///
     /// The output of the chain extension method call is always decoded and returned in this case.
-    #[inline(always)]
+    #[inline]
     pub fn ignore_error_code(self) -> ChainExtensionMethod<I, O, state::IgnoreErrorCode> {
         ChainExtensionMethod {
             func_id: self.func_id,
@@ -174,7 +174,7 @@ impl<I, O> ChainExtensionMethod<I, O, ()> {
     ///
     /// This will handle the returned status code and only loads and decodes the value
     /// returned as the output of the chain extension method call in case of success.
-    #[inline(always)]
+    #[inline]
     pub fn handle_error_code<ErrorCode>(
         self,
     ) -> ChainExtensionMethod<I, O, state::HandleErrorCode<ErrorCode>>
@@ -261,7 +261,7 @@ where
     /// #     fn from_status_code(status_code: u32) -> Result<(), Self> { Ok(()) }
     /// # }
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn call(self, input: &I) -> Result<T, E> {
         <EnvInstance as OnInstance>::on_instance(|instance| {
             EnvBackend::call_chain_extension::<I, T, E, ErrorCode, _, _>(
@@ -315,7 +315,7 @@ where
     /// #     fn from(_error: scale::Error) -> Self { Self {} }
     /// # }
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn call(self, input: &I) -> Result<T, E> {
         <EnvInstance as OnInstance>::on_instance(|instance| {
             EnvBackend::call_chain_extension::<I, T, E, E, _, _>(
@@ -372,7 +372,7 @@ where
     /// #     fn from_status_code(status_code: u32) -> Result<(), Self> { Ok(()) }
     /// # }
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn call(self, input: &I) -> Result<O, ErrorCode> {
         <EnvInstance as OnInstance>::on_instance(|instance| {
             EnvBackend::call_chain_extension::<I, O, ErrorCode, ErrorCode, _, _>(
@@ -421,7 +421,7 @@ where
     ///     .ignore_error_code()
     ///     .call(&(true, 42));
     /// ```
-    #[inline(always)]
+    #[inline]
     pub fn call(self, input: &I) -> O {
         <EnvInstance as OnInstance>::on_instance(|instance| {
             EnvBackend::call_chain_extension::<I, O, (), (), _, _>(

--- a/crates/lang/codegen/src/generator/as_dependency/call_builder.rs
+++ b/crates/lang/codegen/src/generator/as_dependency/call_builder.rs
@@ -188,7 +188,7 @@ impl CallBuilder<'_> {
             impl ::ink_lang::codegen::TraitCallForwarderFor<#trait_info> for #cb_ident {
                 type Forwarder = <<Self as #trait_path>::__ink_TraitInfo as ::ink_lang::codegen::TraitCallForwarder>::Forwarder;
 
-                #[inline(always)]
+                #[inline]
                 fn forward(&self) -> &Self::Forwarder {
                     // SAFETY:
                     //
@@ -201,7 +201,7 @@ impl CallBuilder<'_> {
                     }
                 }
 
-                #[inline(always)]
+                #[inline]
                 fn forward_mut(&mut self) -> &mut Self::Forwarder {
                     // SAFETY:
                     //
@@ -214,14 +214,14 @@ impl CallBuilder<'_> {
                     }
                 }
 
-                #[inline(always)]
+                #[inline]
                 fn build(&self) -> &<Self::Forwarder as ::ink_lang::codegen::TraitCallBuilder>::Builder {
                     <_ as ::ink_lang::codegen::TraitCallBuilder>::call(
                         <Self as ::ink_lang::codegen::TraitCallForwarderFor<#trait_info>>::forward(self)
                     )
                 }
 
-                #[inline(always)]
+                #[inline]
                 fn build_mut(&mut self)
                     -> &mut <Self::Forwarder as ::ink_lang::codegen::TraitCallBuilder>::Builder
                 {

--- a/crates/lang/codegen/src/generator/trait_def/call_builder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_builder.rs
@@ -215,11 +215,11 @@ impl CallBuilder<'_> {
                 E: ::ink_env::Environment,
                 <E as ::ink_env::Environment>::AccountId: ::ink_storage::traits::PackedLayout,
             {
-                #[inline(always)]
+                #[inline]
                 fn pull_packed(&mut self, _at: &::ink_primitives::Key) {}
-                #[inline(always)]
+                #[inline]
                 fn push_packed(&self, _at: &::ink_primitives::Key) {}
-                #[inline(always)]
+                #[inline]
                 fn clear_packed(&self, _at: &::ink_primitives::Key) {}
             }
         )

--- a/crates/lang/src/codegen/dispatch/execution.rs
+++ b/crates/lang/src/codegen/dispatch/execution.rs
@@ -220,12 +220,12 @@ impl<C> ConstructorReturnType<C> for private::Seal<C> {
     type Error = Infallible;
     type ReturnValue = ();
 
-    #[inline(always)]
+    #[inline]
     fn as_result(&self) -> Result<&C, &Self::Error> {
         Ok(&self.0)
     }
 
-    #[inline(always)]
+    #[inline]
     fn return_value(&self) -> &Self::ReturnValue {
         &()
     }
@@ -236,12 +236,12 @@ impl<C, E> ConstructorReturnType<C> for private::Seal<Result<C, E>> {
     type Error = E;
     type ReturnValue = Result<C, E>;
 
-    #[inline(always)]
+    #[inline]
     fn as_result(&self) -> Result<&C, &Self::Error> {
         self.0.as_ref()
     }
 
-    #[inline(always)]
+    #[inline]
     fn return_value(&self) -> &Self::ReturnValue {
         &self.0
     }
@@ -310,7 +310,7 @@ pub struct ExecuteMessageConfig {
 /// This work around that splits executing an ink! message into initiate
 /// and finalize phases was needed due to the fact that `is_result_type`
 /// and `is_result_err` macros do not work in generic contexts.
-#[inline(always)]
+#[inline]
 pub fn initiate_message<Contract>(
     config: ExecuteMessageConfig,
 ) -> Result<Contract, DispatchError>

--- a/crates/lang/src/result_info.rs
+++ b/crates/lang/src/result_info.rs
@@ -44,7 +44,7 @@ macro_rules! is_result_type {
 pub struct IsResultErr<'lt, T>(pub &'lt T);
 
 impl<T, E> IsResultErr<'_, ::core::result::Result<T, E>> {
-    #[inline(always)]
+    #[inline]
     // We need to allow for dead code at this point because
     // the Rust compiler thinks this function is unused even
     // though it acts as the specialized case for detection.
@@ -55,7 +55,7 @@ impl<T, E> IsResultErr<'_, ::core::result::Result<T, E>> {
 }
 
 pub trait IsResultErrFallback {
-    #[inline(always)]
+    #[inline]
     fn value(&self) -> bool {
         false
     }

--- a/crates/primitives/src/key.rs
+++ b/crates/primitives/src/key.rs
@@ -144,7 +144,7 @@ impl Key {
 }
 
 impl scale::Encode for Key {
-    #[inline(always)]
+    #[inline]
     fn size_hint(&self) -> usize {
         32
     }
@@ -165,7 +165,7 @@ impl scale::Encode for Key {
         f(self.as_ref())
     }
 
-    #[inline(always)]
+    #[inline]
     fn encoded_size(&self) -> usize {
         self.size_hint()
     }
@@ -183,7 +183,7 @@ impl scale::Decode for Key {
         Ok(Self::from(bytes))
     }
 
-    #[inline(always)]
+    #[inline]
     fn encoded_fixed_size() -> Option<usize> {
         Some(32)
     }

--- a/crates/storage/src/collections/stash/storage.rs
+++ b/crates/storage/src/collections/stash/storage.rs
@@ -98,16 +98,16 @@ impl SpreadAllocate for Header {
 }
 
 impl PackedLayout for Header {
-    #[inline(always)]
+    #[inline]
     fn pull_packed(&mut self, _at: &Key) {}
-    #[inline(always)]
+    #[inline]
     fn push_packed(&self, _at: &Key) {}
-    #[inline(always)]
+    #[inline]
     fn clear_packed(&self, _at: &Key) {}
 }
 
 impl PackedAllocate for Header {
-    #[inline(always)]
+    #[inline]
     fn allocate_packed(&mut self, _at: &Key) {}
 }
 

--- a/crates/storage/src/memory.rs
+++ b/crates/storage/src/memory.rs
@@ -80,10 +80,10 @@ where
         Default::default()
     }
 
-    #[inline(always)]
+    #[inline]
     fn push_spread(&self, _ptr: &mut KeyPtr) {}
 
-    #[inline(always)]
+    #[inline]
     fn clear_spread(&self, _ptr: &mut KeyPtr) {}
 }
 

--- a/crates/storage/src/traits/impls/collections.rs
+++ b/crates/storage/src/traits/impls/collections.rs
@@ -163,7 +163,7 @@ where
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn pull_packed(&mut self, _at: &Key) {
         // We cannot mutate keys in a set so we cannot forward pull signals.
     }
@@ -173,7 +173,7 @@ impl<T> PackedAllocate for StdBTreeSet<T>
 where
     T: PackedAllocate + Ord,
 {
-    #[inline(always)]
+    #[inline]
     fn allocate_packed(&mut self, _at: &Key) {
         // We cannot mutate keys in a set so we cannot forward pull signals.
     }
@@ -228,7 +228,7 @@ where
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn pull_packed(&mut self, _at: &Key) {
         // We cannot mutate keys in a heap so we cannot forward pull signals.
     }
@@ -238,7 +238,7 @@ impl<T> PackedAllocate for StdBinaryHeap<T>
 where
     T: PackedAllocate + Ord,
 {
-    #[inline(always)]
+    #[inline]
     fn allocate_packed(&mut self, _at: &Key) {
         // We cannot mutate keys in a heap so we cannot forward pull signals.
     }

--- a/crates/storage/src/traits/impls/prims.rs
+++ b/crates/storage/src/traits/impls/prims.rs
@@ -35,15 +35,15 @@ macro_rules! impl_layout_for_primitive {
         $(
             impl_always_packed_layout!($ty, deep: false);
             impl $crate::traits::PackedLayout for $ty {
-                #[inline(always)]
+                #[inline]
                 fn pull_packed(&mut self, _at: &::ink_primitives::Key) {}
-                #[inline(always)]
+                #[inline]
                 fn push_packed(&self, _at: &::ink_primitives::Key) {}
-                #[inline(always)]
+                #[inline]
                 fn clear_packed(&self, _at: &::ink_primitives::Key) {}
             }
             impl $crate::traits::PackedAllocate for $ty {
-                #[inline(always)]
+                #[inline]
                 fn allocate_packed(&mut self, _at: &::ink_primitives::Key) {}
             }
         )*


### PR DESCRIPTION
It's funny, but removing `always` with combination https://github.com/paritytech/cargo-contract/pull/358, reduces the size of `Erc20` contract in `master` from  31.4K to 27.4K