### PR TITLE
Don't copy attributes to call builders

### DIFF
--- a/crates/lang/codegen/src/generator/as_dependency/call_builder.rs
+++ b/crates/lang/codegen/src/generator/as_dependency/call_builder.rs
@@ -279,7 +279,6 @@ impl CallBuilder<'_> {
             ir::Receiver::Ref => quote! { build },
             ir::Receiver::RefMut => quote! { build_mut },
         };
-        let attrs = message.attrs();
         quote_spanned!(span=>
             type #output_ident = <<<
                 Self
@@ -288,7 +287,6 @@ impl CallBuilder<'_> {
                 as #trait_path>::#output_ident;
 
             #[inline]
-            #( #attrs )*
             fn #message_ident(
                 & #mut_token self
                 #( , #input_bindings: #input_types )*
@@ -356,7 +354,6 @@ impl CallBuilder<'_> {
         let span = message.span();
         let callable = message.callable();
         let message_ident = message.ident();
-        let attrs = message.attrs();
         let selector = message.composed_selector();
         let selector_bytes = selector.hex_lits();
         let input_bindings = generator::input_bindings(callable.inputs());
@@ -380,7 +377,6 @@ impl CallBuilder<'_> {
             >
         );
         quote_spanned!(span=>
-            #( #attrs )*
             #[allow(clippy::type_complexity)]
             #[inline]
             pub fn #message_ident(

--- a/crates/lang/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/lang/codegen/src/generator/as_dependency/contract_ref.rs
@@ -332,7 +332,6 @@ impl ContractRef<'_> {
     ) -> TokenStream2 {
         use ir::Callable as _;
         let span = message.span();
-        let attrs = message.attrs();
         let storage_ident = self.contract.module().storage().ident();
         let message_ident = message.ident();
         let call_operator = match message.receiver() {
@@ -344,7 +343,6 @@ impl ContractRef<'_> {
         let input_types = message.inputs().map(|input| &input.ty).collect::<Vec<_>>();
         let output_type = message.output().map(|ty| quote! { -> #ty });
         quote_spanned!(span=>
-            #( #attrs )*
             #[inline]
             pub fn #message_ident(
                 & #mut_token self
@@ -375,14 +373,12 @@ impl ContractRef<'_> {
         constructor: ir::CallableWithSelector<ir::Constructor>,
     ) -> TokenStream2 {
         let span = constructor.span();
-        let attrs = constructor.attrs();
         let constructor_ident = constructor.ident();
         let selector_bytes = constructor.composed_selector().hex_lits();
         let input_bindings = generator::input_bindings(constructor.inputs());
         let input_types = generator::input_types(constructor.inputs());
         let arg_list = generator::generate_argument_list(input_types.iter().cloned());
         quote_spanned!(span =>
-            #( #attrs )*
             #[inline]
             #[allow(clippy::type_complexity)]
             pub fn #constructor_ident(

--- a/crates/lang/codegen/src/generator/trait_def/call_builder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_builder.rs
@@ -357,7 +357,6 @@ impl CallBuilder<'_> {
     ) -> TokenStream2 {
         let span = message.span();
         let message_ident = message.ident();
-        let attrs = message.attrs();
         let output_ident = generator::output_ident(message_ident);
         let output = message.output();
         let output_sig = output.map_or_else(
@@ -380,7 +379,6 @@ impl CallBuilder<'_> {
                 ::ink_env::call::utils::Set<#output_sig>,
             >;
 
-            #( #attrs )*
             #[inline]
             fn #message_ident(
                 & #mut_tok self

--- a/crates/lang/codegen/src/generator/trait_def/call_forwarder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_forwarder.rs
@@ -388,7 +388,6 @@ impl CallForwarder<'_> {
         let trait_ident = self.trait_def.trait_def.item().ident();
         let forwarder_ident = self.ident();
         let message_ident = message.ident();
-        let attrs = message.attrs();
         let output_ident = generator::output_ident(message_ident);
         let output_type = message
             .output()
@@ -408,7 +407,6 @@ impl CallForwarder<'_> {
         quote_spanned!(span =>
             type #output_ident = #output_type;
 
-            #( #attrs )*
             #[inline]
             fn #message_ident(
                 & #mut_tok self


### PR DESCRIPTION
The current codegen copy all attributes from the original method. But that attributes were initially added for the original function and may require some restrictions on the struct that uses these attributes.

For example, OpenBrush provides [`#[brush::modifiers]` attribute](https://github.com/Supercolony-net/openbrush-contracts#modifiers) that inserts some code before the function. 
In the case of [`when_paused`](https://github.com/Supercolony-net/openbrush-contracts/blob/main/contracts/security/pausable/mod.rs#L24) modifier, the struct should implement the `PausableStorage` trait. [That contract](https://github.com/Supercolony-net/openbrush-contracts/blob/main/examples/pausable/lib.rs#L9) derives that trait but auto-generated call builders don't derive it(and they can't because it is complicated for them). And it will cause a compilation error because call builders will try to use that modifier.

The idea of that PR is to not insert attributes from the original method for auto-generated call builders. 

Call builders are used only for cross-contract communication so they don't participate in the code logic of the contract and they don't participate in the metadata generation(ABI). So attributes like `#[doc]` is not important. 

BUT, maybe someone wants to apply some functional attributes like `clippy` or `allow` and that change will break it. So maybe we also need to think about how ink! can provide customization of attributes(which attributes should be passed to auto-generated structures and which not).