### PR TITLE
Implement utility methods for experimental off-chain testing env

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -22,12 +22,15 @@ sha2 = { version = "0.10" }
 sha3 = { version = "0.10" }
 blake2 = { version = "0.10" }
 
+rand = { version = "0.8" }
+
 # ECDSA for the off-chain environment.
 secp256k1 = { version = "0.21.2", features = ["recovery", "global-context"], optional = true }
 
 [features]
 default = ["std"]
 std = [
+    "rand/std",
     "scale/std",
     "secp256k1"
 ]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -30,7 +30,6 @@ secp256k1 = { version = "0.21.2", features = ["recovery", "global-context"], opt
 [features]
 default = ["std"]
 std = [
-    "rand/std",
     "scale/std",
     "secp256k1"
 ]

--- a/crates/engine/src/exec_context.rs
+++ b/crates/engine/src/exec_context.rs
@@ -15,7 +15,11 @@
 use super::types::{
     AccountId,
     Balance,
+    BlockNumber,
+    BlockTimestamp,
+    Hash,
 };
+use rand::Rng;
 
 /// The context of a contract execution.
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
@@ -36,16 +40,27 @@ pub struct ExecContext {
     pub callee: Option<AccountId>,
     /// The value transferred to the contract as part of the call.
     pub value_transferred: Balance,
+    /// The current block number.
+    pub block_number: BlockNumber,
+    /// The current block timestamp.
+    pub block_timestamp: BlockTimestamp,
+    /// The randomization entropy for a block.
+    pub entropy: Hash,
 }
 
 #[allow(clippy::new_without_default)]
 impl ExecContext {
     /// Creates a new execution context.
     pub fn new() -> Self {
+        let mut entropy: [u8; 32] = Default::default();
+        rand::thread_rng().fill(entropy.as_mut());
         Self {
             caller: None,
             callee: None,
             value_transferred: 0,
+            block_number: 0,
+            block_timestamp: 0,
+            entropy,
         }
     }
 
@@ -63,6 +78,12 @@ impl ExecContext {
         self.caller = None;
         self.callee = None;
         self.value_transferred = Default::default();
+        self.block_number = 0;
+        self.block_timestamp = 0;
+
+        let mut entropy: [u8; 32] = Default::default();
+        rand::thread_rng().fill(entropy.as_mut());
+        self.entropy = entropy;
     }
 }
 
@@ -83,6 +104,10 @@ mod tests {
         assert_eq!(exec_cont.callee(), vec![13]);
 
         exec_cont.reset();
-        assert_eq!(exec_cont, ExecContext::new());
+        exec_cont.entropy = Default::default();
+
+        let mut new_exec_cont = ExecContext::new();
+        new_exec_cont.entropy = Default::default();
+        assert_eq!(exec_cont, new_exec_cont);
     }
 }

--- a/crates/engine/src/exec_context.rs
+++ b/crates/engine/src/exec_context.rs
@@ -48,10 +48,8 @@ pub struct ExecContext {
     pub entropy: Hash,
 }
 
