### PR TITLE
Remove all instance of `inline`

### DIFF
--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -35,7 +35,6 @@ static mut INNER: InnerAlloc = InnerAlloc::new();
 pub struct BumpAllocator;
 
 unsafe impl GlobalAlloc for BumpAllocator {
-    #[inline]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         match INNER.alloc(layout) {
             Some(start) => start as *mut u8,
@@ -43,7 +42,6 @@ unsafe impl GlobalAlloc for BumpAllocator {
         }
     }
 
-    #[inline]
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         // A new page in Wasm is guaranteed to already be zero initialized, so we can just use our
         // regular `alloc` call here and save a bit of work.
@@ -52,7 +50,6 @@ unsafe impl GlobalAlloc for BumpAllocator {
         self.alloc(layout)
     }
 
-    #[inline]
     unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
 }
 
@@ -142,7 +139,6 @@ impl InnerAlloc {
 /// This function rounds up to the next page. For example, if we have an allocation of
 /// `size = PAGE_SIZE / 2` this function will indicate that one page is required to satisfy
 /// the allocation.
-#[inline]
 fn required_pages(size: usize) -> Option<usize> {
     size.checked_add(PAGE_SIZE - 1)
         .and_then(|num| num.checked_div(PAGE_SIZE))

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -54,7 +54,6 @@ macro_rules! define_error_codes {
         }
 
         impl From<ReturnCode> for Result {
-            #[inline]
             fn from(return_code: ReturnCode) -> Self {
                 match return_code.0 {
                     0 => Ok(()),

--- a/crates/env/src/call/call_builder.rs
+++ b/crates/env/src/call/call_builder.rs
@@ -54,31 +54,26 @@ where
     E: Environment,
 {
     /// Returns the account ID of the called contract instance.
-    #[inline]
     pub(crate) fn callee(&self) -> &E::AccountId {
         &self.callee
     }
 
     /// Returns the call flags.
-    #[inline]
     pub(crate) fn call_flags(&self) -> &CallFlags {
         &self.call_flags
     }
 
     /// Returns the chosen gas limit for the called contract execution.
-    #[inline]
     pub(crate) fn gas_limit(&self) -> u64 {
         self.gas_limit
     }
 
     /// Returns the transferred value for the called contract.
-    #[inline]
     pub(crate) fn transferred_value(&self) -> &E::Balance {
         &self.transferred_value
     }
 
     /// Returns the execution input.
-    #[inline]
     pub(crate) fn exec_input(&self) -> &ExecutionInput<Args> {
         &self.exec_input
     }
@@ -240,7 +235,6 @@ where
     E: Environment,
 {
     /// Sets the called smart contract instance account ID to the given value.
-    #[inline]
     pub fn callee(
         self,
         callee: E::AccountId,
@@ -264,7 +258,6 @@ where
     E: Environment,
 {
     /// The flags used to change the behavior of the contract call.
-    #[inline]
     pub fn call_flags(
         self,
         call_flags: CallFlags,
@@ -287,7 +280,6 @@ where
     E: Environment,
 {
     /// Sets the maximum allowed gas costs for the call.
-    #[inline]
     pub fn gas_limit(
         self,
         gas_limit: u64,
@@ -310,7 +302,6 @@ where
     E: Environment,
 {
     /// Sets the value transferred upon the execution of the call.
-    #[inline]
     pub fn transferred_value(
         self,
         transferred_value: E::Balance,
@@ -351,7 +342,6 @@ where
     /// Either use `.returns::<()>` to signal that the call does not return a value
     /// or use `.returns::<ReturnType<T>>` to signal that the call returns a value of
     /// type `T`.
-    #[inline]
     pub fn returns<R>(
         self,
     ) -> CallBuilder<E, Callee, GasLimit, TransferredValue, Args, Set<R>>

--- a/crates/env/src/call/common.rs
+++ b/crates/env/src/call/common.rs
@@ -23,7 +23,6 @@ use core::marker::PhantomData;
 pub struct ReturnType<T>(PhantomData<fn() -> T>);
 
 impl<T> Clone for ReturnType<T> {
-    #[inline]
     fn clone(&self) -> Self {
         Self(Default::default())
     }
@@ -32,7 +31,6 @@ impl<T> Clone for ReturnType<T> {
 impl<T> Copy for ReturnType<T> {}
 
 impl<T> Default for ReturnType<T> {
-    #[inline]
     fn default() -> Self {
         Self(Default::default())
     }
@@ -44,7 +42,6 @@ pub struct Set<T>(pub T);
 
 impl<T> Set<T> {
     /// Returns the set value.
-    #[inline]
     pub fn value(self) -> T {
         self.0
     }
@@ -55,7 +52,6 @@ impl<T> Set<T> {
 pub struct Unset<T>(PhantomData<fn() -> T>);
 
 impl<T> Clone for Unset<T> {
-    #[inline]
     fn clone(&self) -> Self {
         Self(Default::default())
     }
@@ -64,7 +60,6 @@ impl<T> Clone for Unset<T> {
 impl<T> Copy for Unset<T> {}
 
 impl<T> Default for Unset<T> {
-    #[inline]
     fn default() -> Self {
         Self(Default::default())
     }
@@ -87,7 +82,6 @@ pub trait Unwrap {
 impl<T> Unwrap for Unset<T> {
     type Output = T;
 
-    #[inline]
     fn unwrap_or_else<F>(self, f: F) -> Self::Output
     where
         F: FnOnce() -> Self::Output,
@@ -99,7 +93,6 @@ impl<T> Unwrap for Unset<T> {
 impl<T> Unwrap for Set<T> {
     type Output = T;
 
-    #[inline]
     fn unwrap_or_else<F>(self, _: F) -> Self::Output
     where
         F: FnOnce() -> Self::Output,

--- a/crates/env/src/call/create_builder.rs
+++ b/crates/env/src/call/create_builder.rs
@@ -75,25 +75,21 @@ where
     E: Environment,
 {
     /// The code hash of the contract.
-    #[inline]
     pub(crate) fn code_hash(&self) -> &E::Hash {
         &self.code_hash
     }
 
     /// The gas limit for the contract instantiation.
-    #[inline]
     pub(crate) fn gas_limit(&self) -> u64 {
         self.gas_limit
     }
 
     /// The endowment for the instantiated contract.
-    #[inline]
     pub(crate) fn endowment(&self) -> &E::Balance {
         &self.endowment
     }
 
     /// The raw encoded input data.
-    #[inline]
     pub(crate) fn exec_input(&self) -> &ExecutionInput<Args> {
         &self.exec_input
     }
@@ -105,7 +101,6 @@ where
     Salt: AsRef<[u8]>,
 {
     /// The salt for determining the hash for the contract account ID.
-    #[inline]
     pub(crate) fn salt_bytes(&self) -> &Salt {
         &self.salt_bytes
     }
@@ -119,7 +114,6 @@ where
     R: FromAccountId<E>,
 {
     /// Instantiates the contract and returns its account ID back to the caller.
-    #[inline]
     pub fn instantiate(&self) -> Result<R, crate::Error> {
         crate::instantiate_contract(self).map(FromAccountId::from_account_id)
     }
@@ -218,7 +212,6 @@ where
     E: Environment,
 {
     /// Sets the used code hash for the contract instantiation.
-    #[inline]
     pub fn code_hash(
         self,
         code_hash: E::Hash,
@@ -241,7 +234,6 @@ where
     E: Environment,
 {
     /// Sets the maximum allowed gas costs for the contract instantiation.
-    #[inline]
     pub fn gas_limit(
         self,
         gas_limit: u64,
@@ -264,7 +256,6 @@ where
     E: Environment,
 {
     /// Sets the value transferred upon the execution of the call.
-    #[inline]
     pub fn endowment(
         self,
         endowment: E::Balance,
@@ -295,7 +286,6 @@ where
     E: Environment,
 {
     /// Sets the value transferred upon the execution of the call.
-    #[inline]
     pub fn exec_input<Args>(
         self,
         exec_input: ExecutionInput<Args>,
@@ -319,7 +309,6 @@ where
     E: Environment,
 {
     /// Sets the value transferred upon the execution of the call.
-    #[inline]
     pub fn salt_bytes<Salt>(
         self,
         salt: Salt,
@@ -354,7 +343,6 @@ where
     GasLimit: Unwrap<Output = u64>,
 {
     /// Sets the value transferred upon the execution of the call.
-    #[inline]
     pub fn params(self) -> CreateParams<E, Args, Salt, R> {
         CreateParams {
             code_hash: self.code_hash.value(),
@@ -385,7 +373,6 @@ where
     R: FromAccountId<E>,
 {
     /// Instantiates the contract using the given instantiation parameters.
-    #[inline]
     pub fn instantiate(self) -> Result<R, Error> {
         self.params().instantiate()
     }

--- a/crates/env/src/call/execution_input.rs
+++ b/crates/env/src/call/execution_input.rs
@@ -25,7 +25,6 @@ pub struct ExecutionInput<Args> {
 
 impl ExecutionInput<EmptyArgumentList> {
     /// Creates a new execution input with the given selector.
-    #[inline]
     pub fn new(selector: Selector) -> Self {
         Self {
             selector,
@@ -34,7 +33,6 @@ impl ExecutionInput<EmptyArgumentList> {
     }
 
     /// Pushes an argument to the execution input.
-    #[inline]
     pub fn push_arg<T>(
         self,
         arg: T,
@@ -51,7 +49,6 @@ impl ExecutionInput<EmptyArgumentList> {
 
 impl<'a, Head, Rest> ExecutionInput<ArgumentList<Argument<Head>, Rest>> {
     /// Pushes an argument to the execution input.
-    #[inline]
     pub fn push_arg<T>(self, arg: T) -> ExecutionInput<ArgsList<T, ArgsList<Head, Rest>>>
     where
         T: scale::Encode,
@@ -92,7 +89,6 @@ pub struct Argument<T> {
 
 impl<T> Argument<T> {
     /// Creates a new argument.
-    #[inline]
     fn new(arg: T) -> Self {
         Self { arg }
     }
@@ -107,7 +103,6 @@ pub type EmptyArgumentList = ArgumentList<ArgumentListEnd, ArgumentListEnd>;
 
 impl EmptyArgumentList {
     /// Creates a new empty argument list.
-    #[inline]
     pub fn empty() -> EmptyArgumentList {
         ArgumentList {
             head: ArgumentListEnd,
@@ -116,7 +111,6 @@ impl EmptyArgumentList {
     }
 
     /// Pushes the first argument to the empty argument list.
-    #[inline]
     pub fn push_arg<T>(self, arg: T) -> ArgumentList<Argument<T>, Self>
     where
         T: scale::Encode,
@@ -130,7 +124,6 @@ impl EmptyArgumentList {
 
 impl<Head, Rest> ArgumentList<Argument<Head>, Rest> {
     /// Pushes another argument to the argument list.
-    #[inline]
     pub fn push_arg<T>(self, arg: T) -> ArgumentList<Argument<T>, Self>
     where
         T: scale::Encode,
@@ -146,24 +139,20 @@ impl<T> scale::Encode for Argument<T>
 where
     T: scale::Encode,
 {
-    #[inline]
     fn size_hint(&self) -> usize {
         <T as scale::Encode>::size_hint(&self.arg)
     }
 
-    #[inline]
     fn encode_to<O: scale::Output + ?Sized>(&self, output: &mut O) {
         <T as scale::Encode>::encode_to(&self.arg, output)
     }
 }
 
 impl scale::Encode for EmptyArgumentList {
-    #[inline]
     fn size_hint(&self) -> usize {
         0
     }
 
-    #[inline]
     fn encode_to<O: scale::Output + ?Sized>(&self, _output: &mut O) {}
 }
 
@@ -172,12 +161,10 @@ where
     Head: scale::Encode,
     Rest: scale::Encode,
 {
-    #[inline]
     fn size_hint(&self) -> usize {
         scale::Encode::size_hint(&self.head) + scale::Encode::size_hint(&self.rest)
     }
 
-    #[inline]
     fn encode_to<O: scale::Output + ?Sized>(&self, output: &mut O) {
         // We reverse the order of encoding because we build up the list of
         // arguments in reverse order, too. This way we encode the arguments
@@ -192,12 +179,10 @@ impl<Args> scale::Encode for ExecutionInput<Args>
 where
     Args: scale::Encode,
 {
-    #[inline]
     fn size_hint(&self) -> usize {
         scale::Encode::size_hint(&self.selector) + scale::Encode::size_hint(&self.args)
     }
 
-    #[inline]
     fn encode_to<O: scale::Output + ?Sized>(&self, output: &mut O) {
         scale::Encode::encode_to(&self.selector, output);
         scale::Encode::encode_to(&self.args, output);

--- a/crates/env/src/chain_extension.rs
+++ b/crates/env/src/chain_extension.rs
@@ -83,7 +83,6 @@ pub struct ChainExtensionMethod<I, O, ErrorCode> {
 
 impl ChainExtensionMethod<(), (), ()> {
     /// Creates a new chain extension method instance.
-    #[inline]
     pub fn build(func_id: u32) -> Self {
         Self {
             func_id,
@@ -100,7 +99,6 @@ impl<O, ErrorCode> ChainExtensionMethod<(), O, ErrorCode> {
     /// `I` represents the input type of the chain extension method.
     /// All tuple types that may act as input parameters for the chain extension method are valid.
     /// Examples include `()`, `i32`, `(u8, [u8; 5], i32)`, etc.
-    #[inline]
     pub fn input<I>(self) -> ChainExtensionMethod<I, O, ErrorCode>
     where
         I: scale::Encode,
@@ -118,7 +116,6 @@ impl<I, ErrorCode> ChainExtensionMethod<I, (), ErrorCode> {
     /// # Note
     ///
     /// This indicates that the chain extension method return value might represent a failure.
-    #[inline]
     pub fn output_result<T, E>(self) -> ChainExtensionMethod<I, Result<T, E>, ErrorCode>
     where
         Result<T, E>: scale::Decode,
@@ -138,7 +135,6 @@ impl<I, ErrorCode> ChainExtensionMethod<I, (), ErrorCode> {
     /// When using the `#[ink::chain_extension]` procedural macro to define
     /// this chain extension method the above constraint is enforced at
     /// compile time.
-    #[inline]
     pub fn output<O>(self) -> ChainExtensionMethod<I, state::NoResult<O>, ErrorCode>
     where
         O: scale::Decode,
@@ -160,7 +156,6 @@ impl<I, O> ChainExtensionMethod<I, O, ()> {
     /// code that represents failure.
     ///
     /// The output of the chain extension method call is always decoded and returned in this case.
-    #[inline]
     pub fn ignore_error_code(self) -> ChainExtensionMethod<I, O, state::IgnoreErrorCode> {
         ChainExtensionMethod {
             func_id: self.func_id,
@@ -174,7 +169,6 @@ impl<I, O> ChainExtensionMethod<I, O, ()> {
     ///
     /// This will handle the returned status code and only loads and decodes the value
     /// returned as the output of the chain extension method call in case of success.
-    #[inline]
     pub fn handle_error_code<ErrorCode>(
         self,
     ) -> ChainExtensionMethod<I, O, state::HandleErrorCode<ErrorCode>>
@@ -261,7 +255,6 @@ where
     /// #     fn from_status_code(status_code: u32) -> Result<(), Self> { Ok(()) }
     /// # }
     /// ```
-    #[inline]
     pub fn call(self, input: &I) -> Result<T, E> {
         <EnvInstance as OnInstance>::on_instance(|instance| {
             EnvBackend::call_chain_extension::<I, T, E, ErrorCode, _, _>(
@@ -315,7 +308,6 @@ where
     /// #     fn from(_error: scale::Error) -> Self { Self {} }
     /// # }
     /// ```
-    #[inline]
     pub fn call(self, input: &I) -> Result<T, E> {
         <EnvInstance as OnInstance>::on_instance(|instance| {
             EnvBackend::call_chain_extension::<I, T, E, E, _, _>(
@@ -372,7 +364,6 @@ where
     /// #     fn from_status_code(status_code: u32) -> Result<(), Self> { Ok(()) }
     /// # }
     /// ```
-    #[inline]
     pub fn call(self, input: &I) -> Result<O, ErrorCode> {
         <EnvInstance as OnInstance>::on_instance(|instance| {
             EnvBackend::call_chain_extension::<I, O, ErrorCode, ErrorCode, _, _>(
@@ -421,7 +412,6 @@ where
     ///     .ignore_error_code()
     ///     .call(&(true, 42));
     /// ```
-    #[inline]
     pub fn call(self, input: &I) -> O {
         <EnvInstance as OnInstance>::on_instance(|instance| {
             EnvBackend::call_chain_extension::<I, O, (), (), _, _>(

--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -39,7 +39,6 @@ macro_rules! define_error_codes {
         }
 
         impl From<ReturnCode> for Result {
-            #[inline]
             fn from(return_code: ReturnCode) -> Self {
                 match return_code.0 {
                     0 => Ok(()),

--- a/crates/env/src/topics.rs
+++ b/crates/env/src/topics.rs
@@ -223,12 +223,10 @@ impl<X> scale::Encode for PrefixedValue<'_, '_, X>
 where
     X: scale::Encode,
 {
-    #[inline]
     fn size_hint(&self) -> usize {
         self.prefix.size_hint() + self.value.size_hint()
     }
 
-    #[inline]
     fn encode_to<T: scale::Output + ?Sized>(&self, dest: &mut T) {
         self.prefix.encode_to(dest);
         self.value.encode_to(dest);

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -58,7 +58,6 @@ pub trait FromLittleEndian {
 impl FromLittleEndian for u8 {
     type Bytes = [u8; 1];
 
-    #[inline]
     fn from_le_bytes(bytes: Self::Bytes) -> Self {
         Self::from_le_bytes(bytes)
     }
@@ -67,7 +66,6 @@ impl FromLittleEndian for u8 {
 impl FromLittleEndian for u16 {
     type Bytes = [u8; 2];
 
-    #[inline]
     fn from_le_bytes(bytes: Self::Bytes) -> Self {
         Self::from_le_bytes(bytes)
     }
@@ -76,7 +74,6 @@ impl FromLittleEndian for u16 {
 impl FromLittleEndian for u32 {
     type Bytes = [u8; 4];
 
-    #[inline]
     fn from_le_bytes(bytes: Self::Bytes) -> Self {
         Self::from_le_bytes(bytes)
     }
@@ -85,7 +82,6 @@ impl FromLittleEndian for u32 {
 impl FromLittleEndian for u64 {
     type Bytes = [u8; 8];
 
-    #[inline]
     fn from_le_bytes(bytes: Self::Bytes) -> Self {
         Self::from_le_bytes(bytes)
     }
@@ -94,7 +90,6 @@ impl FromLittleEndian for u64 {
 impl FromLittleEndian for u128 {
     type Bytes = [u8; 16];
 
-    #[inline]
     fn from_le_bytes(bytes: Self::Bytes) -> Self {
         Self::from_le_bytes(bytes)
     }
@@ -228,28 +223,24 @@ pub type RentFraction = Perbill;
 pub struct AccountId([u8; 32]);
 
 impl AsRef<[u8; 32]> for AccountId {
-    #[inline]
     fn as_ref(&self) -> &[u8; 32] {
         &self.0
     }
 }
 
 impl AsMut<[u8; 32]> for AccountId {
-    #[inline]
     fn as_mut(&mut self) -> &mut [u8; 32] {
         &mut self.0
     }
 }
 
 impl AsRef<[u8]> for AccountId {
-    #[inline]
     fn as_ref(&self) -> &[u8] {
         &self.0[..]
     }
 }
 
 impl AsMut<[u8]> for AccountId {
-    #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0[..]
     }

--- a/crates/lang/codegen/src/generator/as_dependency/call_builder.rs
+++ b/crates/lang/codegen/src/generator/as_dependency/call_builder.rs
@@ -122,14 +122,12 @@ impl CallBuilder<'_> {
         let cb_ident = Self::call_builder_ident();
         quote_spanned!(span=>
             impl ::ink_env::call::FromAccountId<Environment> for #cb_ident {
-                #[inline]
                 fn from_account_id(account_id: AccountId) -> Self {
                     Self { account_id }
                 }
             }
 
             impl ::ink_lang::ToAccountId<Environment> for #cb_ident {
-                #[inline]
                 fn to_account_id(&self) -> AccountId {
                     <AccountId as ::core::clone::Clone>::clone(&self.account_id)
                 }
@@ -188,7 +186,6 @@ impl CallBuilder<'_> {
             impl ::ink_lang::codegen::TraitCallForwarderFor<#trait_info> for #cb_ident {
                 type Forwarder = <<Self as #trait_path>::__ink_TraitInfo as ::ink_lang::codegen::TraitCallForwarder>::Forwarder;
 
-                #[inline]
                 fn forward(&self) -> &Self::Forwarder {
                     // SAFETY:
                     //
@@ -201,7 +198,6 @@ impl CallBuilder<'_> {
                     }
                 }
 
-                #[inline]
                 fn forward_mut(&mut self) -> &mut Self::Forwarder {
                     // SAFETY:
                     //
@@ -214,14 +210,12 @@ impl CallBuilder<'_> {
                     }
                 }
 
-                #[inline]
                 fn build(&self) -> &<Self::Forwarder as ::ink_lang::codegen::TraitCallBuilder>::Builder {
                     <_ as ::ink_lang::codegen::TraitCallBuilder>::call(
                         <Self as ::ink_lang::codegen::TraitCallForwarderFor<#trait_info>>::forward(self)
                     )
                 }
 
-                #[inline]
                 fn build_mut(&mut self)
                     -> &mut <Self::Forwarder as ::ink_lang::codegen::TraitCallBuilder>::Builder
                 {
@@ -287,7 +281,6 @@ impl CallBuilder<'_> {
                 as ::ink_lang::codegen::TraitCallBuilder>::Builder
                 as #trait_path>::#output_ident;
 
-            #[inline]
             #( #attrs )*
             fn #message_ident(
                 & #mut_token self
@@ -382,7 +375,6 @@ impl CallBuilder<'_> {
         quote_spanned!(span=>
             #( #attrs )*
             #[allow(clippy::type_complexity)]
-            #[inline]
             pub fn #message_ident(
                 & #mut_tok self
                 #( , #input_bindings : #input_types )*

--- a/crates/lang/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/lang/codegen/src/generator/as_dependency/contract_ref.rs
@@ -128,7 +128,6 @@ impl ContractRef<'_> {
         let ref_ident = self.generate_contract_ref_ident();
         quote_spanned!(span=>
             impl ::ink_env::call::FromAccountId<Environment> for #ref_ident {
-                #[inline]
                 fn from_account_id(account_id: AccountId) -> Self {
                     Self { inner: <<#storage_ident
                         as ::ink_lang::codegen::ContractCallBuilder>::Type
@@ -138,7 +137,6 @@ impl ContractRef<'_> {
             }
 
             impl ::ink_lang::ToAccountId<Environment> for #ref_ident {
-                #[inline]
                 fn to_account_id(&self) -> AccountId {
                     <<#storage_ident as ::ink_lang::codegen::ContractCallBuilder>::Type
                         as ::ink_lang::ToAccountId<Environment>>::to_account_id(&self.inner)
@@ -160,12 +158,10 @@ impl ContractRef<'_> {
                 impl ::ink_lang::codegen::TraitCallBuilder for #ref_ident {
                     type Builder = <#storage_ident as ::ink_lang::codegen::ContractCallBuilder>::Type;
 
-                    #[inline]
                     fn call(&self) -> &Self::Builder {
                         &self.inner
                     }
 
-                    #[inline]
                     fn call_mut(&mut self) -> &mut Self::Builder {
                         &mut self.inner
                     }
@@ -260,7 +256,6 @@ impl ContractRef<'_> {
             type #output_ident =
                 <<Self::__ink_TraitInfo as ::ink_lang::codegen::TraitCallForwarder>::Forwarder as #trait_path>::#output_ident;
 
-            #[inline]
             fn #message_ident(
                 & #mut_token self
                 #( , #input_bindings : #input_types )*
@@ -345,7 +340,6 @@ impl ContractRef<'_> {
         let output_type = message.output().map(|ty| quote! { -> #ty });
         quote_spanned!(span=>
             #( #attrs )*
-            #[inline]
             pub fn #message_ident(
                 & #mut_token self
                 #( , #input_bindings : #input_types )*
@@ -383,7 +377,6 @@ impl ContractRef<'_> {
         let arg_list = generator::generate_argument_list(input_types.iter().cloned());
         quote_spanned!(span =>
             #( #attrs )*
-            #[inline]
             #[allow(clippy::type_complexity)]
             pub fn #constructor_ident(
                 #( #input_bindings : #input_types ),*

--- a/crates/lang/codegen/src/generator/chain_extension.rs
+++ b/crates/lang/codegen/src/generator/chain_extension.rs
@@ -122,7 +122,6 @@ impl ChainExtension<'_> {
 
         quote_spanned!(span=>
             #( #attrs )*
-            #[inline]
             pub fn #ident(self, #inputs) -> #returned_type
             where
                 #where_output_is_result

--- a/crates/lang/codegen/src/generator/trait_def/call_builder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_builder.rs
@@ -175,7 +175,6 @@ impl CallBuilder<'_> {
                 const FOOTPRINT: ::core::primitive::u64 = 1;
                 const REQUIRES_DEEP_CLEAN_UP: ::core::primitive::bool = false;
 
-                #[inline]
                 fn pull_spread(ptr: &mut ::ink_primitives::KeyPtr) -> Self {
                     Self {
                         account_id: <<E as ::ink_env::Environment>::AccountId
@@ -183,13 +182,11 @@ impl CallBuilder<'_> {
                     }
                 }
 
-                #[inline]
                 fn push_spread(&self, ptr: &mut ::ink_primitives::KeyPtr) {
                     <<E as ::ink_env::Environment>::AccountId
                         as ::ink_storage::traits::SpreadLayout>::push_spread(&self.account_id, ptr)
                 }
 
-                #[inline]
                 fn clear_spread(&self, ptr: &mut ::ink_primitives::KeyPtr) {
                     <<E as ::ink_env::Environment>::AccountId
                         as ::ink_storage::traits::SpreadLayout>::clear_spread(&self.account_id, ptr)
@@ -215,11 +212,8 @@ impl CallBuilder<'_> {
                 E: ::ink_env::Environment,
                 <E as ::ink_env::Environment>::AccountId: ::ink_storage::traits::PackedLayout,
             {
-                #[inline]
                 fn pull_packed(&mut self, _at: &::ink_primitives::Key) {}
-                #[inline]
                 fn push_packed(&self, _at: &::ink_primitives::Key) {}
-                #[inline]
                 fn clear_packed(&self, _at: &::ink_primitives::Key) {}
             }
         )
@@ -243,7 +237,6 @@ impl CallBuilder<'_> {
                 E: ::ink_env::Environment,
                 <E as ::ink_env::Environment>::AccountId: ::core::clone::Clone,
             {
-                #[inline]
                 fn clone(&self) -> Self {
                     Self {
                         account_id: ::core::clone::Clone::clone(&self.account_id),
@@ -281,7 +274,6 @@ impl CallBuilder<'_> {
             where
                 E: ::ink_env::Environment,
             {
-                #[inline]
                 fn from_account_id(account_id: <E as ::ink_env::Environment>::AccountId) -> Self {
                     Self { account_id }
                 }
@@ -291,7 +283,6 @@ impl CallBuilder<'_> {
             where
                 E: ::ink_env::Environment,
             {
-                #[inline]
                 fn to_account_id(&self) -> <E as ::ink_env::Environment>::AccountId {
                     <<E as ::ink_env::Environment>::AccountId as ::core::clone::Clone>::clone(&self.account_id)
                 }
@@ -381,7 +372,6 @@ impl CallBuilder<'_> {
             >;
 
             #( #attrs )*
-            #[inline]
             fn #message_ident(
                 & #mut_tok self
                 #( , #input_bindings : #input_types )*

--- a/crates/lang/codegen/src/generator/trait_def/call_forwarder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_forwarder.rs
@@ -171,7 +171,6 @@ impl CallForwarder<'_> {
                 const FOOTPRINT: ::core::primitive::u64 = 1;
                 const REQUIRES_DEEP_CLEAN_UP: ::core::primitive::bool = false;
 
-                #[inline]
                 fn pull_spread(ptr: &mut ::ink_primitives::KeyPtr) -> Self {
                     Self {
                         builder: <<Self as ::ink_lang::codegen::TraitCallBuilder>::Builder
@@ -179,13 +178,11 @@ impl CallForwarder<'_> {
                     }
                 }
 
-                #[inline]
                 fn push_spread(&self, ptr: &mut ::ink_primitives::KeyPtr) {
                     <<Self as ::ink_lang::codegen::TraitCallBuilder>::Builder
                         as ::ink_storage::traits::SpreadLayout>::push_spread(&self.builder, ptr)
                 }
 
-                #[inline]
                 fn clear_spread(&self, ptr: &mut ::ink_primitives::KeyPtr) {
                     <<Self as ::ink_lang::codegen::TraitCallBuilder>::Builder
                         as ::ink_storage::traits::SpreadLayout>::clear_spread(&self.builder, ptr)
@@ -210,11 +207,8 @@ impl CallForwarder<'_> {
                 E: ::ink_env::Environment,
                 <E as ::ink_env::Environment>::AccountId: ::ink_storage::traits::PackedLayout,
             {
-                #[inline]
                 fn pull_packed(&mut self, _at: &::ink_primitives::Key) {}
-                #[inline]
                 fn push_packed(&self, _at: &::ink_primitives::Key) {}
-                #[inline]
                 fn clear_packed(&self, _at: &::ink_primitives::Key) {}
             }
         )
@@ -237,7 +231,6 @@ impl CallForwarder<'_> {
                 E: ::ink_env::Environment,
                 <E as ::ink_env::Environment>::AccountId: ::core::clone::Clone,
             {
-                #[inline]
                 fn clone(&self) -> Self {
                     Self {
                         builder: <<Self as ::ink_lang::codegen::TraitCallBuilder>::Builder
@@ -275,7 +268,6 @@ impl CallForwarder<'_> {
             where
                 E: ::ink_env::Environment,
             {
-                #[inline]
                 fn from_account_id(account_id: <E as ::ink_env::Environment>::AccountId) -> Self {
                     Self { builder: <<Self as ::ink_lang::codegen::TraitCallBuilder>::Builder
                         as ::ink_env::call::FromAccountId<E>>::from_account_id(account_id) }
@@ -286,7 +278,6 @@ impl CallForwarder<'_> {
             where
                 E: ::ink_env::Environment,
             {
-                #[inline]
                 fn to_account_id(&self) -> <E as ::ink_env::Environment>::AccountId {
                     <<Self as ::ink_lang::codegen::TraitCallBuilder>::Builder
                         as ::ink_lang::ToAccountId<E>>::to_account_id(&self.builder)
@@ -317,12 +308,10 @@ impl CallForwarder<'_> {
             {
                 type Builder = #call_builder_ident<E>;
 
-                #[inline]
                 fn call(&self) -> &<Self as ::ink_lang::codegen::TraitCallBuilder>::Builder {
                     &self.builder
                 }
 
-                #[inline]
                 fn call_mut(&mut self) -> &mut <Self as ::ink_lang::codegen::TraitCallBuilder>::Builder {
                     &mut self.builder
                 }
@@ -409,7 +398,6 @@ impl CallForwarder<'_> {
             type #output_ident = #output_type;
 
             #( #attrs )*
-            #[inline]
             fn #message_ident(
                 & #mut_tok self
                 #( , #input_bindings : #input_types )*

--- a/crates/lang/src/codegen/dispatch/execution.rs
+++ b/crates/lang/src/codegen/dispatch/execution.rs
@@ -58,7 +58,6 @@ pub trait ContractRootKey {
 /// # Errors
 ///
 /// If the caller did send some amount of transferred value to the callee.
-#[inline]
 pub fn deny_payment<E>() -> Result<(), DispatchError>
 where
     E: Environment,
@@ -87,7 +86,6 @@ pub struct ExecuteConstructorConfig {
 ///
 /// The closure is supposed to already contain all the arguments that the real
 /// constructor message requires and forwards them.
-#[inline]
 pub fn execute_constructor<Contract, F, R>(
     config: ExecuteConstructorConfig,
     f: F,
@@ -139,7 +137,6 @@ where
 ///   If `R` is `()` then `Contract` is returned and if `R` is any type of
 ///   `Result<(), E>` then `Result<Contract, E>` is returned.
 ///   Other return types for `F` than the ones listed above are not allowed.
-#[inline]
 pub fn initialize_contract<Contract, F, R>(
     initializer: F,
 ) -> <R as InitializerReturnType<Contract>>::Wrapped
@@ -220,12 +217,10 @@ impl<C> ConstructorReturnType<C> for private::Seal<C> {
     type Error = Infallible;
     type ReturnValue = ();
 
-    #[inline]
     fn as_result(&self) -> Result<&C, &Self::Error> {
         Ok(&self.0)
     }
 
-    #[inline]
     fn return_value(&self) -> &Self::ReturnValue {
         &()
     }
@@ -236,12 +231,10 @@ impl<C, E> ConstructorReturnType<C> for private::Seal<Result<C, E>> {
     type Error = E;
     type ReturnValue = Result<C, E>;
 
-    #[inline]
     fn as_result(&self) -> Result<&C, &Self::Error> {
         self.0.as_ref()
     }
 
-    #[inline]
     fn return_value(&self) -> &Self::ReturnValue {
         &self.0
     }
@@ -262,7 +255,6 @@ pub trait InitializerReturnType<C>: private::Sealed {
 impl<C> InitializerReturnType<C> for () {
     type Wrapped = C;
 
-    #[inline]
     fn into_wrapped(self, wrapped: C) -> C {
         wrapped
     }
@@ -270,7 +262,6 @@ impl<C> InitializerReturnType<C> for () {
 impl<C, E> InitializerReturnType<C> for Result<(), E> {
     type Wrapped = Result<C, E>;
 
-    #[inline]
     fn into_wrapped(self, wrapped: C) -> Self::Wrapped {
         self.map(|_| wrapped)
     }
@@ -310,7 +301,6 @@ pub struct ExecuteMessageConfig {
 /// This work around that splits executing an ink! message into initiate
 /// and finalize phases was needed due to the fact that `is_result_type`
 /// and `is_result_err` macros do not work in generic contexts.
-#[inline]
 pub fn initiate_message<Contract>(
     config: ExecuteMessageConfig,
 ) -> Result<Contract, DispatchError>
@@ -343,7 +333,6 @@ where
 /// This work around that splits executing an ink! message into initiate
 /// and finalize phases was needed due to the fact that `is_result_type`
 /// and `is_result_err` macros do not work in generic contexts.
-#[inline]
 pub fn finalize_message<Contract, R>(
     success: bool,
     contract: &Contract,
@@ -361,7 +350,6 @@ where
     }
 }
 
-#[inline]
 fn finalize_infallible_message<Contract, R>(
     contract: &Contract,
     config: ExecuteMessageConfig,
@@ -385,7 +373,6 @@ where
     Ok(())
 }
 
-#[inline]
 fn finalize_fallible_message<R>(result: &R) -> !
 where
     R: scale::Encode + 'static,

--- a/crates/lang/src/env_access.rs
+++ b/crates/lang/src/env_access.rs
@@ -44,7 +44,6 @@ pub struct EnvAccess<'a, T> {
 }
 
 impl<'a, T> Default for EnvAccess<'a, T> {
-    #[inline]
     fn default() -> Self {
         Self {
             marker: Default::default(),

--- a/crates/lang/src/reflect/dispatch.rs
+++ b/crates/lang/src/reflect/dispatch.rs
@@ -538,7 +538,6 @@ impl Display for DispatchError {
 
 impl DispatchError {
     /// Returns a string representation of the error.
-    #[inline]
     fn as_str(&self) -> &'static str {
         match self {
             Self::InvalidSelector => "unable to decode selector",
@@ -551,7 +550,6 @@ impl DispatchError {
 }
 
 impl From<DispatchError> for scale::Error {
-    #[inline]
     fn from(error: DispatchError) -> Self {
         Self::from(error.as_str())
     }

--- a/crates/lang/src/result_info.rs
+++ b/crates/lang/src/result_info.rs
@@ -44,7 +44,6 @@ macro_rules! is_result_type {
 pub struct IsResultErr<'lt, T>(pub &'lt T);
 
 impl<T, E> IsResultErr<'_, ::core::result::Result<T, E>> {
-    #[inline]
     // We need to allow for dead code at this point because
     // the Rust compiler thinks this function is unused even
     // though it acts as the specialized case for detection.
@@ -55,7 +54,6 @@ impl<T, E> IsResultErr<'_, ::core::result::Result<T, E>> {
 }
 
 pub trait IsResultErrFallback {
-    #[inline]
     fn value(&self) -> bool {
         false
     }

--- a/crates/primitives/src/key.rs
+++ b/crates/primitives/src/key.rs
@@ -53,28 +53,24 @@ impl Key {
     ///
     /// This constructor only exists since it is not yet possible to define
     /// the `From` trait implementation as const.
-    #[inline]
     pub const fn new(bytes: [u8; 32]) -> Self {
         Self(bytes)
     }
 }
 
 impl From<[u8; 32]> for Key {
-    #[inline]
     fn from(bytes: [u8; 32]) -> Self {
         Self::new(bytes)
     }
 }
 
 impl AsRef<[u8; 32]> for Key {
-    #[inline]
     fn as_ref(&self) -> &[u8; 32] {
         &self.0
     }
 }
 
 impl AsMut<[u8; 32]> for Key {
-    #[inline]
     fn as_mut(&mut self) -> &mut [u8; 32] {
         &mut self.0
     }
@@ -144,12 +140,10 @@ impl Key {
 }
 
 impl scale::Encode for Key {
-    #[inline]
     fn size_hint(&self) -> usize {
         32
     }
 
-    #[inline]
     fn encode_to<O>(&self, output: &mut O)
     where
         O: scale::Output + ?Sized,
@@ -157,7 +151,6 @@ impl scale::Encode for Key {
         output.write(self.as_ref());
     }
 
-    #[inline]
     fn using_encoded<R, F>(&self, f: F) -> R
     where
         F: FnOnce(&[u8]) -> R,
@@ -165,7 +158,6 @@ impl scale::Encode for Key {
         f(self.as_ref())
     }
 
-    #[inline]
     fn encoded_size(&self) -> usize {
         self.size_hint()
     }
@@ -174,7 +166,6 @@ impl scale::Encode for Key {
 impl scale::EncodeLike<[u8; 32]> for Key {}
 
 impl scale::Decode for Key {
-    #[inline]
     fn decode<I>(input: &mut I) -> Result<Self, scale::Error>
     where
         I: scale::Input,
@@ -183,7 +174,6 @@ impl scale::Decode for Key {
         Ok(Self::from(bytes))
     }
 
-    #[inline]
     fn encoded_fixed_size() -> Option<usize> {
         Some(32)
     }
@@ -315,7 +305,6 @@ impl Key {
     /// # Note
     ///
     /// This will overwrite the contents of the `result` key.
-    #[inline]
     pub fn add_assign_using<T>(&self, rhs: T, result: &mut Key)
     where
         T: Into<u64>,
@@ -332,7 +321,6 @@ impl Key {
 }
 
 impl AddAssign<u64> for Key {
-    #[inline]
     fn add_assign(&mut self, rhs: u64) {
         cfg_if! {
             if #[cfg(target_endian = "little")] {
@@ -345,7 +333,6 @@ impl AddAssign<u64> for Key {
 }
 
 impl AddAssign<&u64> for Key {
-    #[inline]
     fn add_assign(&mut self, rhs: &u64) {
         <Self as AddAssign<u64>>::add_assign(self, *rhs)
     }

--- a/crates/primitives/src/key_ptr.rs
+++ b/crates/primitives/src/key_ptr.rs
@@ -27,7 +27,6 @@ pub struct KeyPtr {
 }
 
 impl From<Key> for KeyPtr {
-    #[inline]
     fn from(key: Key) -> Self {
         Self { key, last_shift: 0 }
     }
@@ -35,7 +34,6 @@ impl From<Key> for KeyPtr {
 
 impl KeyPtr {
     /// Advances the key pointer by the given amount and returns the old value.
-    #[inline]
     pub fn advance_by(&mut self, new_shift: u64) -> &Key {
         let old_shift = core::mem::replace(&mut self.last_shift, new_shift);
         self.key += old_shift;

--- a/crates/storage/src/collections/binary_heap/children_vec.rs
+++ b/crates/storage/src/collections/binary_heap/children_vec.rs
@@ -91,7 +91,6 @@ where
     T: PackedLayout + Ord,
 {
     /// Creates a new empty storage heap.
-    #[inline]
     pub fn new() -> Self {
         Self {
             len: Lazy::new(0),
@@ -100,7 +99,6 @@ where
     }
 
     /// Returns the number of elements in the heap, also referred to as its length.
-    #[inline]
     pub fn len(&self) -> u32 {
         *self.len
     }
@@ -113,7 +111,6 @@ where
     }
 
     /// Returns `true` if the heap contains no elements.
-    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/crates/storage/src/collections/binary_heap/reverse.rs
+++ b/crates/storage/src/collections/binary_heap/reverse.rs
@@ -88,22 +88,18 @@ impl<T> scale::Encode for Reverse<T>
 where
     T: PackedLayout + Ord + scale::Encode,
 {
-    #[inline]
     fn size_hint(&self) -> usize {
         <T as scale::Encode>::size_hint(self.value())
     }
 
-    #[inline]
     fn encode_to<O: scale::Output + ?Sized>(&self, dest: &mut O) {
         <T as scale::Encode>::encode_to(self.value(), dest)
     }
 
-    #[inline]
     fn encode(&self) -> Vec<u8> {
         <T as scale::Encode>::encode(self.value())
     }
 
-    #[inline]
     fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
         <T as scale::Encode>::using_encoded(self.value(), f)
     }

--- a/crates/storage/src/collections/smallvec/mod.rs
+++ b/crates/storage/src/collections/smallvec/mod.rs
@@ -112,19 +112,16 @@ where
     }
 
     /// Returns the capacity of the small vector.
-    #[inline]
     pub fn capacity(&self) -> u32 {
         self.elems.capacity()
     }
 
     /// Returns the number of elements in the vector, also referred to as its length.
-    #[inline]
     pub fn len(&self) -> u32 {
         *self.len
     }
 
     /// Returns `true` if the vector contains no elements.
-    #[inline]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/crates/storage/src/collections/stash/storage.rs
+++ b/crates/storage/src/collections/stash/storage.rs
@@ -98,16 +98,12 @@ impl SpreadAllocate for Header {
 }
 
 impl PackedLayout for Header {
-    #[inline]
     fn pull_packed(&mut self, _at: &Key) {}
-    #[inline]
     fn push_packed(&self, _at: &Key) {}
-    #[inline]
     fn clear_packed(&self, _at: &Key) {}
 }
 
 impl PackedAllocate for Header {
-    #[inline]
     fn allocate_packed(&mut self, _at: &Key) {}
 }
 

--- a/crates/storage/src/collections/vec/mod.rs
+++ b/crates/storage/src/collections/vec/mod.rs
@@ -233,7 +233,6 @@ where
     /// let r = s.binary_search(&1);
     /// assert!(match r { Ok(1..=4) => true, _ => false, });
     /// ```
-    #[inline]
     pub fn binary_search(&self, x: &T) -> Result<u32, u32>
     where
         T: Ord,
@@ -285,7 +284,6 @@ where
     // The binary_search implementation is ported from
     // https://github.com/rust-lang/rust/blob/c5e344f7747dbd7e7d4b209e3c480deb5979a56f/library/core/src/slice/mod.rs#L2191
     // and attempts to remain as close to the source as possible.
-    #[inline]
     pub fn binary_search_by<'a, F>(&'a self, mut f: F) -> Result<u32, u32>
     where
         F: FnMut(&'a T) -> core::cmp::Ordering,
@@ -365,7 +363,6 @@ where
     /// let r = s.binary_search_by_key(&1, |&(a, b)| b);
     /// assert!(match r { Ok(1..=4) => true, _ => false, });
     /// ```
-    #[inline]
     pub fn binary_search_by_key<'a, B, F>(&'a self, b: &B, mut f: F) -> Result<u32, u32>
     where
         F: FnMut(&'a T) -> B,
@@ -490,7 +487,6 @@ where
     /// Won't return the old element back to the caller.
     /// Prefer this operation over other method of overriding an element
     /// in the storage vector since this is more efficient.
-    #[inline]
     pub fn set(&mut self, index: u32, new_value: T) -> Result<(), IndexOutOfBounds> {
         if self.within_bounds(index).is_none() {
             return Err(IndexOutOfBounds)

--- a/crates/storage/src/lazy/cache_cell.rs
+++ b/crates/storage/src/lazy/cache_cell.rs
@@ -31,7 +31,6 @@ pub struct CacheCell<T: ?Sized> {
 
 impl<T> CacheCell<T> {
     /// Creates a new cache cell from the given value.
-    #[inline]
     pub fn new(value: T) -> Self {
         Self {
             inner: UnsafeCell::new(value),
@@ -55,7 +54,6 @@ where
 }
 
 impl<T> From<T> for CacheCell<T> {
-    #[inline]
     fn from(value: T) -> Self {
         Self::new(value)
     }
@@ -65,7 +63,6 @@ impl<T> Default for CacheCell<T>
 where
     T: Default,
 {
-    #[inline]
     fn default() -> Self {
         Self::new(<T as Default>::default())
     }
@@ -76,7 +73,6 @@ where
     T: ?Sized,
 {
     /// Returns a shared reference to the inner value.
-    #[inline]
     pub fn as_inner(&self) -> &T {
         // SAFETY: This is safe since we are returning a shared reference back
         //         to the caller while this method itself accesses `self` as
@@ -85,7 +81,6 @@ where
     }
 
     /// Returns an exclusive reference to the inner value.
-    #[inline]
     pub fn as_inner_mut(&mut self) -> &mut T {
         // SAFETY: This is safe since we are returning the exclusive reference
         //         of the inner value through the `get_mut` API which itself
@@ -95,7 +90,6 @@ where
     }
 
     /// Returns a mutable pointer to the inner value.
-    #[inline]
     pub fn get_ptr(&self) -> NonNull<T> {
         // SAFETY: The inner `T` of the internal `UnsafeCell` exists and thus
         //         the pointer that we get returned to it via `UnsafeCell::get`

--- a/crates/storage/src/lazy/entry.rs
+++ b/crates/storage/src/lazy/entry.rs
@@ -102,19 +102,16 @@ where
 {
     const FOOTPRINT: u64 = <T as SpreadLayout>::FOOTPRINT;
 
-    #[inline]
     fn pull_spread(ptr: &mut KeyPtr) -> Self {
         let root_key = ExtKeyPtr::next_for::<Self>(ptr);
         Self::pull_spread_root(root_key)
     }
 
-    #[inline]
     fn push_spread(&self, ptr: &mut KeyPtr) {
         let root_key = ExtKeyPtr::next_for::<Self>(ptr);
         self.push_spread_root(root_key)
     }
 
-    #[inline]
     fn clear_spread(&self, ptr: &mut KeyPtr) {
         let root_key = ExtKeyPtr::next_for::<Self>(ptr);
         self.clear_spread_root(root_key)
@@ -125,7 +122,6 @@ impl<T> SpreadAllocate for StorageEntry<T>
 where
     T: SpreadLayout,
 {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         let root_key = ExtKeyPtr::next_for::<Self>(ptr);
         Self::pull_spread_root(root_key)
@@ -136,22 +132,18 @@ impl<T> scale::Encode for StorageEntry<T>
 where
     T: scale::Encode,
 {
-    #[inline]
     fn size_hint(&self) -> usize {
         <Option<T> as scale::Encode>::size_hint(&self.value)
     }
 
-    #[inline]
     fn encode_to<O: scale::Output + ?Sized>(&self, dest: &mut O) {
         <Option<T> as scale::Encode>::encode_to(&self.value, dest)
     }
 
-    #[inline]
     fn encode(&self) -> Vec<u8> {
         <Option<T> as scale::Encode>::encode(&self.value)
     }
 
-    #[inline]
     fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
         <Option<T> as scale::Encode>::using_encoded(&self.value, f)
     }
@@ -173,17 +165,14 @@ impl<T> PackedLayout for StorageEntry<T>
 where
     T: PackedLayout,
 {
-    #[inline]
     fn pull_packed(&mut self, at: &Key) {
         PackedLayout::pull_packed(&mut self.value, at)
     }
 
-    #[inline]
     fn push_packed(&self, at: &Key) {
         PackedLayout::push_packed(&self.value, at)
     }
 
-    #[inline]
     fn clear_packed(&self, at: &Key) {
         PackedLayout::clear_packed(&self.value, at)
     }
@@ -193,7 +182,6 @@ impl<T> PackedAllocate for StorageEntry<T>
 where
     T: PackedAllocate,
 {
-    #[inline]
     fn allocate_packed(&mut self, at: &Key) {
         PackedAllocate::allocate_packed(&mut self.value, at)
     }

--- a/crates/storage/src/lazy/lazy_array.rs
+++ b/crates/storage/src/lazy/lazy_array.rs
@@ -229,7 +229,6 @@ impl<T, const N: usize> Default for EntryArray<T, N> {
 
 impl<T, const N: usize> EntryArray<T, N> {
     /// Returns the constant capacity of the lazy array.
-    #[inline]
     pub fn capacity() -> u32 {
         array_capacity::<T, N>()
     }
@@ -340,7 +339,6 @@ impl<T, const N: usize> LazyArray<T, N> {
     }
 
     /// Returns the constant capacity of the lazy array.
-    #[inline]
     pub fn capacity(&self) -> u32 {
         array_capacity::<T, N>()
     }
@@ -376,7 +374,6 @@ where
 {
     const FOOTPRINT: u64 = N as u64;
 
-    #[inline]
     fn pull_spread(ptr: &mut KeyPtr) -> Self {
         Self::lazy(*ExtKeyPtr::next_for::<Self>(ptr))
     }
@@ -392,7 +389,6 @@ where
         }
     }
 
-    #[inline]
     fn clear_spread(&self, _ptr: &mut KeyPtr) {
         // Low-level lazy abstractions won't perform automated clean-up since
         // they generally are not aware of their entire set of associated
@@ -405,7 +401,6 @@ impl<T, const N: usize> SpreadAllocate for LazyArray<T, N>
 where
     T: PackedLayout,
 {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         Self::lazy(*ExtKeyPtr::next_for::<Self>(ptr))
     }

--- a/crates/storage/src/lazy/lazy_cell.rs
+++ b/crates/storage/src/lazy/lazy_cell.rs
@@ -201,7 +201,6 @@ impl<T> SpreadAllocate for LazyCell<T>
 where
     T: SpreadLayout,
 {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         Self::lazy(*ExtKeyPtr::next_for::<Self>(ptr))
     }
@@ -373,7 +372,6 @@ where
     /// # Panics
     ///
     /// If accessing the inner value fails.
-    #[inline]
     pub fn set(&mut self, new_value: T) {
         // SAFETY: This is critical because we mutably access the entry.
         let cache = unsafe { &mut *self.cache.get_ptr().as_ptr() };

--- a/crates/storage/src/lazy/lazy_hmap.rs
+++ b/crates/storage/src/lazy/lazy_hmap.rs
@@ -265,7 +265,6 @@ where
 {
     const FOOTPRINT: u64 = 1;
 
-    #[inline]
     fn pull_spread(ptr: &mut KeyPtr) -> Self {
         Self::lazy(*ExtKeyPtr::next_for::<Self>(ptr))
     }
@@ -278,7 +277,6 @@ where
         }
     }
 
-    #[inline]
     fn clear_spread(&self, _ptr: &mut KeyPtr) {
         // Low-level lazy abstractions won't perform automated clean-up since
         // they generally are not aware of their entire set of associated
@@ -294,7 +292,6 @@ where
     H: CryptoHash,
     Key: From<<H as HashOutput>::Type>,
 {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         Self::lazy(*ExtKeyPtr::next_for::<Self>(ptr))
     }

--- a/crates/storage/src/lazy/lazy_imap.rs
+++ b/crates/storage/src/lazy/lazy_imap.rs
@@ -243,7 +243,6 @@ where
 {
     const FOOTPRINT: u64 = 1_u64 << 32;
 
-    #[inline]
     fn pull_spread(ptr: &mut KeyPtr) -> Self {
         Self::lazy(*ExtKeyPtr::next_for::<Self>(ptr))
     }
@@ -257,7 +256,6 @@ where
         }
     }
 
-    #[inline]
     fn clear_spread(&self, _ptr: &mut KeyPtr) {
         // Low-level lazy abstractions won't perform automated clean-up since
         // they generally are not aware of their entire set of associated
@@ -270,7 +268,6 @@ impl<V> SpreadAllocate for LazyIndexMap<V>
 where
     V: PackedLayout,
 {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         Self::lazy(*ExtKeyPtr::next_for::<Self>(ptr))
     }

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -68,7 +68,6 @@ where
     V: PackedLayout,
 {
     /// Insert the given `value` to the contract storage.
-    #[inline]
     pub fn insert<Q, R>(&mut self, key: Q, value: &R)
     where
         Q: scale::EncodeLike<K>,
@@ -80,7 +79,6 @@ where
     /// Get the `value` at `key` from the contract storage.
     ///
     /// Returns `None` if no `value` exists at the given `key`.
-    #[inline]
     pub fn get<Q>(&self, key: Q) -> Option<V>
     where
         Q: scale::EncodeLike<K>,
@@ -107,7 +105,6 @@ impl<K, V> SpreadLayout for Mapping<K, V> {
     const FOOTPRINT: u64 = 1;
     const REQUIRES_DEEP_CLEAN_UP: bool = false;
 
-    #[inline]
     fn pull_spread(ptr: &mut KeyPtr) -> Self {
         // Note: There is no need to pull anything from the storage for the
         //       mapping type since it initializes itself entirely by the
@@ -115,14 +112,12 @@ impl<K, V> SpreadLayout for Mapping<K, V> {
         Self::new(*ExtKeyPtr::next_for::<Self>(ptr))
     }
 
-    #[inline]
     fn push_spread(&self, ptr: &mut KeyPtr) {
         // Note: The mapping type does not store any state in its associated
         //       storage region, therefore only the pointer has to be incremented.
         ptr.advance_by(Self::FOOTPRINT);
     }
 
-    #[inline]
     fn clear_spread(&self, ptr: &mut KeyPtr) {
         // Note: The mapping type is not aware of its elements, therefore
         //       it is not possible to clean up after itself.
@@ -131,7 +126,6 @@ impl<K, V> SpreadLayout for Mapping<K, V> {
 }
 
 impl<K, V> SpreadAllocate for Mapping<K, V> {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         // Note: The mapping type initializes itself entirely by the key pointer.
         Self::new(*ExtKeyPtr::next_for::<Self>(ptr))

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -183,7 +183,6 @@ where
     /// # Panics
     ///
     /// If accessing the inner value fails.
-    #[inline]
     pub fn set(lazy: &mut Self, new_value: T) {
         lazy.cell.set(new_value);
     }

--- a/crates/storage/src/memory.rs
+++ b/crates/storage/src/memory.rs
@@ -75,15 +75,12 @@ where
 {
     const FOOTPRINT: u64 = 0;
 
-    #[inline]
     fn pull_spread(_ptr: &mut KeyPtr) -> Self {
         Default::default()
     }
 
-    #[inline]
     fn push_spread(&self, _ptr: &mut KeyPtr) {}
 
-    #[inline]
     fn clear_spread(&self, _ptr: &mut KeyPtr) {}
 }
 
@@ -91,7 +88,6 @@ impl<T> SpreadAllocate for Memory<T>
 where
     T: Default,
 {
-    #[inline]
     fn allocate_spread(_ptr: &mut KeyPtr) -> Self {
         Default::default()
     }
@@ -99,26 +95,22 @@ where
 
 impl<T> Memory<T> {
     /// Creates a new memory instance.
-    #[inline]
     pub fn new(inner: T) -> Self {
         Self { inner }
     }
 
     /// Returns a shared reference to the inner `T`.
-    #[inline]
     pub fn get(memory: &Self) -> &T {
         &memory.inner
     }
 
     /// Returns an exclusive reference to the inner `T`.
-    #[inline]
     pub fn get_mut(memory: &mut Self) -> &mut T {
         &mut memory.inner
     }
 }
 
 impl<T> From<T> for Memory<T> {
-    #[inline]
     fn from(inner: T) -> Self {
         Self::new(inner)
     }
@@ -128,7 +120,6 @@ impl<T> Default for Memory<T>
 where
     T: Default,
 {
-    #[inline]
     fn default() -> Self {
         Self::new(<T as Default>::default())
     }
@@ -146,14 +137,12 @@ where
 impl<T> Deref for Memory<T> {
     type Target = T;
 
-    #[inline]
     fn deref(&self) -> &Self::Target {
         Self::get(self)
     }
 }
 
 impl<T> DerefMut for Memory<T> {
-    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         Self::get_mut(self)
     }
@@ -163,7 +152,6 @@ impl<T> AsRef<T> for Memory<T>
 where
     T: SpreadLayout,
 {
-    #[inline]
     fn as_ref(&self) -> &T {
         Self::get(self)
     }
@@ -173,7 +161,6 @@ impl<T> convert::AsMut<T> for Memory<T>
 where
     T: SpreadLayout,
 {
-    #[inline]
     fn as_mut(&mut self) -> &mut T {
         Self::get_mut(self)
     }
@@ -183,7 +170,6 @@ impl<T> Borrow<T> for Memory<T>
 where
     T: SpreadLayout,
 {
-    #[inline]
     fn borrow(&self) -> &T {
         Self::get(self)
     }
@@ -193,7 +179,6 @@ impl<T> BorrowMut<T> for Memory<T>
 where
     T: SpreadLayout,
 {
-    #[inline]
     fn borrow_mut(&mut self) -> &mut T {
         Self::get_mut(self)
     }

--- a/crates/storage/src/pack.rs
+++ b/crates/storage/src/pack.rs
@@ -77,27 +77,22 @@ impl<T> scale::Encode for Pack<T>
 where
     T: scale::Encode + PackedLayout,
 {
-    #[inline]
     fn size_hint(&self) -> usize {
         <T as scale::Encode>::size_hint(&self.inner)
     }
 
-    #[inline]
     fn encode_to<O: scale::Output + ?Sized>(&self, dest: &mut O) {
         <T as scale::Encode>::encode_to(&self.inner, dest)
     }
 
-    #[inline]
     fn encode(&self) -> Vec<u8> {
         <T as scale::Encode>::encode(&self.inner)
     }
 
-    #[inline]
     fn using_encoded<R, F: FnOnce(&[u8]) -> R>(&self, f: F) -> R {
         <T as scale::Encode>::using_encoded(&self.inner, f)
     }
 
-    #[inline]
     fn encoded_size(&self) -> usize {
         <T as scale::Encode>::encoded_size(&self.inner)
     }

--- a/crates/storage/src/traits/impls/arrays.rs
+++ b/crates/storage/src/traits/impls/arrays.rs
@@ -41,7 +41,6 @@ where
         }
     }
 
-    #[inline]
     fn pull_spread(ptr: &mut KeyPtr) -> Self {
         array_init::<_, T, N>(|_| <T as SpreadLayout>::pull_spread(ptr))
     }
@@ -51,7 +50,6 @@ impl<T, const N: usize> SpreadAllocate for [T; N]
 where
     T: SpreadAllocate,
 {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         array_init::<_, T, N>(|_| <T as SpreadAllocate>::allocate_spread(ptr))
     }
@@ -61,21 +59,18 @@ impl<T, const N: usize> PackedLayout for [T; N]
 where
     T: PackedLayout,
 {
-    #[inline]
     fn push_packed(&self, at: &Key) {
         for elem in self {
             <T as PackedLayout>::push_packed(elem, at)
         }
     }
 
-    #[inline]
     fn clear_packed(&self, at: &Key) {
         for elem in self {
             <T as PackedLayout>::clear_packed(elem, at)
         }
     }
 
-    #[inline]
     fn pull_packed(&mut self, at: &Key) {
         for elem in self {
             <T as PackedLayout>::pull_packed(elem, at)
@@ -87,7 +82,6 @@ impl<T, const N: usize> PackedAllocate for [T; N]
 where
     T: PackedAllocate,
 {
-    #[inline]
     fn allocate_packed(&mut self, at: &Key) {
         for elem in self {
             <T as PackedAllocate>::allocate_packed(elem, at)

--- a/crates/storage/src/traits/impls/collections.rs
+++ b/crates/storage/src/traits/impls/collections.rs
@@ -45,17 +45,14 @@ where
     const FOOTPRINT: u64 = 1;
     const REQUIRES_DEEP_CLEAN_UP: bool = <V as SpreadLayout>::REQUIRES_DEEP_CLEAN_UP;
 
-    #[inline]
     fn pull_spread(ptr: &mut KeyPtr) -> Self {
         forward_pull_packed::<Self>(ptr)
     }
 
-    #[inline]
     fn push_spread(&self, ptr: &mut KeyPtr) {
         forward_push_packed::<Self>(self, ptr)
     }
 
-    #[inline]
     fn clear_spread(&self, ptr: &mut KeyPtr) {
         forward_clear_packed::<Self>(self, ptr)
     }
@@ -66,7 +63,6 @@ where
     K: PackedAllocate + Ord,
     V: PackedAllocate,
 {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         forward_allocate_packed::<Self>(ptr)
     }
@@ -121,17 +117,14 @@ where
     const FOOTPRINT: u64 = 1;
     const REQUIRES_DEEP_CLEAN_UP: bool = <T as SpreadLayout>::REQUIRES_DEEP_CLEAN_UP;
 
-    #[inline]
     fn pull_spread(ptr: &mut KeyPtr) -> Self {
         forward_pull_packed::<Self>(ptr)
     }
 
-    #[inline]
     fn push_spread(&self, ptr: &mut KeyPtr) {
         forward_push_packed::<Self>(self, ptr)
     }
 
-    #[inline]
     fn clear_spread(&self, ptr: &mut KeyPtr) {
         forward_clear_packed::<Self>(self, ptr)
     }
@@ -141,7 +134,6 @@ impl<T> SpreadAllocate for StdBTreeSet<T>
 where
     T: PackedAllocate + Ord,
 {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         forward_allocate_packed::<Self>(ptr)
     }
@@ -163,7 +155,6 @@ where
         }
     }
 
-    #[inline]
     fn pull_packed(&mut self, _at: &Key) {
         // We cannot mutate keys in a set so we cannot forward pull signals.
     }
@@ -173,7 +164,6 @@ impl<T> PackedAllocate for StdBTreeSet<T>
 where
     T: PackedAllocate + Ord,
 {
-    #[inline]
     fn allocate_packed(&mut self, _at: &Key) {
         // We cannot mutate keys in a set so we cannot forward pull signals.
     }
@@ -186,17 +176,14 @@ where
     const FOOTPRINT: u64 = 1;
     const REQUIRES_DEEP_CLEAN_UP: bool = <T as SpreadLayout>::REQUIRES_DEEP_CLEAN_UP;
 
-    #[inline]
     fn pull_spread(ptr: &mut KeyPtr) -> Self {
         forward_pull_packed::<Self>(ptr)
     }
 
-    #[inline]
     fn push_spread(&self, ptr: &mut KeyPtr) {
         forward_push_packed::<Self>(self, ptr)
     }
 
-    #[inline]
     fn clear_spread(&self, ptr: &mut KeyPtr) {
         forward_clear_packed::<Self>(self, ptr)
     }
@@ -206,7 +193,6 @@ impl<T> SpreadAllocate for StdBinaryHeap<T>
 where
     T: PackedAllocate + Ord,
 {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         forward_allocate_packed::<Self>(ptr)
     }
@@ -228,7 +214,6 @@ where
         }
     }
 
-    #[inline]
     fn pull_packed(&mut self, _at: &Key) {
         // We cannot mutate keys in a heap so we cannot forward pull signals.
     }
@@ -238,7 +223,6 @@ impl<T> PackedAllocate for StdBinaryHeap<T>
 where
     T: PackedAllocate + Ord,
 {
-    #[inline]
     fn allocate_packed(&mut self, _at: &Key) {
         // We cannot mutate keys in a heap so we cannot forward pull signals.
     }

--- a/crates/storage/src/traits/impls/mod.rs
+++ b/crates/storage/src/traits/impls/mod.rs
@@ -23,17 +23,14 @@ macro_rules! impl_always_packed_layout {
             const FOOTPRINT: ::core::primitive::u64 = 1_u64;
             const REQUIRES_DEEP_CLEAN_UP: ::core::primitive::bool = $deep;
 
-            #[inline]
             fn pull_spread(ptr: &mut $crate::traits::KeyPtr) -> Self {
                 $crate::traits::impls::forward_pull_packed::<Self>(ptr)
             }
 
-            #[inline]
             fn push_spread(&self, ptr: &mut $crate::traits::KeyPtr) {
                 $crate::traits::impls::forward_push_packed::<Self>(self, ptr)
             }
 
-            #[inline]
             fn clear_spread(&self, ptr: &mut $crate::traits::KeyPtr) {
                 $crate::traits::impls::forward_clear_packed::<Self>(self, ptr)
             }
@@ -46,7 +43,6 @@ macro_rules! impl_always_packed_layout {
                 $frag: $crate::traits::PackedAllocate,
             )+
         {
-            #[inline]
             fn allocate_spread(ptr: &mut $crate::traits::KeyPtr) -> Self {
                 $crate::traits::impls::forward_allocate_packed::<Self>(ptr)
             }
@@ -60,17 +56,14 @@ macro_rules! impl_always_packed_layout {
             const FOOTPRINT: ::core::primitive::u64 = 1_u64;
             const REQUIRES_DEEP_CLEAN_UP: ::core::primitive::bool = $deep;
 
-            #[inline]
             fn pull_spread(ptr: &mut $crate::traits::KeyPtr) -> Self {
                 $crate::traits::impls::forward_pull_packed::<Self>(ptr)
             }
 
-            #[inline]
             fn push_spread(&self, ptr: &mut $crate::traits::KeyPtr) {
                 $crate::traits::impls::forward_push_packed::<Self>(self, ptr)
             }
 
-            #[inline]
             fn clear_spread(&self, ptr: &mut $crate::traits::KeyPtr) {
                 $crate::traits::impls::forward_clear_packed::<Self>(self, ptr)
             }
@@ -80,7 +73,6 @@ macro_rules! impl_always_packed_layout {
         where
             Self: $crate::traits::PackedLayout + ::core::default::Default,
         {
-            #[inline]
             fn allocate_spread(ptr: &mut $crate::traits::KeyPtr) -> Self {
                 $crate::traits::impls::forward_allocate_packed::<Self>(ptr)
             }
@@ -123,7 +115,6 @@ const fn max(a: u64, b: u64) -> u64 {
 ///
 /// Use this utility function to use a packed pull operation for the type
 /// instead of a spread storage layout pull operation.
-#[inline]
 pub fn forward_pull_packed<T>(ptr: &mut KeyPtr) -> T
 where
     T: PackedLayout,
@@ -140,7 +131,6 @@ where
 ///
 /// Use this utility function to use a packed allocate operation for the type
 /// instead of a spread storage layout allocation operation.
-#[inline]
 pub fn forward_allocate_packed<T>(ptr: &mut KeyPtr) -> T
 where
     T: PackedAllocate + Default,
@@ -157,7 +147,6 @@ where
 ///
 /// Use this utility function to use a packed push operation for the type
 /// instead of a spread storage layout push operation.
-#[inline]
 pub fn forward_push_packed<T>(entity: &T, ptr: &mut KeyPtr)
 where
     T: PackedLayout,
@@ -174,7 +163,6 @@ where
 ///
 /// Use this utility function to use a packed clear operation for the type
 /// instead of a spread storage layout clear operation.
-#[inline]
 pub fn forward_clear_packed<T>(entity: &T, ptr: &mut KeyPtr)
 where
     T: PackedLayout,

--- a/crates/storage/src/traits/impls/prims.rs
+++ b/crates/storage/src/traits/impls/prims.rs
@@ -35,15 +35,11 @@ macro_rules! impl_layout_for_primitive {
         $(
             impl_always_packed_layout!($ty, deep: false);
             impl $crate::traits::PackedLayout for $ty {
-                #[inline]
                 fn pull_packed(&mut self, _at: &::ink_primitives::Key) {}
-                #[inline]
                 fn push_packed(&self, _at: &::ink_primitives::Key) {}
-                #[inline]
                 fn clear_packed(&self, _at: &::ink_primitives::Key) {}
             }
             impl $crate::traits::PackedAllocate for $ty {
-                #[inline]
                 fn allocate_packed(&mut self, _at: &::ink_primitives::Key) {}
             }
         )*
@@ -105,7 +101,6 @@ impl<T> SpreadAllocate for Option<T>
 where
     T: SpreadLayout,
 {
-    #[inline]
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         ptr.advance_by(<T as SpreadLayout>::FOOTPRINT);
         None
@@ -116,21 +111,18 @@ impl<T> PackedLayout for Option<T>
 where
     T: PackedLayout,
 {
-    #[inline]
     fn push_packed(&self, at: &Key) {
         if let Some(value) = self {
             <T as PackedLayout>::push_packed(value, at)
         }
     }
 
-    #[inline]
     fn clear_packed(&self, at: &Key) {
         if let Some(value) = self {
             <T as PackedLayout>::clear_packed(value, at)
         }
     }
 
-    #[inline]
     fn pull_packed(&mut self, at: &Key) {
         if let Some(value) = self {
             <T as PackedLayout>::pull_packed(value, at)
@@ -142,7 +134,6 @@ impl<T> PackedAllocate for Option<T>
 where
     T: PackedAllocate,
 {
-    #[inline]
     fn allocate_packed(&mut self, at: &Key) {
         // Note: Maybe this is not needed since `Option<T>` is alwyas default
         //       initialized as `None` so this cannot really occur.
@@ -204,7 +195,6 @@ where
     T: PackedLayout,
     E: PackedLayout,
 {
-    #[inline]
     fn push_packed(&self, at: &Key) {
         match self {
             Ok(value) => <T as PackedLayout>::push_packed(value, at),
@@ -212,7 +202,6 @@ where
         }
     }
 
-    #[inline]
     fn clear_packed(&self, at: &Key) {
         match self {
             Ok(value) => <T as PackedLayout>::clear_packed(value, at),
@@ -220,7 +209,6 @@ where
         }
     }
 
-    #[inline]
     fn pull_packed(&mut self, at: &Key) {
         match self {
             Ok(value) => <T as PackedLayout>::pull_packed(value, at),
@@ -262,17 +250,14 @@ impl<T> PackedLayout for Box<T>
 where
     T: PackedLayout,
 {
-    #[inline]
     fn push_packed(&self, at: &Key) {
         <T as PackedLayout>::push_packed(&*self, at)
     }
 
-    #[inline]
     fn clear_packed(&self, at: &Key) {
         <T as PackedLayout>::clear_packed(&*self, at)
     }
 
-    #[inline]
     fn pull_packed(&mut self, at: &Key) {
         <T as PackedLayout>::pull_packed(&mut *self, at)
     }
@@ -282,7 +267,6 @@ impl<T> PackedAllocate for Box<T>
 where
     T: PackedAllocate,
 {
-    #[inline]
     fn allocate_packed(&mut self, at: &Key) {
         <T as PackedAllocate>::allocate_packed(&mut *self, at)
     }

--- a/crates/storage/src/traits/impls/tuples.rs
+++ b/crates/storage/src/traits/impls/tuples.rs
@@ -34,7 +34,6 @@ macro_rules! impl_layout_for_tuple {
             const REQUIRES_DEEP_CLEAN_UP: ::core::primitive::bool =
                 false $(|| <$frag as SpreadLayout>::REQUIRES_DEEP_CLEAN_UP)*;
 
-            #[inline]
             fn push_spread(&self, ptr: &mut KeyPtr) {
                 #[allow(non_snake_case)]
                 let ($($frag),*,) = self;
@@ -43,7 +42,6 @@ macro_rules! impl_layout_for_tuple {
                 )*
             }
 
-            #[inline]
             fn clear_spread(&self, ptr: &mut KeyPtr) {
                 #[allow(non_snake_case)]
                 let ($($frag),*,) = self;
@@ -52,7 +50,6 @@ macro_rules! impl_layout_for_tuple {
                 )*
             }
 
-            #[inline]
             fn pull_spread(ptr: &mut KeyPtr) -> Self {
                 (
                     $(
@@ -68,7 +65,6 @@ macro_rules! impl_layout_for_tuple {
                 $frag: SpreadAllocate,
             )*
         {
-            #[inline]
             fn allocate_spread(ptr: &mut KeyPtr) -> Self {
                 (
                     $(
@@ -84,7 +80,6 @@ macro_rules! impl_layout_for_tuple {
                 $frag: PackedLayout,
             )*
         {
-            #[inline]
             fn push_packed(&self, at: &Key) {
                 #[allow(non_snake_case)]
                 let ($($frag),*,) = self;
@@ -93,7 +88,6 @@ macro_rules! impl_layout_for_tuple {
                 )*
             }
 
-            #[inline]
             fn clear_packed(&self, at: &Key) {
                 #[allow(non_snake_case)]
                 let ($($frag),*,) = self;
@@ -102,7 +96,6 @@ macro_rules! impl_layout_for_tuple {
                 )*
             }
 
-            #[inline]
             fn pull_packed(&mut self, at: &Key) {
                 #[allow(non_snake_case)]
                 let ($($frag),*,) = self;
@@ -118,7 +111,6 @@ macro_rules! impl_layout_for_tuple {
                 $frag: PackedAllocate,
             )*
         {
-            #[inline]
             fn allocate_packed(&mut self, at: &Key) {
                 #[allow(non_snake_case)]
                 let ($($frag),*,) = self;

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -102,7 +102,6 @@ mod erc20 {
         ///
         /// Prefer to call this method over `balance_of` since this
         /// works using references which are more efficient in Wasm.
-        #[inline]
         fn balance_of_impl(&self, owner: &AccountId) -> Balance {
             self.balances.get(owner).unwrap_or_default()
         }
@@ -123,7 +122,6 @@ mod erc20 {
         ///
         /// Prefer to call this method over `allowance` since this
         /// works using references which are more efficient in Wasm.
-        #[inline]
         fn allowance_impl(&self, owner: &AccountId, spender: &AccountId) -> Balance {
             self.allowances.get((owner, spender)).unwrap_or_default()
         }
@@ -527,12 +525,10 @@ mod erc20 {
     where
         X: scale::Encode,
     {
-        #[inline]
         fn size_hint(&self) -> usize {
             self.prefix.size_hint() + self.value.size_hint()
         }
 
-        #[inline]
         fn encode_to<T: scale::Output + ?Sized>(&self, dest: &mut T) {
             self.prefix.encode_to(dest);
             self.value.encode_to(dest);

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -565,12 +565,10 @@ mod erc20 {
     where
         X: scale::Encode,
     {
-        #[inline]
         fn size_hint(&self) -> usize {
             self.prefix.size_hint() + self.value.size_hint()
         }
 
-        #[inline]
         fn encode_to<T: scale::Output + ?Sized>(&self, dest: &mut T) {
             self.prefix.encode_to(dest);
             self.value.encode_to(dest);


### PR DESCRIPTION
A naive follow up to #1012. I just ran `fd -e rs -x sed -i '' -e '/\#\[inline\]/d'` and
want to see how contract sizes get affected.
