### PR TITLE
Add tests in experimental off-chain env for `trait-erc20`

### DIFF
--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -31,3 +31,4 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
+ink-experimental-engine = ["ink_env/ink-experimental-engine"]

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -295,7 +295,6 @@ mod erc20 {
             } else {
                 panic!("encountered unexpected event kind: expected a Transfer event")
             }
-
             fn encoded_into_hash<T>(entity: &T) -> Hash
             where
                 T: scale::Encode,
@@ -315,7 +314,6 @@ mod erc20 {
                 result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
                 result
             }
-
             let expected_topics = [
                 encoded_into_hash(&PrefixedValue {
                     prefix: b"",
@@ -370,9 +368,7 @@ mod erc20 {
         #[ink::test]
         fn total_supply_works() {
             // Constructor works.
-            let initial_supply = 100;
-            let erc20 = Erc20::new(initial_supply);
-
+            let erc20 = Erc20::new(100);
             // Transfer event triggered during initial construction.
             let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
             assert_transfer_event(
@@ -381,7 +377,6 @@ mod erc20 {
                 Some(AccountId::from([0x01; 32])),
                 100,
             );
-
             // Get the token total supply.
             assert_eq!(erc20.total_supply(), 100);
         }
@@ -390,9 +385,7 @@ mod erc20 {
         #[ink::test]
         fn balance_of_works() {
             // Constructor works
-            let initial_supply = 100;
-            let erc20 = Erc20::new(initial_supply);
-
+            let erc20 = Erc20::new(100);
             // Transfer event triggered during initial construction
             let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
             assert_transfer_event(
@@ -413,9 +406,7 @@ mod erc20 {
         #[ink::test]
         fn transfer_works() {
             // Constructor works.
-            let initial_supply = 100;
-            let erc20 = Erc20::new(initial_supply);
-
+            let mut erc20 = Erc20::new(100);
             // Transfer event triggered during initial construction.
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
@@ -448,8 +439,7 @@ mod erc20 {
         #[ink::test]
         fn invalid_transfer_should_fail() {
             // Constructor works.
-            let initial_supply = 100;
-            let erc20 = Erc20::new(initial_supply);
+            let mut erc20 = Erc20::new(100);
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
                     .expect("Cannot get accounts");
@@ -494,8 +484,7 @@ mod erc20 {
         #[ink::test]
         fn transfer_from_works() {
             // Constructor works.
-            let initial_supply = 100;
-            let erc20 = Erc20::new(initial_supply);
+            let mut erc20 = Erc20::new(100);
             // Transfer event triggered during initial construction.
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
@@ -555,8 +544,7 @@ mod erc20 {
 
         #[ink::test]
         fn allowance_must_not_change_on_failed_transfer() {
-            let initial_supply = 100;
-            let erc20 = Erc20::new(initial_supply);
+            let mut erc20 = Erc20::new(100);
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
                     .expect("Cannot get accounts");
@@ -778,7 +766,7 @@ mod erc20 {
 
             assert_eq!(erc20.balance_of(accounts.bob), 0);
             // Set Bob as caller
-            set_caller(accounts.bob);
+            set_sender(accounts.bob);
 
             // Bob fails to transfers 10 tokens to Eve.
             assert_eq!(
@@ -821,7 +809,7 @@ mod erc20 {
             assert_eq!(ink_env::test::recorded_events().count(), 2);
 
             // Set Bob as caller.
-            set_caller(accounts.bob);
+            set_sender(accounts.bob);
 
             // Bob transfers tokens from Alice to Eve.
             assert_eq!(
@@ -861,7 +849,7 @@ mod erc20 {
             assert_eq!(erc20.approve(accounts.bob, initial_allowance), Ok(()));
 
             // Set Bob as caller.
-            set_caller(accounts.bob);
+            set_sender(accounts.bob);
 
             // Bob tries to transfer tokens from Alice to Eve.
             let emitted_events_before = ink_env::test::recorded_events();
@@ -879,7 +867,7 @@ mod erc20 {
             assert_eq!(emitted_events_before.count(), emitted_events_after.count());
         }
 
-        fn set_caller(sender: AccountId) {
+        fn set_sender(sender: AccountId) {
             ink_env::test::set_caller::<Environment>(sender);
         }
     }

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -295,6 +295,7 @@ mod erc20 {
             } else {
                 panic!("encountered unexpected event kind: expected a Transfer event")
             }
+
             fn encoded_into_hash<T>(entity: &T) -> Hash
             where
                 T: scale::Encode,
@@ -314,6 +315,7 @@ mod erc20 {
                 result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
                 result
             }
+
             let expected_topics = [
                 encoded_into_hash(&PrefixedValue {
                     prefix: b"",
@@ -368,7 +370,9 @@ mod erc20 {
         #[ink::test]
         fn total_supply_works() {
             // Constructor works.
-            let erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let erc20 = Erc20::new(initial_supply);
+
             // Transfer event triggered during initial construction.
             let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
             assert_transfer_event(
@@ -377,6 +381,7 @@ mod erc20 {
                 Some(AccountId::from([0x01; 32])),
                 100,
             );
+
             // Get the token total supply.
             assert_eq!(erc20.total_supply(), 100);
         }
@@ -385,7 +390,9 @@ mod erc20 {
         #[ink::test]
         fn balance_of_works() {
             // Constructor works
-            let erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let erc20 = Erc20::new(initial_supply);
+
             // Transfer event triggered during initial construction
             let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
             assert_transfer_event(
@@ -406,7 +413,9 @@ mod erc20 {
         #[ink::test]
         fn transfer_works() {
             // Constructor works.
-            let mut erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let erc20 = Erc20::new(initial_supply);
+
             // Transfer event triggered during initial construction.
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
@@ -439,7 +448,8 @@ mod erc20 {
         #[ink::test]
         fn invalid_transfer_should_fail() {
             // Constructor works.
-            let mut erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let erc20 = Erc20::new(initial_supply);
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
                     .expect("Cannot get accounts");
@@ -484,7 +494,8 @@ mod erc20 {
         #[ink::test]
         fn transfer_from_works() {
             // Constructor works.
-            let mut erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let erc20 = Erc20::new(initial_supply);
             // Transfer event triggered during initial construction.
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
@@ -544,7 +555,8 @@ mod erc20 {
 
         #[ink::test]
         fn allowance_must_not_change_on_failed_transfer() {
-            let mut erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let erc20 = Erc20::new(initial_supply);
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>()
                     .expect("Cannot get accounts");
@@ -766,7 +778,7 @@ mod erc20 {
 
             assert_eq!(erc20.balance_of(accounts.bob), 0);
             // Set Bob as caller
-            set_sender(accounts.bob);
+            set_caller(accounts.bob);
 
             // Bob fails to transfers 10 tokens to Eve.
             assert_eq!(
@@ -809,7 +821,7 @@ mod erc20 {
             assert_eq!(ink_env::test::recorded_events().count(), 2);
 
             // Set Bob as caller.
-            set_sender(accounts.bob);
+            set_caller(accounts.bob);
 
             // Bob transfers tokens from Alice to Eve.
             assert_eq!(
@@ -849,7 +861,7 @@ mod erc20 {
             assert_eq!(erc20.approve(accounts.bob, initial_allowance), Ok(()));
 
             // Set Bob as caller.
-            set_sender(accounts.bob);
+            set_caller(accounts.bob);
 
             // Bob tries to transfer tokens from Alice to Eve.
             let emitted_events_before = ink_env::test::recorded_events();
@@ -867,7 +879,7 @@ mod erc20 {
             assert_eq!(emitted_events_before.count(), emitted_events_after.count());
         }
 
-        fn set_sender(sender: AccountId) {
+        fn set_caller(sender: AccountId) {
             ink_env::test::set_caller::<Environment>(sender);
         }
     }

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -619,6 +619,7 @@ mod erc20 {
             } else {
                 panic!("encountered unexpected event kind: expected a Transfer event")
             }
+
             fn encoded_into_hash<T>(entity: &T) -> Hash
             where
                 T: scale::Encode,
@@ -638,6 +639,7 @@ mod erc20 {
                 result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
                 result
             }
+
             let expected_topics = [
                 encoded_into_hash(&PrefixedValue {
                     prefix: b"",
@@ -691,7 +693,8 @@ mod erc20 {
         #[ink::test]
         fn total_supply_works() {
             // Constructor works.
-            let erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let erc20 = Erc20::new(initial_supply);
             // Transfer event triggered during initial construction.
             let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
             assert_transfer_event(
@@ -708,7 +711,8 @@ mod erc20 {
         #[ink::test]
         fn balance_of_works() {
             // Constructor works
-            let erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let erc20 = Erc20::new(initial_supply);
             // Transfer event triggered during initial construction
             let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
             assert_transfer_event(
@@ -728,7 +732,8 @@ mod erc20 {
         #[ink::test]
         fn transfer_works() {
             // Constructor works.
-            let mut erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let mut erc20 = Erc20::new(initial_supply);
             // Transfer event triggered during initial construction.
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
@@ -760,13 +765,14 @@ mod erc20 {
         #[ink::test]
         fn invalid_transfer_should_fail() {
             // Constructor works.
-            let mut erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let mut erc20 = Erc20::new(initial_supply);
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
 
             assert_eq!(erc20.balance_of(accounts.bob), 0);
             // Set Bob as caller
-            set_sender(accounts.bob);
+            set_caller(accounts.bob);
 
             // Bob fails to transfers 10 tokens to Eve.
             assert_eq!(
@@ -792,7 +798,8 @@ mod erc20 {
         #[ink::test]
         fn transfer_from_works() {
             // Constructor works.
-            let mut erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let mut erc20 = Erc20::new(initial_supply);
             // Transfer event triggered during initial construction.
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
@@ -809,7 +816,7 @@ mod erc20 {
             assert_eq!(ink_env::test::recorded_events().count(), 2);
 
             // Set Bob as caller.
-            set_sender(accounts.bob);
+            set_caller(accounts.bob);
 
             // Bob transfers tokens from Alice to Eve.
             assert_eq!(
@@ -839,7 +846,8 @@ mod erc20 {
 
         #[ink::test]
         fn allowance_must_not_change_on_failed_transfer() {
-            let mut erc20 = Erc20::new(100);
+            let initial_supply = 100;
+            let mut erc20 = Erc20::new(initial_supply);
             let accounts =
                 ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
 
@@ -849,7 +857,7 @@ mod erc20 {
             assert_eq!(erc20.approve(accounts.bob, initial_allowance), Ok(()));
 
             // Set Bob as caller.
-            set_sender(accounts.bob);
+            set_caller(accounts.bob);
 
             // Bob tries to transfer tokens from Alice to Eve.
             let emitted_events_before = ink_env::test::recorded_events();
@@ -867,7 +875,7 @@ mod erc20 {
             assert_eq!(emitted_events_before.count(), emitted_events_after.count());
         }
 
-        fn set_sender(sender: AccountId) {
+        fn set_caller(sender: AccountId) {
             ink_env::test::set_caller::<Environment>(sender);
         }
     }

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -263,6 +263,7 @@ mod erc20 {
     }
 
     /// Unit tests.
+    #[cfg(not(feature = "ink-experimental-engine"))]
     #[cfg(test)]
     mod tests {
         /// Imports all the definitions from the outer scope so we can use them here.
@@ -582,6 +583,292 @@ mod erc20 {
             // No more events must have been emitted
             let emitted_events_after = ink_env::test::recorded_events();
             assert_eq!(emitted_events_before.count(), emitted_events_after.count());
+        }
+    }
+
+    /// Unit tests.
+    #[cfg(feature = "ink-experimental-engine")]
+    #[cfg(test)]
+    mod tests_experimental_engine {
+        /// Imports all the definitions from the outer scope so we can use them here.
+        use super::*;
+        use ink_env::{
+            hash::{
+                Blake2x256,
+                CryptoHash,
+                HashOutput,
+            },
+            Clear,
+        };
+        use ink_lang as ink;
+
+        type Event = <Erc20 as ::ink_lang::reflect::ContractEventBase>::Type;
+
+        fn assert_transfer_event(
+            event: &ink_env::test::EmittedEvent,
+            expected_from: Option<AccountId>,
+            expected_to: Option<AccountId>,
+            expected_value: Balance,
+        ) {
+            let decoded_event = <Event as scale::Decode>::decode(&mut &event.data[..])
+                .expect("encountered invalid contract event data buffer");
+            if let Event::Transfer(Transfer { from, to, value }) = decoded_event {
+                assert_eq!(from, expected_from, "encountered invalid Transfer.from");
+                assert_eq!(to, expected_to, "encountered invalid Transfer.to");
+                assert_eq!(value, expected_value, "encountered invalid Trasfer.value");
+            } else {
+                panic!("encountered unexpected event kind: expected a Transfer event")
+            }
+            fn encoded_into_hash<T>(entity: &T) -> Hash
+            where
+                T: scale::Encode,
+            {
+                let mut result = Hash::clear();
+                let len_result = result.as_ref().len();
+                let encoded = entity.encode();
+                let len_encoded = encoded.len();
+                if len_encoded <= len_result {
+                    result.as_mut()[..len_encoded].copy_from_slice(&encoded);
+                    return result
+                }
+                let mut hash_output =
+                    <<Blake2x256 as HashOutput>::Type as Default>::default();
+                <Blake2x256 as CryptoHash>::hash(&encoded, &mut hash_output);
+                let copy_len = core::cmp::min(hash_output.len(), len_result);
+                result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
+                result
+            }
+            let expected_topics = [
+                encoded_into_hash(&PrefixedValue {
+                    prefix: b"",
+                    value: b"Erc20::Transfer",
+                }),
+                encoded_into_hash(&PrefixedValue {
+                    prefix: b"Erc20::Transfer::from",
+                    value: &expected_from,
+                }),
+                encoded_into_hash(&PrefixedValue {
+                    prefix: b"Erc20::Transfer::to",
+                    value: &expected_to,
+                }),
+                encoded_into_hash(&PrefixedValue {
+                    prefix: b"Erc20::Transfer::value",
+                    value: &expected_value,
+                }),
+            ];
+            for (n, (actual_topic, expected_topic)) in
+                event.topics.iter().zip(expected_topics).enumerate()
+            {
+                let topic = <Hash as scale::Decode>::decode(&mut &actual_topic[..])
+                    .expect("encountered invalid topic encoding");
+                assert_eq!(topic, expected_topic, "encountered invalid topic at {}", n);
+            }
+        }
+
+        /// The default constructor does its job.
+        #[ink::test]
+        fn new_works() {
+            // Constructor works.
+            let initial_supply = 100;
+            let erc20 = Erc20::new(initial_supply);
+
+            // The `BaseErc20` trait has indeed been implemented.
+            assert_eq!(<Erc20 as BaseErc20>::total_supply(&erc20), initial_supply);
+
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(1, emitted_events.len());
+
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+        }
+
+        /// The total supply was applied.
+        #[ink::test]
+        fn total_supply_works() {
+            // Constructor works.
+            let erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // Get the token total supply.
+            assert_eq!(erc20.total_supply(), 100);
+        }
+
+        /// Get the actual balance of an account.
+        #[ink::test]
+        fn balance_of_works() {
+            // Constructor works
+            let erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            let accounts =
+                ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
+            // Alice owns all the tokens on contract instantiation
+            assert_eq!(erc20.balance_of(accounts.alice), 100);
+            // Bob does not owns tokens
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+        }
+
+        #[ink::test]
+        fn transfer_works() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let accounts =
+                ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
+
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+            // Alice transfers 10 tokens to Bob.
+            assert_eq!(erc20.transfer(accounts.bob, 10), Ok(()));
+            // Bob owns 10 tokens.
+            assert_eq!(erc20.balance_of(accounts.bob), 10);
+
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 2);
+            // Check first transfer event related to ERC-20 instantiation.
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // Check the second transfer event relating to the actual trasfer.
+            assert_transfer_event(
+                &emitted_events[1],
+                Some(AccountId::from([0x01; 32])),
+                Some(AccountId::from([0x02; 32])),
+                10,
+            );
+        }
+
+        #[ink::test]
+        fn invalid_transfer_should_fail() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            let accounts =
+                ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
+
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+            // Set Bob as caller
+            set_sender(accounts.bob);
+
+            // Bob fails to transfers 10 tokens to Eve.
+            assert_eq!(
+                erc20.transfer(accounts.eve, 10),
+                Err(Error::InsufficientBalance)
+            );
+            // Alice owns all the tokens.
+            assert_eq!(erc20.balance_of(accounts.alice), 100);
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+            assert_eq!(erc20.balance_of(accounts.eve), 0);
+
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 1);
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+        }
+
+        #[ink::test]
+        fn transfer_from_works() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let accounts =
+                ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
+
+            // Bob fails to transfer tokens owned by Alice.
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, 10),
+                Err(Error::InsufficientAllowance)
+            );
+            // Alice approves Bob for token transfers on her behalf.
+            assert_eq!(erc20.approve(accounts.bob, 10), Ok(()));
+
+            // The approve event takes place.
+            assert_eq!(ink_env::test::recorded_events().count(), 2);
+
+            // Set Bob as caller.
+            set_sender(accounts.bob);
+
+            // Bob transfers tokens from Alice to Eve.
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, 10),
+                Ok(())
+            );
+            // Eve owns tokens.
+            assert_eq!(erc20.balance_of(accounts.eve), 10);
+
+            // Check all transfer events that happened during the previous calls:
+            let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 3);
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // The second event `emitted_events[1]` is an Approve event that we skip checking.
+            assert_transfer_event(
+                &emitted_events[2],
+                Some(AccountId::from([0x01; 32])),
+                Some(AccountId::from([0x05; 32])),
+                10,
+            );
+        }
+
+        #[ink::test]
+        fn allowance_must_not_change_on_failed_transfer() {
+            let mut erc20 = Erc20::new(100);
+            let accounts =
+                ink_env::test::default_accounts::<ink_env::DefaultEnvironment>();
+
+            // Alice approves Bob for token transfers on her behalf.
+            let alice_balance = erc20.balance_of(accounts.alice);
+            let initial_allowance = alice_balance + 2;
+            assert_eq!(erc20.approve(accounts.bob, initial_allowance), Ok(()));
+
+            // Set Bob as caller.
+            set_sender(accounts.bob);
+
+            // Bob tries to transfer tokens from Alice to Eve.
+            let emitted_events_before = ink_env::test::recorded_events();
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, alice_balance + 1),
+                Err(Error::InsufficientBalance)
+            );
+            // Allowance must have stayed the same
+            assert_eq!(
+                erc20.allowance(accounts.alice, accounts.bob),
+                initial_allowance
+            );
+            // No more events must have been emitted
+            let emitted_events_after = ink_env::test::recorded_events();
+            assert_eq!(emitted_events_before.count(), emitted_events_after.count());
+        }
+
+        fn set_sender(sender: AccountId) {
+            ink_env::test::set_caller::<Environment>(sender);
         }
     }
 


### PR DESCRIPTION
Mostly copy/paste from the existing tests.

* Got rid of `push_execution_context`/`pop_execution_context`, replaced it with `set_sender` instead.
* Removed all the `CallData` stuff, since it wasn't used anyway.
* Replaced the `default_accounts` implementation.