### PR TITLE
Actualizing of the size of the `delegator` example

### DIFF
--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -12,11 +12,11 @@ ink_storage = { version = "3.0.0-rc7", path = "../../crates/storage", default-fe
 ink_lang = { version = "3.0.0-rc7", path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2", default-features = false, features = ["derive"] }
+scale-info = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 adder = { version = "3.0.0-rc7", path = "adder", default-features = false, features = ["ink-as-dependency"] }
 subber = { version = "3.0.0-rc7", path = "subber", default-features = false, features = ["ink-as-dependency"] }
 accumulator = { version = "3.0.0-rc7", path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
-scale-info = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "delegator"
@@ -41,10 +41,3 @@ std = [
     "accumulator/std",
 ]
 ink-as-dependency = []
-
-[workspace]
-members = [
-    "accumulator",
-    "adder",
-    "subber",
-]

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -41,3 +41,11 @@ std = [
     "accumulator/std",
 ]
 ink-as-dependency = []
+
+[workspace]
+members = [
+    "accumulator",
+    "adder",
+    "subber",
+]
+

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -41,4 +41,6 @@ std = [
 
     "accumulator/std",
 ]
-ink-as-dependency = []
+ink-as-dependency = [
+    "accumulator/ink-as-dependency",
+]

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -41,4 +41,6 @@ std = [
 
     "accumulator/std",
 ]
-ink-as-dependency = []
+ink-as-dependency = [
+    "accumulator/ink-as-dependency",
+]


### PR DESCRIPTION
Extracted that change from [here](https://github.com/paritytech/ink/pull/1017#issuecomment-980830916). 

Using `workspace` forces the compiler to keep stuff for debugging. It increases the size of `adder`, `subber`, `accumulator`. 

`accumulator`: `Original wasm size: 26.8K, Optimized: 6.2K` -> `Original wasm size: 20.5K, Optimized: 1.7K`
`subber`: `Original wasm size: 28.4K, Optimized: 7.4K` -> `Original wasm size: 21.5K, Optimized: 2.9K`
`adder`: `Original wasm size: 28.4K, Optimized: 7.4K` -> `Original wasm size: 21.5K, Optimized: 2.9K`

I think it is better to remove it to track the actual size of these contracts.
CI fails with that change due to a strange error. I think it is related to caching, so created that PR separately. Hope you will find the reason=)