### PR TITLE
Make Vector usable when initialized with `SpreadAllocate`

### DIFF
--- a/crates/storage/src/alloc/tests.rs
+++ b/crates/storage/src/alloc/tests.rs
@@ -158,7 +158,7 @@ fn spread_pull_push_works() {
 }
 
 #[test]
-#[should_panic(expected = "encountered empty storage cell")]
+#[should_panic(expected = "index is out of bounds")]
 fn spread_clear_works() {
     run_default_test(|| {
         let alloc = spread_layout_alloc_setup();

--- a/crates/storage/src/collections/binary_heap/tests.rs
+++ b/crates/storage/src/collections/binary_heap/tests.rs
@@ -229,8 +229,10 @@ fn spread_layout_clear_works() {
         // loading another instance from this storage will panic since the
         // heap's length property cannot read a value:
         SpreadLayout::clear_spread(&heap1, &mut KeyPtr::from(root_key));
-        let _ =
+        let instance =
             <BinaryHeap<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        instance.len();
+
         Ok(())
     })
     .unwrap()
@@ -266,8 +268,12 @@ fn drop_works() {
         .expect("Used cells must be returned");
         assert_eq!(used_cells, 0);
 
-        let _ =
+        // We try and grab the length from storage, but it doesn't exist anymore
+        // so this will panic
+        let instance =
             <BinaryHeap<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        instance.len();
+
         Ok(())
     })
     .unwrap()
@@ -300,8 +306,12 @@ fn drop_works() {
         .expect("Used cells must be returned");
         assert_eq!(used_cells, 0);
 
-        let _ =
+        // We try and grab the length from storage, but it doesn't exist anymore
+        // so this will panic
+        let instance =
             <BinaryHeap<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        instance.len();
+
         Ok(())
     })
     .unwrap()

--- a/crates/storage/src/collections/bitstash/tests.rs
+++ b/crates/storage/src/collections/bitstash/tests.rs
@@ -138,7 +138,7 @@ fn spread_layout_push_pull_works() {
 }
 
 #[test]
-#[should_panic(expected = "encountered empty storage cell")]
+#[should_panic(expected = "index is out of bounds")]
 fn spread_layout_clear_works() {
     ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
         let default = filled_bitstash();
@@ -155,9 +155,9 @@ fn spread_layout_clear_works() {
             <BitStash as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
         // We have to prevent calling its destructor since that would also panic but
         // in an uncontrollable way.
-        let mut invalid = core::mem::ManuallyDrop::new(invalid);
+        let invalid = core::mem::ManuallyDrop::new(invalid);
         // Now interact with invalid instance.
-        let _ = invalid.put();
+        invalid.get(0);
         Ok(())
     })
     .unwrap()

--- a/crates/storage/src/collections/bitvec/tests.rs
+++ b/crates/storage/src/collections/bitvec/tests.rs
@@ -207,13 +207,18 @@ fn spread_layout_clear_works() {
         SpreadLayout::clear_spread(&bv1, &mut KeyPtr::from(root_key));
 
         let len_result = std::panic::catch_unwind(|| {
-            let instance = <StorageBitvec as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+            let instance =
+                <StorageBitvec as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
             let _ = crate::Lazy::get(&instance.len);
         });
-        assert!(len_result.is_err(), "Length shouldn't be in storage at this point.");
+        assert!(
+            len_result.is_err(),
+            "Length shouldn't be in storage at this point."
+        );
 
         // In practice we wouldn't get the raw `len` field though, so no panic occurs
-        let instance = <StorageBitvec as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        let instance =
+            <StorageBitvec as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
         assert!(instance.is_empty());
 
         Ok(())

--- a/crates/storage/src/collections/bitvec/tests.rs
+++ b/crates/storage/src/collections/bitvec/tests.rs
@@ -205,7 +205,17 @@ fn spread_layout_clear_works() {
         // loading another instance from this storage will panic since the
         // vector's length property cannot read a value:
         SpreadLayout::clear_spread(&bv1, &mut KeyPtr::from(root_key));
-        let _ = <StorageBitvec as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+
+        let len_result = std::panic::catch_unwind(|| {
+            let instance = <StorageBitvec as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+            let _ = crate::Lazy::get(&instance.len);
+        });
+        assert!(len_result.is_err(), "Length shouldn't be in storage at this point.");
+
+        // In practice we wouldn't get the raw `len` field though, so no panic occurs
+        let instance = <StorageBitvec as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        assert!(instance.is_empty());
+
         Ok(())
     })
     .unwrap()

--- a/crates/storage/src/collections/vec/mod.rs
+++ b/crates/storage/src/collections/vec/mod.rs
@@ -197,7 +197,7 @@ where
             "cannot push more elements into the storage vector"
         );
         let last_index = self.len();
-        *self.len += 1;
+        Lazy::set(&mut self.len, last_index + 1);
         self.elems.put(last_index, Some(value));
     }
 
@@ -387,7 +387,7 @@ where
             return None
         }
         let last_index = self.len() - 1;
-        *self.len = last_index;
+        Lazy::set(&mut self.len, last_index);
         self.elems.put_get(last_index, None)
     }
 
