### PR TITLE
Re-export `initialize_contract` function

### DIFF
--- a/crates/lang/src/lib.rs
+++ b/crates/lang/src/lib.rs
@@ -20,7 +20,13 @@ pub mod result_info;
 
 #[cfg_attr(not(feature = "show-codegen-docs"), doc(hidden))]
 pub mod codegen;
-pub use codegen::initialize_contract;
+
+/// Utility functions for contract development.
+pub mod utils {
+    // We want to expose this function without making users go through
+    // the `codgen` module
+    pub use super::codegen::initialize_contract;
+}
 
 pub mod reflect;
 

--- a/crates/lang/src/lib.rs
+++ b/crates/lang/src/lib.rs
@@ -20,6 +20,7 @@ pub mod result_info;
 
 #[cfg_attr(not(feature = "show-codegen-docs"), doc(hidden))]
 pub mod codegen;
+pub use codegen::initialize_contract;
 
 pub mod reflect;
 

--- a/crates/lang/tests/ui/contract/pass/example-erc20-works.rs
+++ b/crates/lang/tests/ui/contract/pass/example-erc20-works.rs
@@ -58,7 +58,7 @@ mod erc20 {
         /// Creates a new ERC-20 contract with the specified initial supply.
         #[ink(constructor)]
         pub fn new(initial_supply: Balance) -> Self {
-            ink_lang::codegen::initialize_contract(|contract| {
+            ink_lang::utils::initialize_contract(|contract| {
                 Self::new_init(contract, initial_supply)
             })
         }

--- a/crates/lang/tests/ui/contract/pass/example-erc721-works.rs
+++ b/crates/lang/tests/ui/contract/pass/example-erc721-works.rs
@@ -79,7 +79,7 @@ mod erc721 {
         pub fn new() -> Self {
             // This call is required in order to correctly initialize the
             // `Mapping`s of our contract.
-            ink_lang::codegen::initialize_contract(|_| {})
+            ink_lang::utils::initialize_contract(|_| {})
         }
 
         /// Returns the balance of the owner.

--- a/examples/dns/lib.rs
+++ b/examples/dns/lib.rs
@@ -85,7 +85,9 @@ mod dns {
         /// Creates a new domain name service contract.
         #[ink(constructor)]
         pub fn new() -> Self {
-            ink_lang::codegen::initialize_contract(|contract: &mut Self| {
+            // This call is required in order to correctly initialize the
+            // `Mapping`s of our contract.
+            ink_lang::initialize_contract(|contract: &mut Self| {
                 contract.default_address = Default::default();
             })
         }

--- a/examples/dns/lib.rs
+++ b/examples/dns/lib.rs
@@ -87,7 +87,7 @@ mod dns {
         pub fn new() -> Self {
             // This call is required in order to correctly initialize the
             // `Mapping`s of our contract.
-            ink_lang::initialize_contract(|contract: &mut Self| {
+            ink_lang::utils::initialize_contract(|contract: &mut Self| {
                 contract.default_address = Default::default();
             })
         }

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -272,7 +272,7 @@ mod erc1155 {
             // `Mapping`s of our contract.
             //
             // Not that `token_id_nonce` will be initialized to its `Default` value.
-            ink_lang::codegen::initialize_contract(|_| {})
+            ink_lang::initialize_contract(|_| {})
         }
 
         /// Create the initial supply for a token.

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -272,7 +272,7 @@ mod erc1155 {
             // `Mapping`s of our contract.
             //
             // Not that `token_id_nonce` will be initialized to its `Default` value.
-            ink_lang::initialize_contract(|_| {})
+            ink_lang::utils::initialize_contract(|_| {})
         }
 
         /// Create the initial supply for a token.

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -60,7 +60,9 @@ mod erc20 {
         /// Creates a new ERC-20 contract with the specified initial supply.
         #[ink(constructor)]
         pub fn new(initial_supply: Balance) -> Self {
-            ink_lang::codegen::initialize_contract(|contract| {
+            // This call is required in order to correctly initialize the
+            // `Mapping`s of our contract.
+            ink_lang::initialize_contract(|contract| {
                 Self::new_init(contract, initial_supply)
             })
         }

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -62,7 +62,7 @@ mod erc20 {
         pub fn new(initial_supply: Balance) -> Self {
             // This call is required in order to correctly initialize the
             // `Mapping`s of our contract.
-            ink_lang::initialize_contract(|contract| {
+            ink_lang::utils::initialize_contract(|contract| {
                 Self::new_init(contract, initial_supply)
             })
         }

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -131,7 +131,7 @@ mod erc721 {
         pub fn new() -> Self {
             // This call is required in order to correctly initialize the
             // `Mapping`s of our contract.
-            ink_lang::codegen::initialize_contract(|_| {})
+            ink_lang::utils::initialize_contract(|_| {})
         }
 
         /// Returns the balance of the owner.

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -281,7 +281,7 @@ mod multisig {
         /// If `requirement` violates our invariant.
         #[ink(constructor)]
         pub fn new(requirement: u32, mut owners: Vec<AccountId>) -> Self {
-            ink_lang::codegen::initialize_contract(|contract: &mut Self| {
+            ink_lang::utils::initialize_contract(|contract: &mut Self| {
                 owners.sort_unstable();
                 owners.dedup();
                 ensure_requirement_is_valid(owners.len() as u32, requirement);

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -97,7 +97,7 @@ mod erc20 {
         /// Creates a new ERC-20 contract with the specified initial supply.
         #[ink(constructor)]
         pub fn new(initial_supply: Balance) -> Self {
-            ink_lang::codegen::initialize_contract(|contract| {
+            ink_lang::utils::initialize_contract(|contract| {
                 Self::new_init(contract, initial_supply)
             })
         }


### PR DESCRIPTION
I don't think users should be accessing stuff from the `codegen` module directly, so this
PR re-exports `initialize_contract` so it can be used from the `ink_lang` module instead.
