### PR TITLE
Remove unnecessary `overflow-checks = false`

### DIFF
--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -20,10 +20,6 @@ name = "proxy"
 path = "lib.rs"
 crate-type = ["cdylib"]
 
-# Needed until https://github.com/paritytech/ink/issues/364 is resolved.
-[profile.release]
-overflow-checks = false
-
 [features]
 default = ["std"]
 std = [


### PR DESCRIPTION
Was probably overlooked, should have been removed in https://github.com/paritytech/ink/pull/1049.