### PR TITLE
Fix test fixtures for `nightly-2022-02-17`

### DIFF
--- a/crates/lang/tests/ui/contract/fail/event-too-many-topics-anonymous.stderr
+++ b/crates/lang/tests/ui/contract/fail/event-too-many-topics-anonymous.stderr
@@ -11,10 +11,10 @@ error[E0277]: the trait bound `EventTopics<4_usize>: RespectTopicLimit<2_usize>`
    | |_____^ the trait `RespectTopicLimit<2_usize>` is not implemented for `EventTopics<4_usize>`
    |
    = help: the following implementations were found:
-             <EventTopics<0_usize> as RespectTopicLimit<0_usize>>
-             <EventTopics<0_usize> as RespectTopicLimit<10_usize>>
-             <EventTopics<0_usize> as RespectTopicLimit<11_usize>>
-             <EventTopics<0_usize> as RespectTopicLimit<12_usize>>
+             <EventTopics<4_usize> as RespectTopicLimit<10_usize>>
+             <EventTopics<4_usize> as RespectTopicLimit<11_usize>>
+             <EventTopics<4_usize> as RespectTopicLimit<12_usize>>
+             <EventTopics<4_usize> as RespectTopicLimit<4_usize>>
            and 87 others
 note: required by a bound in `EventRespectsTopicLimit`
   --> src/codegen/event/topics.rs

--- a/crates/lang/tests/ui/contract/fail/event-too-many-topics.stderr
+++ b/crates/lang/tests/ui/contract/fail/event-too-many-topics.stderr
@@ -11,10 +11,10 @@ error[E0277]: the trait bound `EventTopics<3_usize>: RespectTopicLimit<2_usize>`
    | |_____^ the trait `RespectTopicLimit<2_usize>` is not implemented for `EventTopics<3_usize>`
    |
    = help: the following implementations were found:
-             <EventTopics<0_usize> as RespectTopicLimit<0_usize>>
-             <EventTopics<0_usize> as RespectTopicLimit<10_usize>>
-             <EventTopics<0_usize> as RespectTopicLimit<11_usize>>
-             <EventTopics<0_usize> as RespectTopicLimit<12_usize>>
+             <EventTopics<3_usize> as RespectTopicLimit<10_usize>>
+             <EventTopics<3_usize> as RespectTopicLimit<11_usize>>
+             <EventTopics<3_usize> as RespectTopicLimit<12_usize>>
+             <EventTopics<3_usize> as RespectTopicLimit<3_usize>>
            and 87 others
 note: required by a bound in `EventRespectsTopicLimit`
   --> src/codegen/event/topics.rs


### PR DESCRIPTION
Two UI tests are broken with the latest nightly: https://gitlab.parity.io/parity/ink/-/jobs/1390520#L852.