### PR TITLE
Remove redundant setting of `std` feature in `Cargo.toml`'s

### DIFF
--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -52,16 +52,13 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 [features]
 default = ["std"]
 std = [
-    "ink_metadata",
     "ink_metadata/std",
     "ink_allocator/std",
     "ink_prelude/std",
     "ink_primitives/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
     "secp256k1",
-    "rand",
     "rand/std",
     "rand/std_rng",
     "num-traits/std",

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -37,7 +37,6 @@ scale-info = { version = "2", default-features = false, features = ["derive"] }
 [features]
 default = ["std"]
 std = [
-    "ink_metadata",
     "ink_metadata/std",
     "ink_prelude/std",
     "ink_primitives/std",

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -38,13 +38,11 @@ ink_lang = { version = "3.0.0-rc8", path = "../lang/", default-features = false 
 [features]
 default = ["std"]
 std = [
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_prelude/std",
     "ink_primitives/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-fuzz-tests = ["std"]

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -23,13 +23,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -24,13 +24,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -27,13 +27,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 
     "adder/std",

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -28,13 +28,11 @@ crate-type = [
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -30,13 +30,11 @@ crate-type = [
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 
     "accumulator/std",

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -30,13 +30,11 @@ crate-type = [
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 
     "accumulator/std",

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -23,13 +23,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -24,14 +24,12 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "ink_prelude/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -23,13 +23,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -23,13 +23,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -23,13 +23,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -23,13 +23,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -23,7 +23,6 @@ crate-type = ["cdylib"]
 [features]
 default = ["std"]
 std = [
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
@@ -31,7 +30,6 @@ std = [
     "ink_primitives/std",
     "ink_prelude/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -28,13 +28,11 @@ overflow-checks = false
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -27,7 +27,6 @@ std = [
     "ink_storage/std",
     "ink_primitives/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -23,13 +23,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -23,13 +23,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []

--- a/examples/trait-incrementer/Cargo.toml
+++ b/examples/trait-incrementer/Cargo.toml
@@ -23,13 +23,11 @@ crate-type = ["cdylib"]
 default = ["std"]
 std = [
     "ink_primitives/std",
-    "ink_metadata",
     "ink_metadata/std",
     "ink_env/std",
     "ink_storage/std",
     "ink_lang/std",
     "scale/std",
-    "scale-info",
     "scale-info/std",
 ]
 ink-as-dependency = []


### PR DESCRIPTION
It's redundant and irritating, especially in the examples which people look at to understand how to build an ink! project.