@@ -404,7 +404,7 @@ where
             return None
         }
         let last_index = self.len() - 1;
-        *self.len = last_index;
+        Lazy::set(&mut self.len, last_index);
         self.elems.put(last_index, None);
         Some(())
     }
@@ -481,7 +481,7 @@ where
         let last_index = self.len() - 1;
         let last = self.elems.put_get(last_index, None);
         self.elems.put(n, last);
-        *self.len = last_index;
+        Lazy::set(&mut self.len, last_index);
         Some(())
     }
 
@@ -513,6 +513,6 @@ where
         for index in 0..self.len() {
             self.elems.put(index, None);
         }
-        *self.len = 0;
+        Lazy::set(&mut self.len, 0);
     }
 }

--- a/crates/storage/src/collections/vec/mod.rs
+++ b/crates/storage/src/collections/vec/mod.rs
@@ -91,7 +91,7 @@ where
 
     /// Returns the number of elements in the vector, also referred to as its length.
     pub fn len(&self) -> u32 {
-        *self.len
+        *Lazy::try_get(&self.len).unwrap_or(&0)
     }
 
     /// Returns `true` if the vector contains no elements.

--- a/crates/storage/src/collections/vec/tests.rs
+++ b/crates/storage/src/collections/vec/tests.rs
@@ -632,3 +632,82 @@ fn drop_works() {
     })
     .unwrap()
 }
+
+#[test]
+fn spread_allocate_drop_works() -> ink_env::Result<()> {
+    use crate::traits::{
+        KeyPtr,
+        SpreadAllocate,
+    };
+
+    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+        let setup_result = std::panic::catch_unwind(|| {
+            let root_key = Key::from([0x42; 32]);
+            let mut key_ptr = KeyPtr::from(root_key);
+            let instance =
+                <StorageVec<u8> as SpreadAllocate>::allocate_spread(&mut key_ptr);
+            drop(instance)
+        });
+
+        assert!(setup_result.is_ok());
+
+        Ok(())
+    })
+}
+
+#[test]
+fn spread_allocate_push_works() -> ink_env::Result<()> {
+    use crate::traits::{
+        KeyPtr,
+        SpreadAllocate,
+    };
+
+    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+        let setup_result = std::panic::catch_unwind(|| {
+            let root_key = Key::from([0x42; 32]);
+            let mut key_ptr = KeyPtr::from(root_key);
+            let mut instance =
+                <StorageVec<u8> as SpreadAllocate>::allocate_spread(&mut key_ptr);
+            instance.push(1u8);
+            dbg!(&instance);
+        });
+
+        assert!(setup_result.is_ok());
+
+        Ok(())
+    })
+}
+
+#[test]
+fn spread_allocate_vector_works() -> ink_env::Result<()> {
+    use crate::traits::{
+        KeyPtr,
+        SpreadAllocate,
+    };
+
+    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+        let root_key = Key::from([0x42; 32]);
+        let mut key_ptr = KeyPtr::from(root_key);
+        let mut instance =
+        <StorageVec<u8> as SpreadAllocate>::allocate_spread(&mut key_ptr);
+
+        instance.push(1);
+        assert_eq!(instance.pop(), Some(1));
+
+        instance.push(2);
+        assert!(instance.pop_drop().is_some());
+
+        instance.push(3);
+        assert!(instance.swap_remove_drop(0).is_some());
+
+        instance.push(4);
+        assert!(instance.set(0, 5).is_ok());
+
+        instance.clear();
+        assert!(instance.is_empty());
+
+        dbg!(&instance);
+
+        Ok(())
+    })
+}

