### PR TITLE
Rename `EcdsaRecover` ➔ `EcdsaRecovery`

### DIFF
--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -92,7 +92,7 @@ define_error_codes! {
     /// recording was disabled.
     LoggingDisabled = 9,
     /// ECDSA pubkey recovery failed. Most probably wrong recovery id or signature.
-    EcdsaRecoverFailed = 11,
+    EcdsaRecoveryFailed = 11,
 }
 
 /// The raw return code returned by the host side.
@@ -423,7 +423,7 @@ impl Engine {
                 *output = pub_key.serialize();
                 Ok(())
             }
-            Err(_) => Err(Error::EcdsaRecoverFailed),
+            Err(_) => Err(Error::EcdsaRecoveryFailed),
         }
     }
 }

--- a/crates/env/src/engine/experimental_off_chain/impls.rs
+++ b/crates/env/src/engine/experimental_off_chain/impls.rs
@@ -111,7 +111,7 @@ impl From<ext::Error> for crate::Error {
             ext::Error::CodeNotFound => Self::CodeNotFound,
             ext::Error::NotCallable => Self::NotCallable,
             ext::Error::LoggingDisabled => Self::LoggingDisabled,
-            ext::Error::EcdsaRecoverFailed => Self::EcdsaRecoverFailed,
+            ext::Error::EcdsaRecoveryFailed => Self::EcdsaRecoveryFailed,
         }
     }
 }
@@ -285,7 +285,7 @@ impl EnvBackend for EnvInstance {
                 *output = pub_key.serialize();
                 Ok(())
             }
-            Err(_) => Err(Error::EcdsaRecoverFailed),
+            Err(_) => Err(Error::EcdsaRecoveryFailed),
         }
     }
 

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -231,7 +231,7 @@ impl EnvBackend for EnvInstance {
                 *output = pub_key.serialize();
                 Ok(())
             }
-            Err(_) => Err(Error::EcdsaRecoverFailed),
+            Err(_) => Err(Error::EcdsaRecoveryFailed),
         }
     }
 

--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -79,7 +79,7 @@ define_error_codes! {
     /// recording was disabled.
     LoggingDisabled = 9,
     /// ECDSA pubkey recovery failed. Most probably wrong recovery id or signature.
-    EcdsaRecoverFailed = 11,
+    EcdsaRecoveryFailed = 11,
 }
 
 /// Thin-wrapper around a `u32` representing a pointer for Wasm32.

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -108,7 +108,7 @@ impl From<ext::Error> for Error {
             ext::Error::CodeNotFound => Self::CodeNotFound,
             ext::Error::NotCallable => Self::NotCallable,
             ext::Error::LoggingDisabled => Self::LoggingDisabled,
-            ext::Error::EcdsaRecoverFailed => Self::EcdsaRecoverFailed,
+            ext::Error::EcdsaRecoveryFailed => Self::EcdsaRecoveryFailed,
         }
     }
 }

--- a/crates/env/src/error.rs
+++ b/crates/env/src/error.rs
@@ -50,7 +50,7 @@ pub enum Error {
     /// recording was disabled.
     LoggingDisabled,
     /// ECDSA pubkey recovery failed. Most probably wrong recovery id or signature.
-    EcdsaRecoverFailed,
+    EcdsaRecoveryFailed,
 }
 
 /// A result of environmental operations.

--- a/crates/lang/src/env_access.rs
+++ b/crates/lang/src/env_access.rs
@@ -821,7 +821,7 @@ where
     ///     let failed_result = self.env().ecdsa_recover(&signature, &[0; 32]);
     ///     assert!(failed_result.is_err());
     ///     if let Err(e) = failed_result {
-    ///         assert_eq!(e, ink_env::Error::EcdsaRecoverFailed);
+    ///         assert_eq!(e, ink_env::Error::EcdsaRecoveryFailed);
     ///     }
     /// }
     /// #
@@ -836,6 +836,6 @@ where
         let mut output = [0; 33];
         ink_env::ecdsa_recover(signature, message_hash, &mut output)
             .map(|_| output.into())
-            .map_err(|_| Error::EcdsaRecoverFailed)
+            .map_err(|_| Error::EcdsaRecoveryFailed)
     }
 }


### PR DESCRIPTION
@ascjones I'm also thinking about if we should rename `ink_env::ecdsa_recover(…)` to something like `ink_env::ecdsa_recovery(…)` or `ink_env::recover_ecdsa(…)`. What does the native speaker say?