### PR TITLE
Correctly calculate internal fragmentation in Bump allocator tests

### DIFF
--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -433,13 +433,8 @@ mod fuzz_tests {
             let current_page_limit = PAGE_SIZE * required_pages(inner.next).unwrap();
             let is_too_big_for_current_page = inner.next + size > current_page_limit;
 
-            if is_too_big_for_current_page && inner.next != 0 {
-                let fragmented_in_current_page = if current_page_limit % inner.next == 0 {
-                    current_page_limit - inner.next
-                } else {
-                    current_page_limit % inner.next
-                };
-
+            if is_too_big_for_current_page {
+                let fragmented_in_current_page = current_page_limit - inner.next;
                 total_bytes_fragmented += fragmented_in_current_page;
 
                 // We expect our next allocation to be aligned to the start of the next page


### PR DESCRIPTION
Closes #1098.

The issue here wasn't actually with the bump allocator, but instead with one of the
calculations used by the fuzz tests.

It looks like I wasn't correctly calculating the number of bytes fragmented when
allocating across page boundaries. I can't remember what scenario I was trying to cover
with the `%` codepath (which is what we were hitting in #1098), but it doesn't seem
necessary.

I've ran the fuzz tests locally in a loop for like an hour and nothing's failed yet, but
I guess the CI will (eventually) alert us if I'm wrong, haha.

### Footnote

Just as a quick footnote, here's the test I ran to show that the bump allocator was
working fine.

```rust
#[test]
fn can_alloc_a_quickcheck() {
    let mut inner = InnerAlloc::new();

    struct Foo {
        _foo: [u8; PAGE_SIZE - 23],
    }

    let foo_layout =
        Layout::from_size_align(size_of::<Foo>(), size_of::<usize>()).unwrap();
    let foo_aligned_size = foo_layout.pad_to_align().size();

    let allocations = vec![1, 1, 1, size_of::<Foo>()];
    let mut total_size = 0;

    for alloc in &allocations {
        let layout = Layout::from_size_align(*alloc, size_of::<usize>()).unwrap();
        assert!(inner.alloc(layout).is_some());
        total_size += layout.pad_to_align().size();
    }

    let expected_limit = PAGE_SIZE * required_pages(total_size).unwrap();
    assert_eq!(inner.upper_limit, expected_limit);

    let expected_alloc_start = PAGE_SIZE + foo_aligned_size;
    assert_eq!(inner.next, expected_alloc_start);
}
```