--- a/crates/storage/src/collections/vec/tests.rs
+++ b/crates/storage/src/collections/vec/tests.rs
@@ -389,13 +389,19 @@ fn spread_layout_clear_works() {
         SpreadLayout::clear_spread(&vec1, &mut KeyPtr::from(root_key));
 
         let len_result = std::panic::catch_unwind(|| {
-            let instance = <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+            let instance = <StorageVec<u8> as SpreadLayout>::pull_spread(
+                &mut KeyPtr::from(root_key),
+            );
             let _ = Lazy::get(&instance.len);
         });
-        assert!(len_result.is_err(), "Length shouldn't be in storage at this point.");
+        assert!(
+            len_result.is_err(),
+            "Length shouldn't be in storage at this point."
+        );
 
         // In practice we wouldn't get the raw `len` field though, so no panic occurs
-        let instance = <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        let instance =
+            <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
         assert!(instance.is_empty());
 
         Ok(())
@@ -569,13 +575,19 @@ fn drop_works() {
         assert_eq!(used_cells, 0);
 
         let len_result = std::panic::catch_unwind(|| {
-            let instance = <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+            let instance = <StorageVec<u8> as SpreadLayout>::pull_spread(
+                &mut KeyPtr::from(root_key),
+            );
             let _ = Lazy::get(&instance.len);
         });
-        assert!(len_result.is_err(), "Length shouldn't be in storage at this point.");
+        assert!(
+            len_result.is_err(),
+            "Length shouldn't be in storage at this point."
+        );
 
         // In practice we wouldn't get the raw `len` field though, so no panic occurs
-        let instance = <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        let instance =
+            <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
         assert!(instance.is_empty());
 
         Ok(())
@@ -704,7 +716,7 @@ fn spread_allocate_vector_works() -> ink_env::Result<()> {
         let root_key = Key::from([0x42; 32]);
         let mut key_ptr = KeyPtr::from(root_key);
         let mut instance =
-        <StorageVec<u8> as SpreadAllocate>::allocate_spread(&mut key_ptr);
+            <StorageVec<u8> as SpreadAllocate>::allocate_spread(&mut key_ptr);
 
         instance.push(1);
         assert_eq!(instance.pop(), Some(1));

--- a/crates/storage/src/collections/vec/tests.rs
+++ b/crates/storage/src/collections/vec/tests.rs
@@ -672,6 +672,9 @@ fn drop_works() {
     .unwrap()
 }
 
+// We explicitly test that `Drop` works here since there was a bug in which a `StorageVec`
+// initialized with `SpreadAllocate` would panic on `Drop` due to an empty storage cell
+// for its length.
 #[test]
 fn spread_allocate_drop_works() -> ink_env::Result<()> {
     use crate::traits::{
@@ -686,29 +689,6 @@ fn spread_allocate_drop_works() -> ink_env::Result<()> {
             let instance =
                 <StorageVec<u8> as SpreadAllocate>::allocate_spread(&mut key_ptr);
             drop(instance)
-        });
-
-        assert!(setup_result.is_ok());
-
-        Ok(())
-    })
-}
-
-#[test]
-fn spread_allocate_push_works() -> ink_env::Result<()> {
-    use crate::traits::{
-        KeyPtr,
-        SpreadAllocate,
-    };
-
-    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
-        let setup_result = std::panic::catch_unwind(|| {
-            let root_key = Key::from([0x42; 32]);
-            let mut key_ptr = KeyPtr::from(root_key);
-            let mut instance =
-                <StorageVec<u8> as SpreadAllocate>::allocate_spread(&mut key_ptr);
-            instance.push(1u8);
-            dbg!(&instance);
         });
 
         assert!(setup_result.is_ok());
@@ -744,8 +724,6 @@ fn spread_allocate_vector_works() -> ink_env::Result<()> {
 
         instance.clear();
         assert!(instance.is_empty());
-
-        dbg!(&instance);
 
         Ok(())
     })

--- a/crates/storage/src/collections/vec/tests.rs
+++ b/crates/storage/src/collections/vec/tests.rs
@@ -629,7 +629,6 @@ fn storage_is_cleared_completely_after_pull_lazy() {
 }
 
 #[test]
-#[should_panic(expected = "encountered empty storage cell")]
 #[cfg(feature = "ink-experimental-engine")]
 fn drop_works() {
     ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
@@ -653,8 +652,21 @@ fn drop_works() {
         .expect("used cells must be returned");
         assert_eq!(used_cells, 0);
 
-        let _ =
+        let len_result = std::panic::catch_unwind(|| {
+            let instance = <StorageVec<u8> as SpreadLayout>::pull_spread(
+                &mut KeyPtr::from(root_key),
+            );
+            let _ = Lazy::get(&instance.len);
+        });
+        assert!(
+            len_result.is_err(),
+            "Length shouldn't be in storage at this point."
+        );
+
+        // In practice we wouldn't get the raw `len` field though, so no panic occurs
+        let instance =
             <StorageVec<u8> as SpreadLayout>::pull_spread(&mut KeyPtr::from(root_key));
+        assert!(instance.is_empty());
         Ok(())
     })
     .unwrap()

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -157,6 +157,17 @@ where
         lazy.cell.get().expect("encountered empty storage cell")
     }
 
+    /// Attempts to load a shared reference to a value in storage.
+    ///
+    /// If there is no value to load `None` is returned.
+    ///
+    /// This method may be useful in situations where a data structure has been
+    /// initialized with `SpreadAllocate`, but nothing has been written to its
+    /// storage yet.
+    pub fn try_get(lazy: &Self) -> Option<&T> {
+        lazy.cell.get()
+    }
+
     /// Returns an exclusive reference to the lazily loaded value.
     ///
     /// # Note


### PR DESCRIPTION
At the moment the `ink_storage::Vec` type is unusable when initialized using
`SpreadAllocate::allocate_spread`. This is because `Vec::len` does not account that the
vector can be in a state where the it is initialized but there is nothing in storage.

This creates problems when using `Vec::len`, such as during `Drop` ([see here](https://github.com/paritytech/ink/blob/708717bc7e874f6c5393c922a9bd3b4d10878fc9/crates/storage/src/collections/vec/mod.rs#L123)),
or `Vec::push`.

This PR changes the behaviour of `Vec::len()` to return a `0` length if there is no
length in storage. It also changes all uses of `Lazy::get_mut` for modifying `Vec.len` to
use `Lazy::set` instead since that doesn't panic if no item exists in storage.

Currently a draft since there are some other storage data structures which use `Vec`
whose tests need to be updated and I'm not quite sure what the best way to fix those
tests is just yet.
