### PR TITLE
Allow `non_camel_case_types` for EventBase ident

### DIFF
--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -88,6 +88,7 @@ impl<'a> Events<'a> {
         let base_event_ident =
             proc_macro2::Ident::new("__ink_EventBase", Span::call_site());
         quote! {
+            #[allow(non_camel_case_types)]
             #[derive(::scale::Encode, ::scale::Decode)]
             pub enum #base_event_ident {
                 #( #event_idents(#event_idents), )*


### PR DESCRIPTION
Small PR to stop `rust-analyzer` from complaining when it expands the macros in the
example contracts.
