### PR TITLE
[ci] Fix publish-docs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -445,11 +445,11 @@ publish-docs:
   before_script:
     - unset CARGO_TARGET_DIR
   script:
+    # Setup ssh
     - eval $(ssh-agent)
     - ssh-add - <<< ${GITHUB_SSH_PRIV_KEY}
     - mkdir ~/.ssh && touch ~/.ssh/known_hosts
     - ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-    - rm -rf /tmp/*
     # Set git config
     - git config user.email "devops-team@parity.io"
     - git config user.name "${GITHUB_USER}"


### PR DESCRIPTION
Removed `- rm -rf /tmp/*` from .gitlab-ci.yml (in `publish-docs` job) because it breaks ssh-agent. Also it's not needed because /tmp is empty when container initialised. 