### PR TITLE
Added `keep_attr` to `#[ink::contract]` and `#[ink::trait_definition]`

### DIFF
--- a/crates/lang/codegen/src/generator/as_dependency/call_builder.rs
+++ b/crates/lang/codegen/src/generator/as_dependency/call_builder.rs
@@ -279,7 +279,11 @@ impl CallBuilder<'_> {
             ir::Receiver::Ref => quote! { build },
             ir::Receiver::RefMut => quote! { build_mut },
         };
-        let attrs = message.attrs();
+        let attrs = self
+            .contract
+            .config()
+            .whitelisted_attributes()
+            .filter_attr(message.attrs().to_vec());
         quote_spanned!(span=>
             type #output_ident = <<<
                 Self
@@ -356,7 +360,11 @@ impl CallBuilder<'_> {
         let span = message.span();
         let callable = message.callable();
         let message_ident = message.ident();
-        let attrs = message.attrs();
+        let attrs = self
+            .contract
+            .config()
+            .whitelisted_attributes()
+            .filter_attr(message.attrs().to_vec());
         let selector = message.composed_selector();
         let selector_bytes = selector.hex_lits();
         let input_bindings = generator::input_bindings(callable.inputs());

--- a/crates/lang/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/lang/codegen/src/generator/as_dependency/contract_ref.rs
@@ -332,7 +332,11 @@ impl ContractRef<'_> {
     ) -> TokenStream2 {
         use ir::Callable as _;
         let span = message.span();
-        let attrs = message.attrs();
+        let attrs = self
+            .contract
+            .config()
+            .whitelisted_attributes()
+            .filter_attr(message.attrs().to_vec());
         let storage_ident = self.contract.module().storage().ident();
         let message_ident = message.ident();
         let call_operator = match message.receiver() {
@@ -375,7 +379,11 @@ impl ContractRef<'_> {
         constructor: ir::CallableWithSelector<ir::Constructor>,
     ) -> TokenStream2 {
         let span = constructor.span();
-        let attrs = constructor.attrs();
+        let attrs = self
+            .contract
+            .config()
+            .whitelisted_attributes()
+            .filter_attr(constructor.attrs().to_vec());
         let constructor_ident = constructor.ident();
         let selector_bytes = constructor.composed_selector().hex_lits();
         let input_bindings = generator::input_bindings(constructor.inputs());

--- a/crates/lang/codegen/src/generator/trait_def/call_builder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_builder.rs
@@ -357,7 +357,12 @@ impl CallBuilder<'_> {
     ) -> TokenStream2 {
         let span = message.span();
         let message_ident = message.ident();
-        let attrs = message.attrs();
+        let attrs = self
+            .trait_def
+            .trait_def
+            .config()
+            .whitelisted_attributes()
+            .filter_attr(message.attrs());
         let output_ident = generator::output_ident(message_ident);
         let output = message.output();
         let output_sig = output.map_or_else(

--- a/crates/lang/codegen/src/generator/trait_def/call_forwarder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_forwarder.rs
@@ -388,7 +388,12 @@ impl CallForwarder<'_> {
         let trait_ident = self.trait_def.trait_def.item().ident();
         let forwarder_ident = self.ident();
         let message_ident = message.ident();
-        let attrs = message.attrs();
+        let attrs = self
+            .trait_def
+            .trait_def
+            .config()
+            .whitelisted_attributes()
+            .filter_attr(message.attrs());
         let output_ident = generator::output_ident(message_ident);
         let output_type = message
             .output()

--- a/crates/lang/ir/src/ir/config.rs
+++ b/crates/lang/ir/src/ir/config.rs
@@ -68,6 +68,9 @@ impl Default for WhitelistedAttributes {
 }
 
 impl WhitelistedAttributes {
+    /// Parses the `MetaNameValue` argument of `keep_attr` attribute. If the argument has
+    /// a correct format `"foo, bar"` then `foo`, `bar` will be included in
+    /// the whitelist of attributes. Else error about parsing will be returned.
     pub fn parse_arg_value(&mut self, arg: &MetaNameValue) -> Result<(), syn::Error> {
         return if let ast::PathOrLit::Lit(syn::Lit::Str(attributes)) = &arg.value {
             attributes.value().split(',').for_each(|attribute| {
@@ -82,6 +85,8 @@ impl WhitelistedAttributes {
         }
     }
 
+    /// Returns the filtered input vector of whitelisted attributes.
+    /// All not whitelisted attributes are removed.
     pub fn filter_attr(&self, attrs: Vec<syn::Attribute>) -> Vec<syn::Attribute> {
         attrs
             .into_iter()

--- a/crates/lang/ir/src/ir/config.rs
+++ b/crates/lang/ir/src/ir/config.rs
@@ -63,6 +63,8 @@ impl Default for WhitelistedAttributes {
             ("must_use".to_string(), ()),
             // Documentation
             ("doc".to_string(), ()),
+            // Formatting
+            ("rustfmt".to_string(), ()),
         ]))
     }
 }

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -226,7 +226,7 @@ pub fn selector_bytes(input: TokenStream) -> TokenStream {
 ///     ```
 ///
 ///     **Allowed attributes by default:** `cfg`, `cfg_attr`, `allow`, `warn`, `deny`, `forbid`,
-///         `deprecated`, `must_use`, `doc`.`
+///         `deprecated`, `must_use`, `doc`, `rustfmt`.
 ///
 /// - `env: impl Environment`
 ///
@@ -740,7 +740,7 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     ```
 ///
 ///     **Allowed attributes by default:** `cfg`, `cfg_attr`, `allow`, `warn`, `deny`, `forbid`,
-///         `deprecated`, `must_use`, `doc`.`
+///         `deprecated`, `must_use`, `doc`, `rustfmt`.
 #[proc_macro_attribute]
 pub fn trait_definition(attr: TokenStream, item: TokenStream) -> TokenStream {
     trait_def::analyze(attr.into(), item.into()).into()

--- a/crates/lang/macro/src/lib.rs
+++ b/crates/lang/macro/src/lib.rs
@@ -200,6 +200,34 @@ pub fn selector_bytes(input: TokenStream) -> TokenStream {
 ///
 ///     **Default value:** Depends on the crate feature propagation of `Cargo.toml`.
 ///
+/// - `keep_attr: String`
+///
+///     Tells the ink! code generator which attributes should be passed to call builders.
+///     Call builders are used to doing cross-contract calls and are automatically
+///     generated for contracts.
+///
+///     **Usage Example:**
+///     ```
+///     # use ink_lang as ink;
+///     #[ink::contract(keep_attr = "foo, bar")]
+///     mod my_contract {
+///         # #[ink(storage)]
+///         # pub struct MyStorage;
+///         # impl MyStorage {
+///         #     #[ink(constructor)]
+///         //    #[bar]
+///         #     pub fn construct() -> Self { MyStorage {} }
+///         #     #[ink(message)]
+///         //    #[foo]
+///         #     pub fn message(&self) {}
+///         # }
+///         // ...
+///     }
+///     ```
+///
+///     **Allowed attributes by default:** `cfg`, `cfg_attr`, `allow`, `warn`, `deny`, `forbid`,
+///         `deprecated`, `must_use`, `doc`.`
+///
 /// - `env: impl Environment`
 ///
 ///     Tells the ink! code generator which environment to use for the ink! smart contract.
@@ -593,7 +621,9 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// structure so that the main [`#[ink::contract]`](`macro@crate::contract`) macro can
 /// properly generate code for its implementations.
 ///
-/// # Example: Definition
+/// # Example
+///
+/// # Trait definition:
 ///
 /// ```
 /// use ink_lang as ink;
@@ -614,7 +644,7 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// # Example: Implementation
+/// # Trait implementation
 ///
 /// Given the above trait definition you can implement it as shown below:
 ///
@@ -661,6 +691,56 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     }
 /// }
 /// ```
+///
+/// ## Header Arguments
+///
+/// The `#[ink::trait_definition]` macro can be provided with some additional comma-separated
+/// header arguments:
+///
+/// - `namespace: String`
+///
+///     The namespace configuration parameter is used to influence the generated
+///     selectors of the ink! trait messages. This is useful to disambiguate
+///     ink! trait definitions with equal names.
+///
+///     **Usage Example:**
+///     ```
+///     # use ink_lang as ink;
+///     #[ink::trait_definition(namespace = "foo")]
+///     pub trait TraitDefinition {
+///         #[ink(message)]
+///         fn message1(&self);
+///     
+///         #[ink(message, selector = 42)]
+///         fn message2(&self);
+///     }
+///     ```
+///
+///     **Default value:** Empty.
+///
+/// - `keep_attr: String`
+///
+///     Tells the ink! code generator which attributes should be passed to call builders.
+///     Call builders are used to doing cross-contract calls and are automatically
+///     generated for contracts.
+///
+///     **Usage Example:**
+///     ```
+///     # use ink_lang as ink;
+///     #[ink::trait_definition(keep_attr = "foo, bar")]
+///     pub trait Storage {
+///         #[ink(message)]
+///     //  #[foo]
+///         fn message1(&self);
+///
+///         #[ink(message)]
+///     //  #[bar]
+///         fn message2(&self);
+///     }
+///     ```
+///
+///     **Allowed attributes by default:** `cfg`, `cfg_attr`, `allow`, `warn`, `deny`, `forbid`,
+///         `deprecated`, `must_use`, `doc`.`
 #[proc_macro_attribute]
 pub fn trait_definition(attr: TokenStream, item: TokenStream) -> TokenStream {
     trait_def::analyze(attr.into(), item.into()).into()

--- a/crates/lang/tests/ui/contract/fail/config-keep-attr-invalid-type.rs
+++ b/crates/lang/tests/ui/contract/fail/config-keep-attr-invalid-type.rs
@@ -1,0 +1,19 @@
+use ink_lang as ink;
+
+#[ink::contract(keep_attr = true)]
+mod contract {
+    #[ink(storage)]
+    pub struct Contract {}
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn message(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/lang/tests/ui/contract/fail/config-keep-attr-invalid-type.stderr
+++ b/crates/lang/tests/ui/contract/fail/config-keep-attr-invalid-type.stderr
@@ -1,0 +1,5 @@
+error: expected a string with attributes separated by `,`
+ --> tests/ui/contract/fail/config-keep-attr-invalid-type.rs:3:17
+  |
+3 | #[ink::contract(keep_attr = true)]
+  |                 ^^^^^^^^^^^^^^^^

--- a/crates/lang/tests/ui/contract/fail/config-keep-attr-missing-arg.rs
+++ b/crates/lang/tests/ui/contract/fail/config-keep-attr-missing-arg.rs
@@ -1,0 +1,19 @@
+use ink_lang as ink;
+
+#[ink::contract(keep_attr)]
+mod contract {
+    #[ink(storage)]
+    pub struct Contract {}
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn message(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/lang/tests/ui/contract/fail/config-keep-attr-missing-arg.stderr
+++ b/crates/lang/tests/ui/contract/fail/config-keep-attr-missing-arg.stderr
@@ -1,0 +1,5 @@
+error: ink! config options require an argument separated by '='
+ --> tests/ui/contract/fail/config-keep-attr-missing-arg.rs:3:17
+  |
+3 | #[ink::contract(keep_attr)]
+  |                 ^^^^^^^^^

--- a/crates/lang/tests/ui/contract/pass/config-keep-attr.rs
+++ b/crates/lang/tests/ui/contract/pass/config-keep-attr.rs
@@ -1,0 +1,20 @@
+use ink_lang as ink;
+
+#[ink::contract(keep_attr = "foo, bar")]
+mod contract {
+    #[ink(storage)]
+    pub struct Contract {}
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        #[allow(non_snake_case)]
+        pub fn meSSage(&self) {}
+    }
+}
+
+fn main() {}

--- a/crates/lang/tests/ui/trait_def/fail/config_keep_attr_invalid_type.rs
+++ b/crates/lang/tests/ui/trait_def/fail/config_keep_attr_invalid_type.rs
@@ -1,0 +1,9 @@
+use ink_lang as ink;
+
+#[ink::trait_definition(keep_attr = true)]
+pub trait TraitDefinition {
+    #[ink(message)]
+    fn message(&self);
+}
+
+fn main() {}

--- a/crates/lang/tests/ui/trait_def/fail/config_keep_attr_invalid_type.stderr
+++ b/crates/lang/tests/ui/trait_def/fail/config_keep_attr_invalid_type.stderr
@@ -1,0 +1,5 @@
+error: expected a string with attributes separated by `,`
+ --> tests/ui/trait_def/fail/config_keep_attr_invalid_type.rs:3:25
+  |
+3 | #[ink::trait_definition(keep_attr = true)]
+  |                         ^^^^^^^^^^^^^^^^

--- a/crates/lang/tests/ui/trait_def/fail/config_keep_attr_missing_arg.rs
+++ b/crates/lang/tests/ui/trait_def/fail/config_keep_attr_missing_arg.rs
@@ -1,0 +1,9 @@
+use ink_lang as ink;
+
+#[ink::trait_definition(keep_attr)]
+pub trait TraitDefinition {
+    #[ink(message)]
+    fn message(&self);
+}
+
+fn main() {}

--- a/crates/lang/tests/ui/trait_def/fail/config_keep_attr_missing_arg.stderr
+++ b/crates/lang/tests/ui/trait_def/fail/config_keep_attr_missing_arg.stderr
@@ -1,0 +1,5 @@
+error: ink! config options require an argument separated by '='
+ --> tests/ui/trait_def/fail/config_keep_attr_missing_arg.rs:3:25
+  |
+3 | #[ink::trait_definition(keep_attr)]
+  |                         ^^^^^^^^^

--- a/crates/lang/tests/ui/trait_def/pass/with_keep_attr.rs
+++ b/crates/lang/tests/ui/trait_def/pass/with_keep_attr.rs
@@ -1,0 +1,10 @@
+use ink_lang as ink;
+
+#[ink::trait_definition(keep_attr = "foo, bar")]
+pub trait WithKeepAttr {
+    #[ink(message)]
+    #[allow(non_snake_case)]
+    fn meSSage(&self);
+}
+
+fn main() {}


### PR DESCRIPTION
Added `keep_attr` to `#[ink::contract]` and `#[ink::trait_definition]` to manage that attributes should be passed to call builder during codegen. All attributes are ignore by default except: `cfg`, `cfg_attr`, `allow`, `warn`, `deny`, `forbid`, `deprecated`, `must_use`, `doc`.

More information in the conversation of https://github.com/paritytech/ink/pull/1130
