### PR TITLE
Debug events

### DIFF
--- a/crates/engine/src/test_api.rs
+++ b/crates/engine/src/test_api.rs
@@ -24,7 +24,7 @@ use crate::{
 use std::collections::HashMap;
 
 /// Record for an emitted event.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EmittedEvent {
     /// Recorded topics of the emitted event.
     pub topics: Vec<Vec<u8>>,

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -38,6 +38,7 @@ use crate::{
     Result,
 };
 use ink_primitives::Key;
+use static_assertions::_core::fmt::Debug;
 
 /// Returns the address of the caller of the executed contract.
 ///
@@ -174,7 +175,7 @@ where
 pub fn emit_event<T, Event>(event: Event)
 where
     T: Environment,
-    Event: Topics + scale::Encode,
+    Event: Topics + scale::Encode + Debug,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         TypedEnvBackend::emit_event::<T, Event>(instance, event)

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -27,6 +27,7 @@ use crate::{
     Result,
 };
 use ink_primitives::Key;
+use static_assertions::_core::fmt::Debug;
 
 /// The flags to indicate further information about the end of a contract execution.
 #[derive(Default)]
@@ -357,7 +358,7 @@ pub trait TypedEnvBackend: EnvBackend {
     fn emit_event<T, Event>(&mut self, event: Event)
     where
         T: Environment,
-        Event: Topics + scale::Encode;
+        Event: Topics + scale::Encode + Debug;
 
     /// Invokes a contract message.
     ///

--- a/crates/env/src/engine/experimental_off_chain/test_api.rs
+++ b/crates/env/src/engine/experimental_off_chain/test_api.rs
@@ -27,7 +27,7 @@ use ink_engine::test_api::RecordedDebugMessages;
 use std::panic::UnwindSafe;
 
 /// Record for an emitted event.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EmittedEvent {
     /// Recorded topics of the emitted event.
     pub topics: Vec<Vec<u8>>,

--- a/crates/env/src/engine/off_chain/db/events.rs
+++ b/crates/env/src/engine/off_chain/db/events.rs
@@ -26,6 +26,7 @@ use crate::{
     Clear,
     Environment,
 };
+use core::fmt::Debug;
 
 #[derive(Default)]
 pub struct TopicsBuilder {
@@ -83,7 +84,7 @@ impl EmittedEvent {
     pub fn new<T, E>(emitted_event: E) -> Self
     where
         T: Environment,
-        E: Topics + scale::Encode,
+        E: Topics + scale::Encode + Debug,
     {
         let topics = emitted_event.topics::<T, _>(TopicsBuilder::default().into());
         Self {
@@ -115,7 +116,7 @@ impl EmittedEventsRecorder {
     pub fn record<T, E>(&mut self, new_event: E)
     where
         T: Environment,
-        E: Topics + scale::Encode,
+        E: Topics + scale::Encode + Debug,
     {
         self.emitted_events
             .push(EmittedEvent::new::<T, E>(new_event));

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -39,10 +39,12 @@ use crate::{
     ReturnFlags,
     TypedEnvBackend,
 };
-use core::convert::TryInto;
+use core::{
+    convert::TryInto,
+    fmt::Debug,
+};
 use ink_primitives::Key;
 use num_traits::Bounded;
-use core::fmt::Debug;
 
 const UNINITIALIZED_EXEC_CONTEXT: &str = "uninitialized execution context: \
 a possible source of error could be that you are using `#[test]` instead of `#[ink::test]`.";

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -42,6 +42,7 @@ use crate::{
 use core::convert::TryInto;
 use ink_primitives::Key;
 use num_traits::Bounded;
+use core::fmt::Debug;
 
 const UNINITIALIZED_EXEC_CONTEXT: &str = "uninitialized execution context: \
 a possible source of error could be that you are using `#[test]` instead of `#[ink::test]`.";
@@ -403,7 +404,7 @@ impl TypedEnvBackend for EnvInstance {
     fn emit_event<T, Event>(&mut self, new_event: Event)
     where
         T: Environment,
-        Event: Topics + scale::Encode,
+        Event: Topics + scale::Encode + Debug,
     {
         self.emitted_events.record::<T, Event>(new_event)
     }

--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -88,7 +88,7 @@ impl<'a> Events<'a> {
         let base_event_ident =
             proc_macro2::Ident::new("__ink_EventBase", Span::call_site());
         quote! {
-            #[derive(::scale::Encode, ::scale::Decode)]
+            #[derive(::scale::Encode, ::scale::Decode, Debug)]
             pub enum #base_event_ident {
                 #( #event_idents(#event_idents), )*
             }

--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -89,7 +89,7 @@ impl<'a> Events<'a> {
             proc_macro2::Ident::new("__ink_EventBase", Span::call_site());
         quote! {
             #[allow(non_camel_case_types)]
-            #[derive(::scale::Encode, ::scale::Decode, Debug)]
+            #[derive(::scale::Encode, ::scale::Decode, ::core::fmt::Debug)]
             pub enum #base_event_ident {
                 #( #event_idents(#event_idents), )*
             }

--- a/crates/lang/ir/src/ir/item/event.rs
+++ b/crates/lang/ir/src/ir/item/event.rs
@@ -229,6 +229,7 @@ mod tests {
     #[test]
     fn simple_try_from_works() {
         let item_struct: syn::ItemStruct = syn::parse_quote! {
+            #[derive(Debug)]
             #[ink(event)]
             pub struct MyEvent {
                 #[ink(topic)]
@@ -250,6 +251,7 @@ mod tests {
     fn conflicting_struct_attributes_fails() {
         assert_try_from_fails(
             syn::parse_quote! {
+                #[derive(Debug)]
                 #[ink(event)]
                 #[ink(storage)]
                 pub struct MyEvent {
@@ -266,6 +268,7 @@ mod tests {
     fn duplicate_struct_attributes_fails() {
         assert_try_from_fails(
             syn::parse_quote! {
+                #[derive(Debug)]
                 #[ink(event)]
                 #[ink(event)]
                 pub struct MyEvent {
@@ -282,6 +285,7 @@ mod tests {
     fn wrong_first_struct_attribute_fails() {
         assert_try_from_fails(
             syn::parse_quote! {
+                #[derive(Debug)]
                 #[ink(storage)]
                 #[ink(event)]
                 pub struct MyEvent {
@@ -298,6 +302,7 @@ mod tests {
     fn missing_storage_attribute_fails() {
         assert_try_from_fails(
             syn::parse_quote! {
+                #[derive(Debug)]
                 pub struct MyEvent {
                     #[ink(topic)]
                     field_1: i32,
@@ -342,6 +347,7 @@ mod tests {
     fn duplicate_field_attributes_fails() {
         assert_try_from_fails(
             syn::parse_quote! {
+                #[derive(Debug)]
                 #[ink(event)]
                 pub struct MyEvent {
                     #[ink(topic)]
@@ -358,6 +364,7 @@ mod tests {
     fn invalid_field_attributes_fails() {
         assert_try_from_fails(
             syn::parse_quote! {
+                #[derive(Debug)]
                 #[ink(event)]
                 pub struct MyEvent {
                     #[ink(message)]
@@ -373,6 +380,7 @@ mod tests {
     fn conflicting_field_attributes_fails() {
         assert_try_from_fails(
             syn::parse_quote! {
+                #[derive(Debug)]
                 #[ink(event)]
                 pub struct MyEvent {
                     #[ink(topic)]
@@ -431,6 +439,7 @@ mod tests {
             ),
         ];
         let input = <Event as TryFrom<syn::ItemStruct>>::try_from(syn::parse_quote! {
+            #[derive(Debug)]
             #[ink(event)]
             pub struct MyEvent {
                 #[ink(topic)]
@@ -461,6 +470,7 @@ mod tests {
             }
         }
         assert_anonymous_event(syn::parse_quote! {
+            #[derive(Debug)]
             #[ink(event)]
             #[ink(anonymous)]
             pub struct MyEvent {
@@ -470,6 +480,7 @@ mod tests {
             }
         });
         assert_anonymous_event(syn::parse_quote! {
+            #[derive(Debug)]
             #[ink(event, anonymous)]
             pub struct MyEvent {
                 #[ink(topic)]

--- a/crates/lang/ir/src/ir/item/tests.rs
+++ b/crates/lang/ir/src/ir/item/tests.rs
@@ -32,6 +32,7 @@ fn simple_storage_works() {
 #[test]
 fn simple_event_works() {
     let event_struct: syn::Item = syn::parse_quote! {
+        #[derive(Debug)]
         #[ink(event)]
         pub struct MyEvent {
             #[ink(topic)]

--- a/crates/lang/ir/src/ir/item_mod.rs
+++ b/crates/lang/ir/src/ir/item_mod.rs
@@ -50,6 +50,7 @@ use syn::{
 ///         /* storage fields */
 ///     }
 ///
+///     #[derive(Debug)]
 ///     #[ink(event)]
 ///     pub struct MyEvent {
 ///         /* event fields */

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -503,6 +503,7 @@ pub fn selector_bytes(input: TokenStream) -> TokenStream {
 /// #[ink::contract]
 /// mod erc20 {
 ///     /// Defines an event that is emitted every time value is transferred.
+///     #[derive(Debug)]
 ///     #[ink(event)]
 ///     pub struct Transferred {
 ///         from: Option<AccountId>,

--- a/crates/lang/src/codegen/event/topics.rs
+++ b/crates/lang/src/codegen/event/topics.rs
@@ -59,6 +59,7 @@ where
 pub trait RespectTopicLimit<const N: usize> {}
 
 /// Represents an the amount of topics for an ink! event definition.
+#[derive(Debug)]
 pub struct EventTopics<const N: usize>;
 
 macro_rules! impl_is_smaller_or_equals {

--- a/crates/lang/src/reflect/event.rs
+++ b/crates/lang/src/reflect/event.rs
@@ -26,9 +26,11 @@
 ///     #[ink(storage)]
 ///     pub struct Contract {}
 ///
+///     #[derive(Debug)]
 ///     #[ink(event)]
 ///     pub struct Event1 {}
 ///
+///     #[derive(Debug)]
 ///     #[ink(event)]
 ///     pub struct Event2 {}
 ///

--- a/crates/lang/tests/unique_topics.rs
+++ b/crates/lang/tests/unique_topics.rs
@@ -43,7 +43,6 @@ mod my_contract {
         }
 
         /// Emits a `MyEvent`.
-        #[derive(Debug)]
         #[ink(message)]
         pub fn emit_my_event(&self) {
             self.env().emit_event(MyEvent {

--- a/crates/lang/tests/unique_topics.rs
+++ b/crates/lang/tests/unique_topics.rs
@@ -22,6 +22,7 @@ mod my_contract {
     pub struct MyContract {}
 
     /// Exemplary event
+    #[derive(Debug)]
     #[ink(event)]
     pub struct MyEvent {
         #[ink(topic)]
@@ -42,6 +43,7 @@ mod my_contract {
         }
 
         /// Emits a `MyEvent`.
+        #[derive(Debug)]
         #[ink(message)]
         pub fn emit_my_event(&self) {
             self.env().emit_event(MyEvent {

--- a/examples/dns/lib.rs
+++ b/examples/dns/lib.rs
@@ -13,6 +13,7 @@ mod dns {
     };
 
     /// Emitted whenever a new name is being registered.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Register {
         #[ink(topic)]
@@ -22,6 +23,7 @@ mod dns {
     }
 
     /// Emitted whenever an address changes.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct SetAddress {
         #[ink(topic)]
@@ -34,6 +36,7 @@ mod dns {
     }
 
     /// Emitted whenever a name is being transferred.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Transfer {
         #[ink(topic)]

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -199,6 +199,7 @@ mod erc1155 {
     /// Indicate that a token transfer has occured.
     ///
     /// This must be emitted even if a zero value transfer occurs.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct TransferSingle {
         #[ink(topic)]
@@ -212,6 +213,7 @@ mod erc1155 {
     }
 
     /// Indicate that an approval event has happened.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct ApprovalForAll {
         #[ink(topic)]
@@ -222,6 +224,7 @@ mod erc1155 {
     }
 
     /// Indicate that a token's URI has been updated.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Uri {
         value: ink_prelude::string::String,

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -26,6 +26,7 @@ mod erc20 {
     }
 
     /// Event emitted when a token transfer occurs.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Transfer {
         #[ink(topic)]
@@ -37,6 +38,7 @@ mod erc20 {
 
     /// Event emitted when an approval occurs that `spender` is allowed to withdraw
     /// up to the amount of `value` tokens from `owner`.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Approval {
         #[ink(topic)]

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -93,6 +93,7 @@ mod erc721 {
     }
 
     /// Event emitted when a token transfer occurs.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Transfer {
         #[ink(topic)]
@@ -104,6 +105,7 @@ mod erc721 {
     }
 
     /// Event emitted when a token approve occurs.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Approval {
         #[ink(topic)]
@@ -116,6 +118,7 @@ mod erc721 {
 
     /// Event emitted when an operator is enabled or disabled for an owner.
     /// The operator can manage all NFTs of the owner.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct ApprovalForAll {
         #[ink(topic)]

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -103,7 +103,7 @@ mod multisig {
     #[derive(scale::Encode, scale::Decode, Clone, Copy, SpreadLayout, PackedLayout)]
     #[cfg_attr(
         feature = "std",
-        derive(scale_info::TypeInfo, ink_storage::traits::StorageLayout)
+        derive(scale_info::TypeInfo, ink_storage::traits::StorageLayout, Debug)
     )]
     pub enum ConfirmationStatus {
         /// The transaction is already confirmed.

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -169,6 +169,7 @@ mod multisig {
     }
 
     /// Emitted when an owner confirms a transaction.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Confirmation {
         /// The transaction that was confirmed.
@@ -183,6 +184,7 @@ mod multisig {
     }
 
     /// Emitted when an owner revoked a confirmation.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Revokation {
         /// The transaction that was revoked.
@@ -194,6 +196,7 @@ mod multisig {
     }
 
     /// Emitted when an owner submits a transaction.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Submission {
         /// The transaction that was submitted.
@@ -202,6 +205,7 @@ mod multisig {
     }
 
     /// Emitted when a transaction was canceled.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Cancelation {
         /// The transaction that was canceled.
@@ -210,6 +214,7 @@ mod multisig {
     }
 
     /// Emitted when a transaction was executed.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Execution {
         /// The transaction that was executed.
@@ -223,6 +228,7 @@ mod multisig {
     }
 
     /// Emitted when an owner is added to the wallet.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct OwnerAddition {
         /// The owner that was added.
@@ -231,6 +237,7 @@ mod multisig {
     }
 
     /// Emitted when an owner is removed from the wallet.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct OwnerRemoval {
         /// The owner that was removed.
@@ -239,6 +246,7 @@ mod multisig {
     }
 
     /// Emitted when the requirement changed.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct RequirementChange {
         /// The new requirement value.

--- a/examples/rand-extension/lib.rs
+++ b/examples/rand-extension/lib.rs
@@ -64,6 +64,7 @@ mod rand_extension {
         value: [u8; 32],
     }
 
+    #[derive(Debug)]
     #[ink(event)]
     pub struct RandomUpdated {
         #[ink(topic)]

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -74,6 +74,7 @@ mod erc20 {
     }
 
     /// Event emitted when a token transfer occurs.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Transfer {
         #[ink(topic)]
@@ -86,6 +87,7 @@ mod erc20 {
 
     /// Event emitted when an approval occurs that `spender` is allowed to withdraw
     /// up to the amount of `value` tokens from `owner`.
+    #[derive(Debug)]
     #[ink(event)]
     pub struct Approval {
         #[ink(topic)]


### PR DESCRIPTION
When debugging contracts it can be helpful to be able to print events in unit tests. This PR allows events to be debug printed and decorates all instances of event with `Debug` in the code base.