### PR TITLE
Do not include `libsecp256k1` on Windows

### DIFF
--- a/crates/eth_compatibility/Cargo.toml
+++ b/crates/eth_compatibility/Cargo.toml
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 [dependencies]
 ink_env = { version = "3.0.0-rc7", path = "../env", default-features = false }
 
-[target.'cfg(not(target_arch = "windows"))'.dependencies]
+[target.'cfg(not(target_os = "windows"))'.dependencies]
 # We do not include `libsecp256k1` on Windows, since it's incompatible.
 # We have https://github.com/paritytech/ink/issues/1068 for removing
 # this dependency altogether.

--- a/crates/eth_compatibility/Cargo.toml
+++ b/crates/eth_compatibility/Cargo.toml
@@ -16,6 +16,11 @@ include = ["Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 ink_env = { version = "3.0.0-rc7", path = "../env", default-features = false }
+
+[target.'cfg(not(target_arch = "windows"))'.dependencies]
+# We do not include `libsecp256k1` on Windows, since it's incompatible.
+# We have https://github.com/paritytech/ink/issues/1068 for removing
+# this dependency altogether.
 libsecp256k1 = { version = "0.7.0", default-features = false }
 
 [features]

--- a/crates/eth_compatibility/src/lib.rs
+++ b/crates/eth_compatibility/src/lib.rs
@@ -95,7 +95,7 @@ impl ECDSAPublicKey {
     // which is incompatible with Windows.
     // We have https://github.com/paritytech/ink/issues/1068 for removing this
     // dependency altogether.
-    #[cfg(not(target_arch = "windows"))]
+    #[cfg(not(target_os = "windows"))]
     pub fn to_eth_address(&self) -> EthereumAddress {
         use ink_env::hash;
         use libsecp256k1::PublicKey;

--- a/crates/eth_compatibility/src/lib.rs
+++ b/crates/eth_compatibility/src/lib.rs
@@ -91,6 +91,11 @@ impl ECDSAPublicKey {
     ///
     /// assert_eq!(pub_key.to_eth_address().as_ref(), EXPECTED_ETH_ADDRESS.as_ref());
     /// ```
+    // We do not include this function on Windows, since it depends on `libsecp256k1`,
+    // which is incompatible with Windows.
+    // We have https://github.com/paritytech/ink/issues/1068 for removing this
+    // dependency altogether.
+    #[cfg(not(target_arch = "windows"))]
     pub fn to_eth_address(&self) -> EthereumAddress {
         use ink_env::hash;
         use libsecp256k1::PublicKey;


### PR DESCRIPTION
Fixes the broken `cargo-contract` Windows CI. See https://github.com/paritytech/ink/issues/1068 for more details.

CI fails due to expected incompatible ink! with `substrate-contracts-node` since the deposit PR merge.