### PR TITLE
Update chain extension example to show argument passing

### DIFF
--- a/examples/rand-extension/lib.rs
+++ b/examples/rand-extension/lib.rs
@@ -86,8 +86,9 @@ mod rand_extension {
             Self::new(Default::default())
         }
 
-        /// Seed a random value by passing some known argument `subject` to the runtime's random
-        /// source. Then, update the current value with the new random value
+        /// Seed a random value by passing some known argument `subject` to the runtime's
+        /// random source. Then, update the current `value` stored in this contract with the
+        /// new random value.
         #[ink(message)]
         pub fn update(&mut self, subject: [u8; 32]) -> Result<(), RandomReadErr> {
             // Get the on-chain random seed

--- a/examples/rand-extension/lib.rs
+++ b/examples/rand-extension/lib.rs
@@ -146,7 +146,7 @@ mod rand_extension {
             assert_eq!(rand_extension.get(), [0; 32]);
 
             // when
-            rand_extension.update().expect("update must work");
+            rand_extension.update([0_u8; 32]).expect("update must work");
 
             // then
             assert_eq!(rand_extension.get(), [1; 32]);

--- a/examples/rand-extension/lib.rs
+++ b/examples/rand-extension/lib.rs
@@ -86,7 +86,8 @@ mod rand_extension {
             Self::new(Default::default())
         }
 
-        /// Update the value from the runtimes random source.
+        /// Seed a random value by passing some known argument `subject` to the runtime's random
+        /// source. Then, update the current value with the new random value
         #[ink(message)]
         pub fn update(&mut self, subject: [u8; 32]) -> Result<(), RandomReadErr> {
             // Get the on-chain random seed

--- a/examples/rand-extension/lib.rs
+++ b/examples/rand-extension/lib.rs
@@ -15,7 +15,7 @@ pub trait FetchRandom {
     /// Note: this gives the operation a corresponding `func_id` (1101 in this case),
     /// and the chain-side chain extension will get the `func_id` to do further operations.
     #[ink(extension = 1101, returns_result = false)]
-    fn fetch_random() -> [u8; 32];
+    fn fetch_random(subject: [u8; 32]) -> [u8; 32];
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
@@ -88,9 +88,9 @@ mod rand_extension {
 
         /// Update the value from the runtimes random source.
         #[ink(message)]
-        pub fn update(&mut self) -> Result<(), RandomReadErr> {
+        pub fn update(&mut self, subject: [u8; 32]) -> Result<(), RandomReadErr> {
             // Get the on-chain random seed
-            let new_random = self.env().extension().fetch_random()?;
+            let new_random = self.env().extension().fetch_random(subject)?;
             self.value = new_random;
             // Emit the `RandomUpdated` event when the random seed
             // is successfully fetched.

--- a/examples/rand-extension/runtime/chain-extension-example.rs
+++ b/examples/rand-extension/runtime/chain-extension-example.rs
@@ -29,7 +29,8 @@ impl ChainExtension<Runtime> for FetchRandomExtension {
         match func_id {
             1101 => {
                 let mut env = env.buf_in_buf_out();
-                let random_seed = crate::RandomnessCollectiveFlip::random_seed().0;
+                let arg: [u8; 32] = env.read_as()?;
+                let random_seed = crate::RandomnessCollectiveFlip::random(&arg).0;
                 let random_slice = random_seed.encode();
                 trace!(
                     target: "runtime",


### PR DESCRIPTION
This changes the `rand-extension` Ink! example code to pass along an argument from the contract to the chain extension in the runtime. This PR addresses the first ToDo [here](https://github.com/paritytech/ink/issues/891), which is a repeat user question. I verified this works in a Substrate node on my machine. 