### PR TITLE
Add phantom markers for ink! primitives

### DIFF
--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -77,6 +77,11 @@ impl<'a> Events<'a> {
     /// Generates the base event enum that comprises all user defined events.
     /// All emitted events are converted into a variant of this enum before being
     /// serialized and emitted to apply their unique event discriminant (ID).
+    ///
+    /// # Developer Note
+    ///
+    /// The `__ink_EventBase` config attribute is used here to convey the information
+    /// that this function is an ink! constructor to `dylint`.
     fn generate_event_base(&self) -> TokenStream2 {
         let storage_ident = &self.contract.module().storage().ident();
         let event_idents = self

--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -80,8 +80,8 @@ impl<'a> Events<'a> {
     ///
     /// # Developer Note
     ///
-    /// The `__ink_EventBase` config attribute is used here to convey the information
-    /// that this function is an ink! constructor to `dylint`.
+    /// The `__ink_dylint_EventBase` config attribute is used here to convey the
+    /// information that this function is an ink! constructor to `dylint`.
     fn generate_event_base(&self) -> TokenStream2 {
         let storage_ident = &self.contract.module().storage().ident();
         let event_idents = self

--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -90,6 +90,7 @@ impl<'a> Events<'a> {
         quote! {
             #[allow(non_camel_case_types)]
             #[derive(::scale::Encode, ::scale::Decode)]
+            #[cfg(not(target_os = "__ink_EventBase"))]
             pub enum #base_event_ident {
                 #( #event_idents(#event_idents), )*
             }

--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -81,7 +81,7 @@ impl<'a> Events<'a> {
     /// # Developer Note
     ///
     /// The `__ink_dylint_EventBase` config attribute is used here to convey the
-    /// information that this function is an ink! constructor to `dylint`.
+    /// information that the generated enum is an ink! event to `dylint`.
     fn generate_event_base(&self) -> TokenStream2 {
         let storage_ident = &self.contract.module().storage().ident();
         let event_idents = self

--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -95,7 +95,7 @@ impl<'a> Events<'a> {
         quote! {
             #[allow(non_camel_case_types)]
             #[derive(::scale::Encode, ::scale::Decode)]
-            #[cfg(not(target_os = "__ink_EventBase"))]
+            #[cfg(not(feature = "__ink_EventBase"))]
             pub enum #base_event_ident {
                 #( #event_idents(#event_idents), )*
             }

--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -95,7 +95,7 @@ impl<'a> Events<'a> {
         quote! {
             #[allow(non_camel_case_types)]
             #[derive(::scale::Encode, ::scale::Decode)]
-            #[cfg(not(feature = "__ink_EventBase"))]
+            #[cfg(not(feature = "__ink_dylint_EventBase"))]
             pub enum #base_event_ident {
                 #( #event_idents(#event_idents), )*
             }

--- a/crates/lang/codegen/src/generator/item_impls.rs
+++ b/crates/lang/codegen/src/generator/item_impls.rs
@@ -230,8 +230,8 @@ impl ItemImpls<'_> {
     ///
     /// # Developer Note
     ///
-    /// The `__ink_Constructor` config attribute is used here to convey the information that
-    /// this function is an ink! constructor to `dylint`.
+    /// The `__ink_dylint_Constructor` config attribute is used here to convey the
+    /// information that this function is an ink! constructor to `dylint`.
     fn generate_inherent_constructor(constructor: &ir::Constructor) -> TokenStream2 {
         let span = constructor.span();
         let attrs = constructor.attrs();

--- a/crates/lang/codegen/src/generator/item_impls.rs
+++ b/crates/lang/codegen/src/generator/item_impls.rs
@@ -241,7 +241,7 @@ impl ItemImpls<'_> {
         let statements = constructor.statements();
         quote_spanned!(span =>
             #( #attrs )*
-            #[cfg(not(target_os = "__ink_Constructor"))]
+            #[cfg(not(feature = "__ink_Constructor"))]
             #vis fn #ident( #( #inputs ),* ) -> Self {
                 #( #statements )*
             }

--- a/crates/lang/codegen/src/generator/item_impls.rs
+++ b/crates/lang/codegen/src/generator/item_impls.rs
@@ -231,7 +231,7 @@ impl ItemImpls<'_> {
     /// # Developer Note
     ///
     /// The `__ink_dylint_Constructor` config attribute is used here to convey the
-    /// information that this function is an ink! constructor to `dylint`.
+    /// information that the generated function is an ink! constructor to `dylint`.
     fn generate_inherent_constructor(constructor: &ir::Constructor) -> TokenStream2 {
         let span = constructor.span();
         let attrs = constructor.attrs();

--- a/crates/lang/codegen/src/generator/item_impls.rs
+++ b/crates/lang/codegen/src/generator/item_impls.rs
@@ -241,7 +241,7 @@ impl ItemImpls<'_> {
         let statements = constructor.statements();
         quote_spanned!(span =>
             #( #attrs )*
-            #[cfg(not(feature = "__ink_Constructor"))]
+            #[cfg(not(feature = "__ink_dylint_Constructor"))]
             #vis fn #ident( #( #inputs ),* ) -> Self {
                 #( #statements )*
             }

--- a/crates/lang/codegen/src/generator/item_impls.rs
+++ b/crates/lang/codegen/src/generator/item_impls.rs
@@ -236,6 +236,7 @@ impl ItemImpls<'_> {
         let statements = constructor.statements();
         quote_spanned!(span =>
             #( #attrs )*
+            #[cfg(not(target_os = "__ink_Constructor"))]
             #vis fn #ident( #( #inputs ),* ) -> Self {
                 #( #statements )*
             }

--- a/crates/lang/codegen/src/generator/item_impls.rs
+++ b/crates/lang/codegen/src/generator/item_impls.rs
@@ -227,6 +227,11 @@ impl ItemImpls<'_> {
     }
 
     /// Generates the code for the given ink! constructor within an inherent implementation block.
+    ///
+    /// # Developer Note
+    ///
+    /// The `__ink_Constructor` config attribute is used here to convey the information that
+    /// this function is an ink! constructor to `dylint`.
     fn generate_inherent_constructor(constructor: &ir::Constructor) -> TokenStream2 {
         let span = constructor.span();
         let attrs = constructor.attrs();

--- a/crates/lang/codegen/src/generator/storage.rs
+++ b/crates/lang/codegen/src/generator/storage.rs
@@ -103,7 +103,7 @@ impl Storage<'_> {
             )]
             #[derive(::ink_storage::traits::SpreadLayout)]
             #[cfg_attr(test, derive(::core::fmt::Debug))]
-            #[cfg(not(target_os = "__ink_Storage"))]
+            #[cfg(not(feature = "__ink_Storage"))]
             pub struct #ident {
                 #( #fields ),*
             }

--- a/crates/lang/codegen/src/generator/storage.rs
+++ b/crates/lang/codegen/src/generator/storage.rs
@@ -88,7 +88,7 @@ impl Storage<'_> {
     /// # Developer Note
     ///
     /// The `__ink_dylint_Storage` config attribute is used here to convey the
-    /// information that this function is an ink! constructor to `dylint`.
+    /// information that the generated struct is an ink! storage struct to `dylint`.
     fn generate_storage_struct(&self) -> TokenStream2 {
         let storage = self.contract.module().storage();
         let span = storage.span();

--- a/crates/lang/codegen/src/generator/storage.rs
+++ b/crates/lang/codegen/src/generator/storage.rs
@@ -103,7 +103,7 @@ impl Storage<'_> {
             )]
             #[derive(::ink_storage::traits::SpreadLayout)]
             #[cfg_attr(test, derive(::core::fmt::Debug))]
-            #[cfg(not(feature = "__ink_Storage"))]
+            #[cfg(not(feature = "__ink_dylint_Storage"))]
             pub struct #ident {
                 #( #fields ),*
             }

--- a/crates/lang/codegen/src/generator/storage.rs
+++ b/crates/lang/codegen/src/generator/storage.rs
@@ -98,6 +98,7 @@ impl Storage<'_> {
             )]
             #[derive(::ink_storage::traits::SpreadLayout)]
             #[cfg_attr(test, derive(::core::fmt::Debug))]
+            #[cfg(not(target_os = "__ink_Storage"))]
             pub struct #ident {
                 #( #fields ),*
             }

--- a/crates/lang/codegen/src/generator/storage.rs
+++ b/crates/lang/codegen/src/generator/storage.rs
@@ -84,6 +84,11 @@ impl Storage<'_> {
     }
 
     /// Generates the storage struct definition.
+    ///
+    /// # Developer Note
+    ///
+    /// The `__ink_EventBase` config attribute is used here to convey the information
+    /// that this function is an ink! constructor to `dylint`.
     fn generate_storage_struct(&self) -> TokenStream2 {
         let storage = self.contract.module().storage();
         let span = storage.span();

--- a/crates/lang/codegen/src/generator/storage.rs
+++ b/crates/lang/codegen/src/generator/storage.rs
@@ -87,7 +87,7 @@ impl Storage<'_> {
     ///
     /// # Developer Note
     ///
-    /// The `__ink_EventBase` config attribute is used here to convey the information
+    /// The `__ink_Storage` config attribute is used here to convey the information
     /// that this function is an ink! constructor to `dylint`.
     fn generate_storage_struct(&self) -> TokenStream2 {
         let storage = self.contract.module().storage();

--- a/crates/lang/codegen/src/generator/storage.rs
+++ b/crates/lang/codegen/src/generator/storage.rs
@@ -87,8 +87,8 @@ impl Storage<'_> {
     ///
     /// # Developer Note
     ///
-    /// The `__ink_Storage` config attribute is used here to convey the information
-    /// that this function is an ink! constructor to `dylint`.
+    /// The `__ink_dylint_Storage` config attribute is used here to convey the
+    /// information that this function is an ink! constructor to `dylint`.
     fn generate_storage_struct(&self) -> TokenStream2 {
         let storage = self.contract.module().storage();
         let span = storage.span();


### PR DESCRIPTION
I'm about to add custom linting into `cargo-contract` using `dylint`. Unfortunately the way we use proc. macros currently the information that a function is e.g. an ink! constructor is not available for lint implementations.

I'm not super proud of this workaround, but `cfg` attributes are retained and accessible within a lint implementation. This hack doesn't generate any additional code and it's hidden to users. Hence I think it's justifiable to do it that way. If we find a better workaround in the future we can still change it.