### PR TITLE
Switch from `libsecp256k1` to `secp256k1`

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -23,7 +23,7 @@ sha3 = { version = "0.9" }
 blake2 = { version = "0.9" }
 
 # ECDSA for the off-chain environment.
-libsecp256k1 = { version = "0.7.0" }
+secp256k1 = { version = "0.20.3", features = ["recovery"] }
 
 [features]
 default = ["std"]

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -387,11 +387,13 @@ impl Engine {
         message_hash: &[u8; 32],
         output: &mut [u8; 33],
     ) -> Result {
-        use libsecp256k1::{
-            recover,
+        use secp256k1::{
+            recovery::{
+                RecoverableSignature,
+                RecoveryId,
+            },
             Message,
-            RecoveryId,
-            Signature,
+            Secp256k1,
         };
 
         // In most implementations, the v is just 0 or 1 internally, but 27 was added
@@ -401,17 +403,24 @@ impl Engine {
         } else {
             signature[64]
         };
-        let message = Message::parse(message_hash);
-        let signature = Signature::parse_standard_slice(&signature[0..64])
-            .unwrap_or_else(|error| panic!("Unable to parse the signature: {}", error));
 
-        let recovery_id = RecoveryId::parse(recovery_byte)
+        let recovery_id = RecoveryId::from_i32(recovery_byte as i32)
             .unwrap_or_else(|error| panic!("Unable to parse the recovery id: {}", error));
 
-        let pub_key = recover(&message, &signature, &recovery_id);
+        let message = Message::from_slice(message_hash).unwrap_or_else(|error| {
+            panic!("Unable to create the message from hash: {}", error)
+        });
+        let signature =
+            RecoverableSignature::from_compact(&signature[0..64], recovery_id)
+                .unwrap_or_else(|error| {
+                    panic!("Unable to parse the signature: {}", error)
+                });
+
+        let secp = Secp256k1::new();
+        let pub_key = secp.recover(&message, &signature);
         match pub_key {
             Ok(pub_key) => {
-                *output = pub_key.serialize_compressed();
+                *output = pub_key.serialize();
                 Ok(())
             }
             Err(_) => Err(Error::EcdsaRecoverFailed),

--- a/crates/engine/src/tests.rs
+++ b/crates/engine/src/tests.rs
@@ -16,9 +16,11 @@ use crate::ext::{
     Engine,
     Error,
 };
-use libsecp256k1::{
+use secp256k1::{
+    recovery::RecoverableSignature,
     Message,
     PublicKey,
+    Secp256k1,
     SecretKey,
 };
 
@@ -236,11 +238,12 @@ fn ecdsa_recovery_test_from_contracts_pallet() {
 fn ecdsa_recovery_with_secp256k1_crate() {
     // given
     let mut engine = Engine::new();
+    let secp = Secp256k1::new();
     let seckey = [
         59, 148, 11, 85, 134, 130, 61, 253, 2, 174, 59, 70, 27, 180, 51, 107, 94, 203,
         174, 253, 102, 39, 170, 146, 46, 252, 4, 143, 236, 12, 136, 28,
     ];
-    let pubkey = PublicKey::parse_compressed(&[
+    let pubkey = PublicKey::from_slice(&[
         2, 29, 21, 35, 7, 198, 183, 43, 14, 208, 65, 139, 14, 112, 205, 128, 231, 245,
         41, 91, 141, 134, 245, 114, 45, 63, 82, 19, 251, 210, 57, 79, 54,
     ])
@@ -249,12 +252,14 @@ fn ecdsa_recovery_with_secp256k1_crate() {
     let mut msg_hash = [0; 32];
     crate::hashing::sha2_256(b"Some message", &mut msg_hash);
 
-    let msg = Message::parse(&msg_hash);
-    let seckey = SecretKey::parse(&seckey).expect("secret key creation failed");
-    let (signature, recovery_id) = libsecp256k1::sign(&msg, &seckey);
+    let msg = Message::from_slice(&msg_hash).expect("message creation failed");
+    let seckey = SecretKey::from_slice(&seckey).expect("secret key creation failed");
+    let recoverable_signature: RecoverableSignature =
+        secp.sign_recoverable(&msg, &seckey);
 
-    let mut signature = signature.serialize().to_vec();
-    signature.push(recovery_id.serialize());
+    let recovery_id = recoverable_signature.serialize_compact().0.to_i32() as u8;
+    let mut signature = recoverable_signature.serialize_compact().1.to_vec();
+    signature.push(recovery_id);
     let signature_with_recovery_id: [u8; 65] = signature
         .try_into()
         .expect("unable to create signature with recovery id");
@@ -262,9 +267,9 @@ fn ecdsa_recovery_with_secp256k1_crate() {
     // when
     let mut output = [0; 33];
     engine
-        .ecdsa_recover(&signature_with_recovery_id, &msg.serialize(), &mut output)
+        .ecdsa_recover(&signature_with_recovery_id, msg.as_ref(), &mut output)
         .expect("ecdsa recovery failed");
 
     // then
-    assert_eq!(output, pubkey.serialize_compressed());
+    assert_eq!(output, pubkey.serialize());
 }

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -29,7 +29,7 @@ arrayref = "0.3"
 static_assertions = "1.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-libsecp256k1 = { version = "0.7.0", default-features = false }
+secp256k1 = { version = "0.20.3", default-features = false }
 rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -41,7 +41,7 @@ sha3 = { version = "0.9", optional = true }
 blake2 = { version = "0.9", optional = true }
 
 # ECDSA for the off-chain environment.
-libsecp256k1 = { version = "0.7.0" }
+secp256k1 = { version = "0.20.3", features = ["recovery"] }
 
 # Only used in the off-chain environment.
 #

--- a/crates/env/src/engine/experimental_off_chain/impls.rs
+++ b/crates/env/src/engine/experimental_off_chain/impls.rs
@@ -251,11 +251,13 @@ impl EnvBackend for EnvInstance {
         message_hash: &[u8; 32],
         output: &mut [u8; 33],
     ) -> Result<()> {
-        use libsecp256k1::{
-            recover,
+        use secp256k1::{
+            recovery::{
+                RecoverableSignature,
+                RecoveryId,
+            },
             Message,
-            RecoveryId,
-            Signature,
+            Secp256k1,
         };
 
         // In most implementations, the v is just 0 or 1 internally, but 27 was added
@@ -265,17 +267,22 @@ impl EnvBackend for EnvInstance {
         } else {
             signature[64]
         };
-        let message = Message::parse(message_hash);
-        let signature = Signature::parse_standard_slice(&signature[0..64])
-            .unwrap_or_else(|error| panic!("Unable to parse the signature: {}", error));
-
-        let recovery_id = RecoveryId::parse(recovery_byte)
+        let recovery_id = RecoveryId::from_i32(recovery_byte as i32)
             .unwrap_or_else(|error| panic!("Unable to parse the recovery id: {}", error));
+        let message = Message::from_slice(message_hash).unwrap_or_else(|error| {
+            panic!("Unable to create the message from hash: {}", error)
+        });
+        let signature =
+            RecoverableSignature::from_compact(&signature[0..64], recovery_id)
+                .unwrap_or_else(|error| {
+                    panic!("Unable to parse the signature: {}", error)
+                });
 
-        let pub_key = recover(&message, &signature, &recovery_id);
+        let secp = Secp256k1::new();
+        let pub_key = secp.recover(&message, &signature);
         match pub_key {
             Ok(pub_key) => {
-                *output = pub_key.serialize_compressed();
+                *output = pub_key.serialize();
                 Ok(())
             }
             Err(_) => Err(Error::EcdsaRecoverFailed),

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -197,11 +197,13 @@ impl EnvBackend for EnvInstance {
         message_hash: &[u8; 32],
         output: &mut [u8; 33],
     ) -> Result<()> {
-        use libsecp256k1::{
-            recover,
+        use secp256k1::{
+            recovery::{
+                RecoverableSignature,
+                RecoveryId,
+            },
             Message,
-            RecoveryId,
-            Signature,
+            Secp256k1,
         };
 
         // In most implementations, the v is just 0 or 1 internally, but 27 was added
@@ -211,17 +213,22 @@ impl EnvBackend for EnvInstance {
         } else {
             signature[64]
         };
-        let message = Message::parse(message_hash);
-        let signature = Signature::parse_standard_slice(&signature[0..64])
-            .unwrap_or_else(|error| panic!("Unable to parse the signature: {}", error));
-
-        let recovery_id = RecoveryId::parse(recovery_byte)
+        let recovery_id = RecoveryId::from_i32(recovery_byte as i32)
             .unwrap_or_else(|error| panic!("Unable to parse the recovery id: {}", error));
+        let message = Message::from_slice(message_hash).unwrap_or_else(|error| {
+            panic!("Unable to create the message from hash: {}", error)
+        });
+        let signature =
+            RecoverableSignature::from_compact(&signature[0..64], recovery_id)
+                .unwrap_or_else(|error| {
+                    panic!("Unable to parse the signature: {}", error)
+                });
 
-        let pub_key = recover(&message, &signature, &recovery_id);
+        let secp = Secp256k1::new();
+        let pub_key = secp.recover(&message, &signature);
         match pub_key {
             Ok(pub_key) => {
-                *output = pub_key.serialize_compressed();
+                *output = pub_key.serialize();
                 Ok(())
             }
             Err(_) => Err(Error::EcdsaRecoverFailed),

--- a/crates/eth_compatibility/Cargo.toml
+++ b/crates/eth_compatibility/Cargo.toml
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 ink_env = { version = "3.0.0-rc7", path = "../env", default-features = false }
-libsecp256k1 = { version = "0.7.0", default-features = false }
+secp256k1 = { version = "0.20.3", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/eth_compatibility/src/lib.rs
+++ b/crates/eth_compatibility/src/lib.rs
@@ -93,12 +93,12 @@ impl ECDSAPublicKey {
     /// ```
     pub fn to_eth_address(&self) -> EthereumAddress {
         use ink_env::hash;
-        use libsecp256k1::PublicKey;
+        use secp256k1::PublicKey;
 
         // Transform compressed public key into uncompressed.
-        let pub_key = PublicKey::parse_compressed(&self.0)
+        let pub_key = PublicKey::from_slice(&self.0)
             .expect("Unable to parse the compressed ECDSA public key");
-        let uncompressed = pub_key.serialize();
+        let uncompressed = pub_key.serialize_uncompressed();
 
         // Hash the uncompressed public key by Keccak256 algorithm.
         let mut hash = <hash::Keccak256 as hash::HashOutput>::Type::default();


### PR DESCRIPTION
Substrate also wants to switch at some point.

This also fixes the failing `cargo-contract` Windows CI, due to incompatibilities of `libsecp256k1`.