-#[allow(clippy::new_without_default)]
-impl ExecContext {
-    /// Creates a new execution context.
-    pub fn new() -> Self {
+impl Default for ExecContext {
+    fn default() -> Self {
         let mut entropy: [u8; 32] = Default::default();
         rand::thread_rng().fill(entropy.as_mut());
         Self {
@@ -62,6 +60,13 @@ impl ExecContext {
             block_timestamp: 0,
             entropy,
         }
+    }
+}
+
+impl ExecContext {
+    /// Creates a new execution context.
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Returns the callee.
@@ -75,15 +80,7 @@ impl ExecContext {
 
     /// Resets the execution context
     pub fn reset(&mut self) {
-        self.caller = None;
-        self.callee = None;
-        self.value_transferred = Default::default();
-        self.block_number = 0;
-        self.block_timestamp = 0;
-
-        let mut entropy: [u8; 32] = Default::default();
-        rand::thread_rng().fill(entropy.as_mut());
-        self.entropy = entropy;
+        *self = Default::default();
     }
 }
 

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -425,12 +425,6 @@ impl Engine {
     ///   It provides the same behavior in that it will likely yield the
     ///   same hash for the same subjects within the same block (or
     ///   execution context).
-    ///
-    /// - Returned hashes on the surface might appear random, however for
-    ///   testing purposes the actual implementation is quite simple and
-    ///   computes those "random" hashes by wrapping XOR of the internal
-    ///   entry hash with the eventually repeated sequence of the subject
-    ///   buffer.
     pub fn random(&self, subject: &[u8], output: &mut &mut [u8]) {
         let seed = (self.exec_context.entropy, subject).encode();
         let mut rng = rand::rngs::StdRng::from_seed(

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -425,11 +425,21 @@ impl Engine {
     ///   It provides the same behavior in that it will likely yield the
     ///   same hash for the same subjects within the same block (or
     ///   execution context).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    ///    let engine = ink_engine::ext::Engine::default();
+    ///    let seed = [0u8; 32];
+    ///    let mut output = [0u8; 32];
+    ///    engine.random(&seed, &mut output.as_mut_slice());
+    /// ```
     pub fn random(&self, subject: &[u8], output: &mut &mut [u8]) {
         let seed = (self.exec_context.entropy, subject).encode();
-        let mut rng = rand::rngs::StdRng::from_seed(
-            seed.try_into().expect("seed must be [u8; 32]"),
-        );
+        let mut digest = [0u8; 32];
+        Engine::hash_blake2_256(&seed, &mut digest);
+
+        let mut rng = rand::rngs::StdRng::from_seed(digest);
         let mut rng_bytes: [u8; 32] = Default::default();
         rng.fill(&mut rng_bytes);
         set_output(output, &rng_bytes[..])

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -152,7 +152,7 @@ impl Default for ChainSpec {
         Self {
             gas_price: 100,
             minimum_balance: 42,
-            block_time: 5,
+            block_time: 6,
         }
     }
 }

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -430,9 +430,9 @@ impl Engine {
     ///
     /// ```rust
     ///    let engine = ink_engine::ext::Engine::default();
-    ///    let seed = [0u8; 32];
+    ///    let subject = [0u8; 32];
     ///    let mut output = [0u8; 32];
-    ///    engine.random(&seed, &mut output.as_mut_slice());
+    ///    engine.random(&subject, &mut output.as_mut_slice());
     /// ```
     pub fn random(&self, subject: &[u8], output: &mut &mut [u8]) {
         let seed = (self.exec_context.entropy, subject).encode();

--- a/crates/engine/src/test_api.rs
+++ b/crates/engine/src/test_api.rs
@@ -315,16 +315,14 @@ mod tests {
         let mut buf = [0_u8; 32];
 
         // when
-        let account_id = vec![1; 32];
-        engine.set_callee(account_id.clone());
+        engine.set_callee(vec![1; 32]);
         engine.set_storage(key, &[0x05_u8; 5]);
         engine.set_storage(key, &[0x05_u8; 6]);
-        engine.get_storage(key, &mut &mut buf[..]);
+        engine.get_storage(key, &mut &mut buf[..]).unwrap();
 
-        let account_id = vec![2; 32];
-        engine.set_callee(account_id.clone());
+        engine.set_callee(vec![2; 32]);
         engine.set_storage(key, &[0x07_u8; 7]);
-        engine.get_storage(key, &mut &mut buf[..]);
+        engine.get_storage(key, &mut &mut buf[..]).unwrap();
 
         // then
         assert_eq!(engine.count_writes(), 3);

--- a/crates/engine/src/test_api.rs
+++ b/crates/engine/src/test_api.rs
@@ -186,6 +186,16 @@ impl Engine {
         (*reads, *writes)
     }
 
+    /// Returns the total number of reads executed.
+    pub fn count_reads(&self) -> usize {
+        self.debug_info.count_reads.iter().map(|(_, v)| v).sum()
+    }
+
+    /// Returns the total number of writes executed.
+    pub fn count_writes(&self) -> usize {
+        self.debug_info.count_writes.iter().map(|(_, v)| v).sum()
+    }
+
     /// Sets a caller for the next call.
     pub fn set_caller(&mut self, caller: Vec<u8>) {
         self.exec_context.caller = Some(caller.into());
@@ -208,6 +218,12 @@ impl Engine {
                 Error::Account(AccountError::NoAccountForId(account_id.to_vec()))
             })?;
         Ok(cells.len())
+    }
+
+    /// Advances the chain by a single block.
+    pub fn advance_block(&mut self) {
+        self.exec_context.block_number += 1;
+        self.exec_context.block_timestamp += self.chain_spec.block_time;
     }
 
     /// Returns the callee, i.e. the currently executing contract.
@@ -289,5 +305,29 @@ mod tests {
 
         // then
         assert_eq!(engine.count_used_storage_cells(&account_id), Ok(0));
+    }
+
+    #[test]
+    fn count_total_writes() {
+        // given
+        let mut engine = Engine::new();
+        let key: &[u8; 32] = &[0x42; 32];
+        let mut buf = [0_u8; 32];
+
+        // when
+        let account_id = vec![1; 32];
+        engine.set_callee(account_id.clone());
+        engine.set_storage(key, &[0x05_u8; 5]);
+        engine.set_storage(key, &[0x05_u8; 6]);
+        engine.get_storage(key, &mut &mut buf[..]);
+
+        let account_id = vec![2; 32];
+        engine.set_callee(account_id.clone());
+        engine.set_storage(key, &[0x07_u8; 7]);
+        engine.get_storage(key, &mut &mut buf[..]);
+
+        // then
+        assert_eq!(engine.count_writes(), 3);
+        assert_eq!(engine.count_reads(), 2);
     }
 }

--- a/crates/engine/src/types.rs
+++ b/crates/engine/src/types.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 //! Right now the `engine` crate can only be used with the `ink_env::DefaultEnvironment`.
+//! This is a known limitation that we want to address in the future.
+//!
+//! # Developer Note
 //!
 //! In the long-term all types in this module should be `Vec<u8>`, as to not
 //! be dependent on any specific off-chain environment type. Then the `engine`
@@ -28,13 +31,13 @@ use derive_more::From;
 /// Same type as the `DefaultEnvironment::Hash` type.
 pub type Hash = [u8; 32];
 
-/// As a temporary solution we choose the same type as the `DefaultEnvironment::BlockNumber` type.
+/// Same type as the `DefaultEnvironment::BlockNumber` type.
 pub type BlockNumber = u32;
 
-/// As a temporary solution we choose the same type as the `DefaultEnvironment::BlockTimestamp` type.
+/// Same type as the `DefaultEnvironment::BlockTimestamp` type.
 pub type BlockTimestamp = u64;
 
-/// As a temporary solution we choose the same type as the `DefaultEnvironment::Balance` type.
+/// Same type as the `DefaultEnvironment::Balance` type.
 pub type Balance = u128;
 
 /// The Account Id type used by this crate.

--- a/crates/engine/src/types.rs
+++ b/crates/engine/src/types.rs
@@ -25,7 +25,7 @@
 
 use derive_more::From;
 
-/// As a temporary solution we choose the same type as the `DefaultEnvironment::Hash` type.
+/// Same type as the `DefaultEnvironment::Hash` type.
 pub type Hash = [u8; 32];
 
 /// As a temporary solution we choose the same type as the `DefaultEnvironment::BlockNumber` type.

--- a/crates/engine/src/types.rs
+++ b/crates/engine/src/types.rs
@@ -12,15 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Right now the `engine` crate can only be used with the `ink_env::DefaultEnvironment`.
+//!
+//! In the long-term all types in this module should be `Vec<u8>`, as to not
+//! be dependent on any specific off-chain environment type. Then the `engine`
+//! crate could be used with an arbitrary `Environment` configuration.
+//!
+//! Right now the issue is that if e.g. some test calls an `engine` API function
+//! to transfer some balance, then there has to be some `+` operation to the
+//! existing balance. And we can't just add a `Vec<u8>` onto another one, we
+//! need to know the type.
+
 use derive_more::From;
 
-/// This is just a temporary solution for the MVP!
-/// As a temporary solution we choose the same type as the default
-/// `env` `Balance` type.
-///
-/// In the long-term this type should be `Vec<u8>` as well, as to not
-/// be dependent on the specific off-chain environment type, so that
-/// the `engine` crate can be used with an arbitrary `Environment` configuration.
+/// As a temporary solution we choose the same type as the `DefaultEnvironment::Hash` type.
+pub type Hash = [u8; 32];
+
+/// As a temporary solution we choose the same type as the `DefaultEnvironment::BlockNumber` type.
+pub type BlockNumber = u32;
+
+/// As a temporary solution we choose the same type as the `DefaultEnvironment::BlockTimestamp` type.
+pub type BlockTimestamp = u64;
+
+/// As a temporary solution we choose the same type as the `DefaultEnvironment::Balance` type.
 pub type Balance = u128;
 
 /// The Account Id type used by this crate.

--- a/crates/engine/src/types.rs
+++ b/crates/engine/src/types.rs
@@ -14,17 +14,6 @@
 
 //! Right now the `engine` crate can only be used with the `ink_env::DefaultEnvironment`.
 //! This is a known limitation that we want to address in the future.
-//!
-//! # Developer Note
-//!
-//! In the long-term all types in this module should be `Vec<u8>`, as to not
-//! be dependent on any specific off-chain environment type. Then the `engine`
-//! crate could be used with an arbitrary `Environment` configuration.
-//!
-//! Right now the issue is that if e.g. some test calls an `engine` API function
-//! to transfer some balance, then there has to be some `+` operation to the
-//! existing balance. And we can't just add a `Vec<u8>` onto another one, we
-//! need to know the type.
 
 use derive_more::From;
 

--- a/crates/env/src/engine/experimental_off_chain/test_api.rs
+++ b/crates/env/src/engine/experimental_off_chain/test_api.rs
@@ -113,6 +113,16 @@ pub fn set_clear_storage_disabled(_disable: bool) {
     );
 }
 
+/// Advances the chain by a single block.
+pub fn advance_block<T>()
+where
+    T: Environment,
+{
+    <EnvInstance as OnInstance>::on_instance(|instance| {
+        instance.engine.advance_block();
+    })
+}
+
 /// Sets a caller for the next call.
 pub fn set_caller<T>(caller: T::AccountId)
 where


### PR DESCRIPTION
Closes https://github.com/paritytech/ink/issues/787.

Well, except an implementation for `gas_left`, because I'm uncertain what a sensible logic for that would be.

Yes, the experimental off-chain env is currently limited in that it only supports `ink_env::DefaultEnvironment`, but IMHO the situation of us currently having two off-chain testing engines in every examples is worse.

So I would like to get the experimental engine into a stage where we can throw the old one out and just use this new one by default everywhere. From my pov this PR is the last prerequisite before we can do that.