### PR TITLE
Use compile time checks for `blake2` hashes

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -20,7 +20,7 @@ derive_more = { version = "0.99", default-features = false, features = ["from", 
 
 sha2 = { version = "0.10" }
 sha3 = { version = "0.10" }
-blake2 = { version = "0.9" }
+blake2 = { version = "0.10" }
 
 # ECDSA for the off-chain environment.
 secp256k1 = { version = "0.20.3", features = ["recovery"] }

--- a/crates/engine/src/hashing.rs
+++ b/crates/engine/src/hashing.rs
@@ -16,13 +16,18 @@
 
 /// Helper routine implementing variable size BLAKE2b hash computation.
 fn blake2b_var(size: usize, input: &[u8], output: &mut [u8]) {
-    use blake2::digest::{
+    use ::blake2::digest::{
         Update as _,
         VariableOutput as _,
     };
-    let mut blake2 = blake2::VarBlake2b::new_keyed(&[], size);
+
+    let mut blake2 = blake2::Blake2bVar::new(size).expect(
+        "The provided `size` is bigger than the maximum `OutputSize` for `Blake2Var` (32-bytes).",
+    );
     blake2.update(input);
-    blake2.finalize_variable(|result| output.copy_from_slice(result));
+    blake2.finalize_variable(output).expect(
+        "The provided `output` size does not match the hasher (`Blake2Var`) output size.",
+    );
 }
 
 /// Conduct the BLAKE2 256-bit hash and place the result into `output`.

--- a/crates/engine/src/hashing.rs
+++ b/crates/engine/src/hashing.rs
@@ -14,30 +14,34 @@
 
 //! Implementations of supported cryptographic hash functions.
 
-/// Helper routine implementing variable size BLAKE2b hash computation.
-fn blake2b_var(size: usize, input: &[u8], output: &mut [u8]) {
-    use ::blake2::digest::{
-        Update as _,
-        VariableOutput as _,
-    };
-
-    let mut blake2 = blake2::Blake2bVar::new(size).expect(
-        "The provided `size` is bigger than the maximum `OutputSize` for `Blake2Var` (32-bytes).",
-    );
-    blake2.update(input);
-    blake2.finalize_variable(output).expect(
-        "The provided `output` size does not match the hasher (`Blake2Var`) output size.",
-    );
-}
-
 /// Conduct the BLAKE2 256-bit hash and place the result into `output`.
 pub fn blake2b_256(input: &[u8], output: &mut [u8; 32]) {
-    blake2b_var(32, input, output)
+    use ::blake2::digest::{
+        consts::U32,
+        Digest as _,
+    };
+
+    type Blake2b256 = ::blake2::Blake2b<U32>;
+
+    let mut blake2 = Blake2b256::new();
+    blake2.update(input);
+    let result = blake2.finalize();
+    output.copy_from_slice(&result);
 }
 
 /// Conduct the BLAKE2 128-bit hash and place the result into `output`.
 pub fn blake2b_128(input: &[u8], output: &mut [u8; 16]) {
-    blake2b_var(16, input, output)
+    use ::blake2::digest::{
+        consts::U16,
+        Digest as _,
+    };
+
+    type Blake2b128 = ::blake2::Blake2b<U16>;
+
+    let mut blake2 = Blake2b128::new();
+    blake2.update(input);
+    let result = blake2.finalize();
+    output.copy_from_slice(&result);
 }
 
 /// Conduct the KECCAK 256-bit hash and place the result into `output`.

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -37,7 +37,7 @@ ink_engine = { version = "3.0.0-rc7", path = "../engine/", default-features = fa
 # Hashes for the off-chain environment.
 sha2 = { version = "0.10", optional = true }
 sha3 = { version = "0.10", optional = true }
-blake2 = { version = "0.9", optional = true }
+blake2 = { version = "0.10", optional = true }
 
 # ECDSA for the off-chain environment.
 secp256k1 = { version = "0.20.3", features = ["recovery"] }

--- a/crates/env/src/engine/off_chain/hashing.rs
+++ b/crates/env/src/engine/off_chain/hashing.rs
@@ -20,9 +20,14 @@ fn blake2b_var(size: usize, input: &[u8], output: &mut [u8]) {
         Update as _,
         VariableOutput as _,
     };
-    let mut blake2 = blake2::VarBlake2b::new_keyed(&[], size);
+
+    let mut blake2 = blake2::Blake2bVar::new(size).expect(
+        "The provided `size` is bigger than the maximum `OutputSize` for `Blake2Var` (32-bytes).",
+    );
     blake2.update(input);
-    blake2.finalize_variable(|result| output.copy_from_slice(result));
+    blake2.finalize_variable(output).expect(
+        "The provided `output` size does not match the hasher (`Blake2Var`) output size.",
+    );
 }
 
 /// Conduct the BLAKE-2 256-bit hash and place the result into `output`.

--- a/crates/env/src/engine/off_chain/hashing.rs
+++ b/crates/env/src/engine/off_chain/hashing.rs
@@ -14,30 +14,34 @@
 
 //! Implementations of supported cryptographic hash functions.
 
-/// Helper routine implementing variable size BLAKE-2b hash computation.
-fn blake2b_var(size: usize, input: &[u8], output: &mut [u8]) {
-    use ::blake2::digest::{
-        Update as _,
-        VariableOutput as _,
-    };
-
-    let mut blake2 = blake2::Blake2bVar::new(size).expect(
-        "The provided `size` is bigger than the maximum `OutputSize` for `Blake2Var` (32-bytes).",
-    );
-    blake2.update(input);
-    blake2.finalize_variable(output).expect(
-        "The provided `output` size does not match the hasher (`Blake2Var`) output size.",
-    );
-}
-
 /// Conduct the BLAKE-2 256-bit hash and place the result into `output`.
 pub fn blake2b_256(input: &[u8], output: &mut [u8; 32]) {
-    blake2b_var(32, input, output)
+    use ::blake2::digest::{
+        consts::U32,
+        Digest as _,
+    };
+
+    type Blake2b128 = ::blake2::Blake2b<U32>;
+
+    let mut blake2 = Blake2b128::new();
+    blake2.update(input);
+    let result = blake2.finalize();
+    output.copy_from_slice(&result);
 }
 
 /// Conduct the BLAKE-2 128-bit hash and place the result into `output`.
 pub fn blake2b_128(input: &[u8], output: &mut [u8; 16]) {
-    blake2b_var(16, input, output)
+    use ::blake2::digest::{
+        consts::U16,
+        Digest as _,
+    };
+
+    type Blake2b128 = ::blake2::Blake2b<U16>;
+
+    let mut blake2 = Blake2b128::new();
+    blake2.update(input);
+    let result = blake2.finalize();
+    output.copy_from_slice(&result);
 }
 
 /// Conduct the KECCAK 256-bit hash and place the result into `output`.

--- a/crates/lang/codegen/Cargo.toml
+++ b/crates/lang/codegen/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro2 = "1.0"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 itertools = "0.10"
 either = { version = "1.5", default-features = false }
-blake2 = "0.9"
+blake2 = "0.10"
 heck = "0.3.1"
 scale = { package = "parity-scale-codec", version = "2.3", default-features = false, features = ["derive", "full"] }
 impl-serde = "0.3.1"

--- a/crates/lang/ir/Cargo.toml
+++ b/crates/lang/ir/Cargo.toml
@@ -23,7 +23,7 @@ syn = { version = "1.0", features = ["parsing", "full", "visit", "extra-traits"]
 proc-macro2 = "1.0"
 itertools = { version = "0.10", default-features = false }
 either = { version = "1.5", default-features = false }
-blake2 = "0.9"
+blake2 = "0.10"
 
 [features]
 default = ["std"]

--- a/crates/lang/ir/src/ir/blake2.rs
+++ b/crates/lang/ir/src/ir/blake2.rs
@@ -22,9 +22,14 @@ pub fn blake2b_256(input: &[u8], output: &mut [u8; 32]) {
         Update as _,
         VariableOutput as _,
     };
-    let mut blake2 = blake2::VarBlake2b::new_keyed(&[], 32);
+
+    let mut blake2 = blake2::Blake2bVar::new(32).expect(
+        "The maximum `OutputSize` for `Blake2bVar` is 32-bytes, so this must succeed.",
+    );
     blake2.update(input);
-    blake2.finalize_variable(|result| output.copy_from_slice(result));
+    blake2.finalize_variable(output).expect(
+        "The function signature requires that the output is 32-bytes, so this must succeed.",
+    );
 }
 
 /// Computes the BLAKE2b-256 bit hash of a string or byte string literal.

--- a/crates/lang/ir/src/ir/blake2.rs
+++ b/crates/lang/ir/src/ir/blake2.rs
@@ -19,17 +19,16 @@ use syn::spanned::Spanned as _;
 /// Computes the BLAKE-2b 256-bit hash for the given input and stores it in output.
 pub fn blake2b_256(input: &[u8], output: &mut [u8; 32]) {
     use ::blake2::digest::{
-        Update as _,
-        VariableOutput as _,
+        consts::U32,
+        Digest as _,
     };
 
-    let mut blake2 = blake2::Blake2bVar::new(32).expect(
-        "The maximum `OutputSize` for `Blake2bVar` is 32-bytes, so this must succeed.",
-    );
+    type Blake2b256 = ::blake2::Blake2b<U32>;
+
+    let mut blake2 = Blake2b256::new();
     blake2.update(input);
-    blake2.finalize_variable(output).expect(
-        "The function signature requires that the output is 32-bytes, so this must succeed.",
-    );
+    let result = blake2.finalize();
+    output.copy_from_slice(&result);
 }
 
 /// Computes the BLAKE2b-256 bit hash of a string or byte string literal.


### PR DESCRIPTION
This supersedes #1072, which updates the `blake2` crate from `v0.9` to `v0.10`. While
resolving some of the conflicts I realized that we could have some of the
variable-sized hashing checks at compile time instead of at runtime. Figured it would be
good to get more eyes on this than having it lost in a `dependabot` PR.
