### PR TITLE
Add `get_owner()` msg to *DNS* contract

### DIFF
--- a/examples/dns/lib.rs
+++ b/examples/dns/lib.rs
@@ -156,6 +156,12 @@ mod dns {
             self.get_address_or_default(name)
         }
 
+        /// Get owner of specific name.
+        #[ink(message)]
+        pub fn get_owner(&self, name: Hash) -> AccountId {
+            self.get_owner_or_default(name)
+        }
+
         /// Returns the owner given the hash or the default address.
         fn get_owner_or_default(&self, name: Hash) -> AccountId {
             self.name_to_owner


### PR DESCRIPTION
As domain name is a tradable entity, there should be a way to get its current owner in a UI-friendly way, to ensure that the seller (which could be a contract) owns the domain being sold.

For that, `get_owner()` message is proposed. 

**Case study**:

Let say a domain name is being put on a [candle auction](https://github.com/agryaznov/candle-auction-ink). Before trading starts, the domain owner should transfer the domain to the auction contract instance. Bidders need some method to check that the auction contract has the ownership of the domain in question. For that, they would use this `get_owner()` message.   