### PR TITLE
Clean up after each Windows example build

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -77,6 +77,7 @@ jobs:
            foreach ($example in Get-ChildItem  -Directory "examples\*") {
                echo "Processing example: $example";
                cargo contract ${{ matrix.job }} --verbose --manifest-path=$example/Cargo.toml;
+               cargo clean --manifest-path=$example/Cargo.toml;
            }
 
       - name: ${{ matrix.job }} examples on ${{ matrix.platform }}-${{ matrix.toolchain }}


### PR DESCRIPTION
The intention is to free up space, since our GHA runners
use up all available space after building a couple examples.