### PR TITLE
Explicitly link against rlibc to get non buggy version of memcpy

### DIFF
--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -30,6 +30,7 @@ static_assertions = "1.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 libsecp256k1 = { version = "0.7.0", default-features = false }
+rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ink_engine = { version = "3.0.0-rc6", path = "../engine/", default-features = false, optional = true }

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -44,6 +44,10 @@
 )]
 
 #[cfg(all(not(feature = "std"), target_arch = "wasm32"))]
+#[allow(unused_extern_crates)]
+extern crate rlibc;
+
+#[cfg(all(not(feature = "std"), target_arch = "wasm32"))]
 #[allow(unused_variables)]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -19,10 +19,6 @@ name = "contract_terminate"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -20,10 +20,6 @@ name = "contract_transfer"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -23,10 +23,6 @@ name = "delegator"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -24,10 +24,6 @@ crate-type = [
     "rlib",
 ]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -26,10 +26,6 @@ crate-type = [
     "rlib",
 ]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -26,10 +26,6 @@ crate-type = [
     "rlib",
 ]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -19,10 +19,6 @@ name = "dns"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -20,10 +20,6 @@ name = "erc1155"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -19,10 +19,6 @@ name = "erc20"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -19,10 +19,6 @@ name = "erc721"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -19,10 +19,6 @@ name = "flipper"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -19,10 +19,6 @@ name = "incrementer"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -20,10 +20,6 @@ name = "multisig"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -19,10 +19,6 @@ name = "rand_extension"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -19,10 +19,6 @@ name = "trait_erc20"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -19,10 +19,6 @@ name = "trait_flipper"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [

--- a/examples/trait-incrementer/Cargo.toml
+++ b/examples/trait-incrementer/Cargo.toml
@@ -19,10 +19,6 @@ name = "trait_incrementer"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [


### PR DESCRIPTION
Fixes #364

The "ghost import" is called by the compiler inserted `memcpy` function. This is a workaround by providing a non buggy version of this functions ourselves.