### PR TITLE
Extract non-generic part of `push_topic` to reduce code size

### DIFF
--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -151,6 +151,21 @@ where
     {
         let mut split = self.scoped_buffer.split();
         let encoded = split.take_encoded(topic_value);
+        let result = Self::push_topic_encoded(encoded);
+        self.scoped_buffer.append_encoded(&result);
+    }
+
+    fn output(mut self) -> Self::Output {
+        let encoded_topics = self.scoped_buffer.take_appended();
+        (self.scoped_buffer, encoded_topics)
+    }
+}
+
+impl<'a, E> TopicsBuilder<'a, E>
+where
+    E: Environment,
+{
+    fn push_topic_encoded(encoded: &mut [u8]) -> <E as Environment>::Hash {
         let len_encoded = encoded.len();
         let mut result = <E as Environment>::Hash::clear();
         let len_result = result.as_ref().len();
@@ -162,12 +177,7 @@ where
             let copy_len = core::cmp::min(hash_output.len(), len_result);
             result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
         }
-        self.scoped_buffer.append_encoded(&result);
-    }
-
-    fn output(mut self) -> Self::Output {
-        let encoded_topics = self.scoped_buffer.take_appended();
-        (self.scoped_buffer, encoded_topics)
+        result
     }
 }
 


### PR DESCRIPTION
Marginal total of `0.3KB` (`10.3` down from `10.6`) on ERC20. 

However it appears to reduce the amount of increase of each additional type of topic (see example below), since the extracted non generic part will not be duplicated each time. e.g. commenting out the `Option<AccountId>` topics

![image](https://user-images.githubusercontent.com/75586/142614944-8700512b-ce55-4686-a164-1b198bf8dba7.png)

`master` `10.2` -> `10.6` = `+0.4`
`this PR` `10.1` -> `10.3` = `+0.2`

Rel #990 