### PR TITLE
Enable use of global secp256k1 context

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -23,10 +23,11 @@ sha3 = { version = "0.10" }
 blake2 = { version = "0.10" }
 
 # ECDSA for the off-chain environment.
-secp256k1 = { version = "0.21.2", features = ["recovery", "global-context"] }
+secp256k1 = { version = "0.21.2", features = ["recovery", "global-context"], optional = true }
 
 [features]
 default = ["std"]
 std = [
     "scale/std",
+    "secp256k1"
 ]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -23,7 +23,7 @@ sha3 = { version = "0.10" }
 blake2 = { version = "0.10" }
 
 # ECDSA for the off-chain environment.
-secp256k1 = { version = "0.21.2", features = ["recovery"] }
+secp256k1 = { version = "0.21.2", features = ["recovery", "global-context"] }
 
 [features]
 default = ["std"]

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -388,7 +388,7 @@ impl Engine {
         use secp256k1::{
             ecdsa::{
                 RecoverableSignature,
-                RecoveryId
+                RecoveryId,
             },
             Message,
             SECP256K1,

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -388,10 +388,10 @@ impl Engine {
         use secp256k1::{
             ecdsa::{
                 RecoverableSignature,
-                RecoveryId,
+                RecoveryId
             },
             Message,
-            Secp256k1,
+            SECP256K1,
         };
 
         // In most implementations, the v is just 0 or 1 internally, but 27 was added
@@ -414,8 +414,7 @@ impl Engine {
                     panic!("Unable to parse the signature: {}", error)
                 });
 
-        let secp = Secp256k1::new();
-        let pub_key = secp.recover_ecdsa(&message, &signature);
+        let pub_key = SECP256K1.recover_ecdsa(&message, &signature);
         match pub_key {
             Ok(pub_key) => {
                 *output = pub_key.serialize();

--- a/crates/engine/src/tests.rs
+++ b/crates/engine/src/tests.rs
@@ -20,7 +20,7 @@ use secp256k1::{
     ecdsa::RecoverableSignature,
     Message,
     PublicKey,
-    Secp256k1,
+    SECP256K1,
     SecretKey,
 };
 
@@ -238,7 +238,6 @@ fn ecdsa_recovery_test_from_contracts_pallet() {
 fn ecdsa_recovery_with_secp256k1_crate() {
     // given
     let mut engine = Engine::new();
-    let secp = Secp256k1::new();
     let seckey = [
         59, 148, 11, 85, 134, 130, 61, 253, 2, 174, 59, 70, 27, 180, 51, 107, 94, 203,
         174, 253, 102, 39, 170, 146, 46, 252, 4, 143, 236, 12, 136, 28,
@@ -255,7 +254,7 @@ fn ecdsa_recovery_with_secp256k1_crate() {
     let msg = Message::from_slice(&msg_hash).expect("message creation failed");
     let seckey = SecretKey::from_slice(&seckey).expect("secret key creation failed");
     let recoverable_signature: RecoverableSignature =
-        secp.sign_ecdsa_recoverable(&msg, &seckey);
+        SECP256K1.sign_ecdsa_recoverable(&msg, &seckey);
 
     let recovery_id = recoverable_signature.serialize_compact().0.to_i32() as u8;
     let mut signature = recoverable_signature.serialize_compact().1.to_vec();

--- a/crates/engine/src/tests.rs
+++ b/crates/engine/src/tests.rs
@@ -20,8 +20,8 @@ use secp256k1::{
     ecdsa::RecoverableSignature,
     Message,
     PublicKey,
-    SECP256K1,
     SecretKey,
+    SECP256K1,
 };
 
 /// The public methods of the `contracts` pallet write their result into an

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -40,7 +40,7 @@ sha3 = { version = "0.10", optional = true }
 blake2 = { version = "0.10", optional = true }
 
 # ECDSA for the off-chain environment.
-secp256k1 = { version = "0.21.2", features = ["recovery", "global-context"] }
+secp256k1 = { version = "0.21.2", features = ["recovery", "global-context"], optional = true }
 
 # Only used in the off-chain environment.
 #
@@ -60,6 +60,7 @@ std = [
     "scale/std",
     "scale-info",
     "scale-info/std",
+    "secp256k1",
     "rand",
     "rand/std",
     "rand/std_rng",

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -40,7 +40,7 @@ sha3 = { version = "0.10", optional = true }
 blake2 = { version = "0.10", optional = true }
 
 # ECDSA for the off-chain environment.
-secp256k1 = { version = "0.21.2", features = ["recovery"] }
+secp256k1 = { version = "0.21.2", features = ["recovery", "global-context"] }
 
 # Only used in the off-chain environment.
 #

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -32,7 +32,7 @@ static_assertions = "1.1"
 rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ink_engine = { version = "3.0.0-rc8", path = "../engine/", default-features = false, optional = true }
+ink_engine = { version = "3.0.0-rc8", path = "../engine/", optional = true }
 
 # Hashes for the off-chain environment.
 sha2 = { version = "0.10", optional = true }

--- a/crates/env/src/engine/experimental_off_chain/impls.rs
+++ b/crates/env/src/engine/experimental_off_chain/impls.rs
@@ -257,7 +257,7 @@ impl EnvBackend for EnvInstance {
                 RecoveryId,
             },
             Message,
-            Secp256k1,
+            SECP256K1,
         };
 
         // In most implementations, the v is just 0 or 1 internally, but 27 was added
@@ -278,8 +278,7 @@ impl EnvBackend for EnvInstance {
                     panic!("Unable to parse the signature: {}", error)
                 });
 
-        let secp = Secp256k1::new();
-        let pub_key = secp.recover_ecdsa(&message, &signature);
+        let pub_key = SECP256K1.recover_ecdsa(&message, &signature);
         match pub_key {
             Ok(pub_key) => {
                 *output = pub_key.serialize();

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -203,7 +203,7 @@ impl EnvBackend for EnvInstance {
                 RecoveryId,
             },
             Message,
-            Secp256k1,
+            SECP256K1,
         };
 
         // In most implementations, the v is just 0 or 1 internally, but 27 was added
@@ -224,8 +224,7 @@ impl EnvBackend for EnvInstance {
                     panic!("Unable to parse the signature: {}", error)
                 });
 
-        let secp = Secp256k1::new();
-        let pub_key = secp.recover_ecdsa(&message, &signature);
+        let pub_key = SECP256K1.recover_ecdsa(&message, &signature);
         match pub_key {
             Ok(pub_key) => {
                 *output = pub_key.serialize();


### PR DESCRIPTION
Context creation is expensive.

Use the preallocated context that ships with the library.

Follows from the work done for this https://github.com/paritytech/substrate/pull/10798