### PR TITLE
Add tests in experimental off-chain env for `dns`

### DIFF
--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -31,3 +31,4 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
+ink-experimental-engine = ["ink_env/ink-experimental-engine"]


### PR DESCRIPTION
It's basically just copy/paste, besides the `default_accounts` and `set_next_caller` function.