### PR TITLE
Add `CODEOWNERS` file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,5 +18,5 @@
 
 # CI
 /.github/ @paritytech/ci @HCastano @cmichi
-/scripts/.ci @paritytech/ci @HCastano @cmichi
+/scripts/.ci/ @paritytech/ci @HCastano @cmichi
 /.gitlab-ci.yml @paritytech/ci @HCastano @cmichi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,6 +20,6 @@
 * @Robbepop @cmichi @ascjones @HCastano
 
 # CI
-/.github/ @paritytech/ci @Robbepop @cmichi @ascjones @HCastano
+/.github/workflows/ @paritytech/ci @Robbepop @cmichi @ascjones @HCastano
 /scripts/.ci/ @paritytech/ci @Robbepop @cmichi @ascjones @HCastano
 /.gitlab-ci.yml @paritytech/ci @Robbepop @cmichi @ascjones @HCastano

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,10 @@
 #   eyou can use them for mentioning unlike an email.
 # - The latest matching rule, if multiple, takes precedence.
 
+# All of the core team members are global code owners.
+* @Robbepop @cmichi @ascjones @HCastano
+
 # CI
-/.github/ @paritytech/ci @HCastano @cmichi
-/scripts/.ci/ @paritytech/ci @HCastano @cmichi
-/.gitlab-ci.yml @paritytech/ci @HCastano @cmichi
+/.github/ @paritytech/ci @Robbepop @cmichi @ascjones @HCastano
+/scripts/.ci/ @paritytech/ci @Robbepop @cmichi @ascjones @HCastano
+/.gitlab-ci.yml @paritytech/ci @Robbepop @cmichi @ascjones @HCastano

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,5 +18,5 @@
 
 # CI
 /.github/ @paritytech/ci @HCastano @cmichi
-/scripts/ci @paritytech/ci @HCastano @cmichi
+/scripts/.ci @paritytech/ci @HCastano @cmichi
 /.gitlab-ci.yml @paritytech/ci @HCastano @cmichi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,22 @@
+# Lists some code owners.
+#
+# A codeowner just oversees some part of the codebase. If an owned file is changed then the
+# corresponding codeowner receives a review request. An approval of the codeowner might be
+# required for merging a PR (depends on repository settings).
+#
+# For details about syntax, see:
+# https://help.github.com/en/articles/about-code-owners
+# But here are some important notes:
+#
+# - Glob syntax is git-like, e.g. `/core` means the core directory in the root, unlike `core`
+#   which can be everywhere.
+# - Multiple owners are supported.
+# - Either handle (e.g, @github_user or @github_org/team) or email can be used. Keep in mind,
+#   that handles might work better because they are more recognizable on GitHub,
+#   eyou can use them for mentioning unlike an email.
+# - The latest matching rule, if multiple, takes precedence.
+
+# CI
+/.github/ @paritytech/ci @HCastano @cmichi
+/scripts/ci @paritytech/ci @HCastano @cmichi
+/.gitlab-ci.yml @paritytech/ci @HCastano @cmichi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@
 # - Multiple owners are supported.
 # - Either handle (e.g, @github_user or @github_org/team) or email can be used. Keep in mind,
 #   that handles might work better because they are more recognizable on GitHub,
-#   eyou can use them for mentioning unlike an email.
+#   you can use them for mentioning unlike an email.
 # - The latest matching rule, if multiple, takes precedence.
 
 # All of the core team members are global code owners.


### PR DESCRIPTION
This PR adds `CODEOWNERS` file to the repository.
It is needed to increase awareness of the developers about related code changes.
Currently it adds CI team related stuff. But feel free to propose additions or changes to it.