### PR TITLE
Make constructor of `contract-transfer` example `payable`

### DIFF
--- a/examples/contract-transfer/lib.rs
+++ b/examples/contract-transfer/lib.rs
@@ -14,7 +14,7 @@ pub mod give_me {
 
     impl GiveMe {
         /// Creates a new instance of this contract.
-        #[ink(constructor)]
+        #[ink(constructor, payable)]
         pub fn new() -> Self {
             Self {}
         }


### PR DESCRIPTION
Follow-up to https://github.com/paritytech/ink/pull/1065.