### PR TITLE
Explicitly specify the trait in the dispatching

### DIFF
--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -385,7 +385,7 @@ impl Dispatch<'_> {
 
                         const CALLABLE: fn(&mut Self::Storage, Self::Input) -> Self::Output =
                             |storage, #input_tuple_bindings| {
-                                #storage_ident::#message_ident( storage #( , #input_bindings )* )
+                                <#storage_ident as #trait_path>::#message_ident( storage #( , #input_bindings )* )
                             };
                         const SELECTOR: [::core::primitive::u8; 4usize] = #selector;
                         const PAYABLE: ::core::primitive::bool = #payable;

--- a/crates/lang/tests/ui/contract/pass/traits-messages-same-name.rs
+++ b/crates/lang/tests/ui/contract/pass/traits-messages-same-name.rs
@@ -1,0 +1,43 @@
+use ink_lang as ink;
+
+#[ink::trait_definition]
+pub trait TraitDefinition1 {
+    #[ink(message)]
+    fn message(&self);
+}
+
+#[ink::trait_definition]
+pub trait TraitDefinition2 {
+    #[ink(message)]
+    fn message(&self);
+}
+
+#[ink::contract]
+mod contract {
+    use super::{
+        TraitDefinition1,
+        TraitDefinition2,
+    };
+
+    #[ink(storage)]
+    pub struct Contract {}
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+    }
+
+    impl TraitDefinition1 for Contract {
+        #[ink(message)]
+        fn message(&self) {}
+    }
+
+    impl TraitDefinition2 for Contract {
+        #[ink(message)]
+        fn message(&self) {}
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Seems the previous implementer forget to specify the trait that should be used during call of the method of that trait in the dispatching logic.

It can cause a compilation error if two trait have the same method name.