### PR TITLE
Streamline terminology to "instantiation" (instead of "deployment")

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ cargo contract build
 
 You should now have an `<name>.contract` file in the `target` folder of the contract.
 
-For information on how to instantiate this file to a chain, please have a look at the [Play with It](#play-with-it) section or our [smart contracts workshop](https://docs.substrate.io/tutorials/v3/ink-workshop/pt1).
+For information on how to upload this file to a chain, please have a look at the [Play with It](#play-with-it) section or our [smart contracts workshop](https://docs.substrate.io/tutorials/v3/ink-workshop/pt1).
 
 
 ## How it Works

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ More relevant links:
 * Talk to us on [Element][k2] or in [Discord][l2]
   on the [`ink_smart-contracts`](https://discord.com/channels/722223075629727774/765280480609828864) channel
 * [`cargo-contract`](https://github.com/paritytech/cargo-contract) ‒ CLI tool for ink! contracts
-* [Canvas UI](https://paritytech.github.io/canvas-ui/#/upload) ‒ Frontend for contract deployment and interaction
+* [Canvas UI](https://paritytech.github.io/canvas-ui/#/upload) ‒ Frontend for contract instantiation and interaction
 * [Substrate Contracts Node](https://github.com/paritytech/substrate-contracts-node) ‒ Simple Substrate blockchain which includes smart contract functionality
 
 
@@ -68,12 +68,12 @@ It's a simple Substrate blockchain which includes the Substrate module for smart
 
 We also have a live testnet on [Rococo](https://github.com/paritytech/cumulus/#rococo-crown)
 called [Canvas](https://github.com/paritytech/canvas/). Canvas is a Substrate based
-parachain which supports ink! smart contracts. For further instructions on testing with
-the Canvas deployment on Rococo, follow the instructions in the
+parachain which supports ink! smart contracts. For further instructions on using this
+testnet, follow the instructions in the
 [Canvas README](https://github.com/paritytech/canvas#rococo-deployment).
 
 For both types of chains the [Canvas UI](https://paritytech.github.io/canvas-ui/#/upload)
-can be used to deploy your contract to a chain and interact with it.
+can be used to instantiate your contract to a chain and interact with it.
 
 ## Usage
 
@@ -105,7 +105,7 @@ cargo +nightly contract build
 ```
 
 As a result you'll get a file `target/flipper.wasm` file, a `metadata.json` file and a `<contract-name>.contract` file in the `target` folder of your contract.
-The `.contract` file combines the Wasm and metadata into one file and needs to be used when deploying the contract.
+The `.contract` file combines the Wasm and metadata into one file and needs to be used when instantiating the contract.
 
 
 ## Hello, World! ‒ The Flipper
@@ -194,7 +194,7 @@ cargo contract build
 
 You should now have an `<name>.contract` file in the `target` folder of the contract.
 
-For information on how to deploy this to a chain, please have a look at the [Play with It](#play-with-it) section or our [smart contracts workshop](https://docs.substrate.io/tutorials/v3/ink-workshop/pt1).
+For information on how to instantiate this file to a chain, please have a look at the [Play with It](#play-with-it) section or our [smart contracts workshop](https://docs.substrate.io/tutorials/v3/ink-workshop/pt1).
 
 
 ## How it Works

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -108,7 +108,7 @@ pub fn selector_bytes(input: TokenStream) -> TokenStream {
 /// - on-chain mode: `no_std` and WebAssembly as target
 /// - off-chain mode: `std`
 ///
-/// We generally use the on-chain mode for actual smart contract deployment
+/// We generally use the on-chain mode for actual smart contract instantiation
 /// whereas we use the off-chain mode for smart contract testing using the
 /// off-chain environment provided by the `ink_env` crate.
 ///

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,7 @@ To build a single example and generate the contracts Wasm file, navigate to the 
 `cargo contract build`
 
 You should now have an optimized `<contract-name>.wasm` file, a `metadata.json` file and a `<contract-name>.contract` file in the `target` folder of your contract.
-The `.contract` file combines the Wasm and metadata into one file and can be used for deployment.
+The `.contract` file combines the Wasm and metadata into one file and can be used for instantiation.
 
 ## License
 

--- a/examples/delegator/lib.rs
+++ b/examples/delegator/lib.rs
@@ -46,7 +46,7 @@ mod delegator {
     ///
     /// # Note
     ///
-    /// In order to deploy the `delegator` smart contract we first
+    /// In order to instantiate the `delegator` smart contract we first
     /// have to manually put the code of the `accumulator`, `adder`
     /// and `subber` smart contracts, receive their code hashes from
     /// the signalled events and put their code hash into our

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -62,7 +62,7 @@ macro_rules! ensure {
 ///
 /// The interface is defined here: <https://eips.ethereum.org/EIPS/eip-1155>.
 ///
-/// The goal of ERC-1155 is to allow a single deployed contract to manage a variety of assets.
+/// The goal of ERC-1155 is to allow a single contract to manage a variety of assets.
 /// These assets can be fungible, non-fungible, or a combination.
 ///
 /// By tracking multiple assets the ERC-1155 standard is able to support batch transfers, which
@@ -280,9 +280,9 @@ mod erc1155 {
         /// The initial supply will be provided to the caller (a.k.a the minter), and the
         /// `token_id` will be assigned by the smart contract.
         ///
-        /// Note that as implemented anyone can create tokens. If you were to deploy this to a
-        /// production environment you'd probably want to lock down the addresses that are allowed
-        /// to create tokens.
+        /// Note that as implemented anyone can create tokens. If you were to instantiate
+        /// this contract in a production environment you'd probably want to lock down
+        /// the addresses that are allowed to create tokens.
         #[ink(message)]
         pub fn create(&mut self, value: Balance) -> TokenId {
             let caller = self.env().caller();
@@ -308,9 +308,9 @@ mod erc1155 {
         /// It is assumed that the token has already been `create`-ed. The newly minted supply will
         /// be assigned to the caller (a.k.a the minter).
         ///
-        /// Note that as implemented anyone can mint tokens. If you were to deploy this to a
-        /// production environment you'd probably want to lock down the addresses that are allowed
-        /// to mint tokens.
+        /// Note that as implemented anyone can mint tokens. If you were to instantiate
+        /// this contract in a production environment you'd probably want to lock down
+        /// the addresses that are allowed to mint tokens.
         #[ink(message)]
         pub fn mint(&mut self, token_id: TokenId, value: Balance) -> Result<()> {
             ensure!(token_id <= self.token_id_nonce, Error::UnexistentToken);

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -328,7 +328,7 @@ mod erc20 {
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
                     .expect("Cannot get accounts");
-            // Alice owns all the tokens on deployment
+            // Alice owns all the tokens on contract instantiation
             assert_eq!(erc20.balance_of(accounts.alice), 100);
             // Bob does not owns tokens
             assert_eq!(erc20.balance_of(accounts.bob), 0);
@@ -649,7 +649,7 @@ mod erc20 {
             );
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
-            // Alice owns all the tokens on deployment
+            // Alice owns all the tokens on contract instantiation
             assert_eq!(erc20.balance_of(accounts.alice), 100);
             // Bob does not owns tokens
             assert_eq!(erc20.balance_of(accounts.bob), 0);

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -366,7 +366,7 @@ mod erc20 {
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
                     .expect("Cannot get accounts");
-            // Alice owns all the tokens on deployment
+            // Alice owns all the tokens on contract instantiation
             assert_eq!(erc20.balance_of(accounts.alice), 100);
             // Bob does not owns tokens
             assert_eq!(erc20.balance_of(accounts.bob), 0);


### PR DESCRIPTION
There are some more mentions regarding "deploy", but those are in dev comments regarding the `fn deploy()`, hence I've left them as is.