### PR TITLE
Unify `ink_env::{eval_contract, invoke_contract}`

### DIFF
--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -216,33 +216,7 @@ pub fn clear_contract_storage(key: &Key) {
     })
 }
 
-/// Invokes a contract message.
-///
-/// # Note
-///
-/// - Prefer using this over [`eval_contract`] if possible. [`invoke_contract`]
-///   will generally have a better performance since it won't try to fetch any results.
-/// - This is a low level way to invoke another smart contract.
-///   Prefer to use the ink! guided and type safe approach to using this.
-///
-/// # Errors
-///
-/// - If the called account does not exist.
-/// - If the called account is not a contract.
-/// - If arguments passed to the called contract message are invalid.
-/// - If the called contract execution has trapped.
-/// - If the called contract ran out of gas upon execution.
-pub fn invoke_contract<T, Args>(params: &CallParams<T, Args, ()>) -> Result<()>
-where
-    T: Environment,
-    Args: scale::Encode,
-{
-    <EnvInstance as OnInstance>::on_instance(|instance| {
-        TypedEnvBackend::invoke_contract::<T, Args>(instance, params)
-    })
-}
-
-/// Evaluates a contract message and returns its result.
+/// Invokes a contract message and returns its result.
 ///
 /// # Note
 ///
@@ -257,14 +231,14 @@ where
 /// - If the called contract execution has trapped.
 /// - If the called contract ran out of gas upon execution.
 /// - If the returned value failed to decode properly.
-pub fn eval_contract<T, Args, R>(params: &CallParams<T, Args, ReturnType<R>>) -> Result<R>
+pub fn invoke_contract<T, Args, R>(params: &CallParams<T, Args, ReturnType<R>>) -> Result<R>
 where
     T: Environment,
     Args: scale::Encode,
     R: scale::Decode,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        TypedEnvBackend::eval_contract::<T, Args, R>(instance, params)
+        TypedEnvBackend::invoke_contract::<T, Args, R>(instance, params)
     })
 }
 

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -359,25 +359,12 @@ pub trait TypedEnvBackend: EnvBackend {
         T: Environment,
         Event: Topics + scale::Encode;
 
-    /// Invokes a contract message.
+    /// Invokes a contract message and returns its result.
     ///
     /// # Note
     ///
     /// For more details visit: [`invoke_contract`][`crate::invoke_contract`]
-    fn invoke_contract<T, Args>(
-        &mut self,
-        call_data: &CallParams<T, Args, ()>,
-    ) -> Result<()>
-    where
-        T: Environment,
-        Args: scale::Encode;
-
-    /// Evaluates a contract message and returns its result.
-    ///
-    /// # Note
-    ///
-    /// For more details visit: [`eval_contract`][`crate::eval_contract`]
-    fn eval_contract<T, Args, R>(
+    fn invoke_contract<T, Args, R>(
         &mut self,
         call_data: &CallParams<T, Args, ReturnType<R>>,
     ) -> Result<R>

--- a/crates/env/src/call/call_builder.rs
+++ b/crates/env/src/call/call_builder.rs
@@ -84,38 +84,17 @@ where
     }
 }
 
-impl<E, Args> CallParams<E, Args, ()>
-where
-    E: Environment,
-    Args: scale::Encode,
-{
-    /// Invokes the contract with the given built-up call parameters.
-    ///
-    /// # Note
-    ///
-    /// Prefer [`invoke`](`Self::invoke`) over [`eval`](`Self::eval`) if the
-    /// called contract message does not return anything because it is more efficient.
-    pub fn invoke(&self) -> Result<(), crate::Error> {
-        crate::invoke_contract(self)
-    }
-}
-
 impl<E, Args, R> CallParams<E, Args, ReturnType<R>>
 where
     E: Environment,
     Args: scale::Encode,
     R: scale::Decode,
 {
-    /// Evaluates the contract with the given built-up call parameters.
+    /// Invokes the contract with the given built-up call parameters.
     ///
     /// Returns the result of the contract execution.
-    ///
-    /// # Note
-    ///
-    /// Prefer [`invoke`](`Self::invoke`) over [`eval`](`Self::eval`) if the
-    /// called contract message does not return anything because it is more efficient.
-    pub fn eval(&self) -> Result<R, crate::Error> {
-        crate::eval_contract(self)
+    pub fn invoke(&self) -> Result<R, crate::Error> {
+        crate::invoke_contract(self)
     }
 }
 
@@ -524,6 +503,6 @@ where
 {
     /// Invokes the cross-chain function call and returns the result.
     pub fn fire(self) -> Result<R, Error> {
-        self.params().eval()
+        self.params().invoke()
     }
 }

--- a/crates/env/src/call/call_builder.rs
+++ b/crates/env/src/call/call_builder.rs
@@ -444,47 +444,6 @@ where
     }
 }
 
-impl<E, GasLimit, TransferredValue, Args>
-    CallBuilder<
-        E,
-        Set<E::AccountId>,
-        GasLimit,
-        TransferredValue,
-        Set<ExecutionInput<Args>>,
-        Set<()>,
-    >
-where
-    E: Environment,
-    GasLimit: Unwrap<Output = u64>,
-    Args: scale::Encode,
-    TransferredValue: Unwrap<Output = E::Balance>,
-{
-    /// Invokes the cross-chain function call.
-    pub fn fire(self) -> Result<(), Error> {
-        self.params().invoke()
-    }
-}
-
-impl<E, GasLimit, TransferredValue>
-    CallBuilder<
-        E,
-        Set<E::AccountId>,
-        GasLimit,
-        TransferredValue,
-        Unset<ExecutionInput<EmptyArgumentList>>,
-        Unset<ReturnType<()>>,
-    >
-where
-    E: Environment,
-    GasLimit: Unwrap<Output = u64>,
-    TransferredValue: Unwrap<Output = E::Balance>,
-{
-    /// Invokes the cross-chain function call.
-    pub fn fire(self) -> Result<(), Error> {
-        self.params().invoke()
-    }
-}
-
 impl<E, GasLimit, TransferredValue, Args, R>
     CallBuilder<
         E,

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -387,20 +387,7 @@ impl TypedEnvBackend for EnvInstance {
         self.engine.deposit_event(&enc_topics[..], enc_data);
     }
 
-    fn invoke_contract<T, Args>(&mut self, params: &CallParams<T, Args, ()>) -> Result<()>
-    where
-        T: Environment,
-        Args: scale::Encode,
-    {
-        let _gas_limit = params.gas_limit();
-        let _callee = params.callee();
-        let _call_flags = params.call_flags().into_u32();
-        let _transferred_value = params.transferred_value();
-        let _input = params.exec_input();
-        unimplemented!("off-chain environment does not support contract invocation")
-    }
-
-    fn eval_contract<T, Args, R>(
+    fn invoke_contract<T, Args, R>(
         &mut self,
         _call_params: &CallParams<T, Args, ReturnType<R>>,
     ) -> Result<R>
@@ -409,7 +396,7 @@ impl TypedEnvBackend for EnvInstance {
         Args: scale::Encode,
         R: scale::Decode,
     {
-        unimplemented!("off-chain environment does not support contract evaluation")
+        unimplemented!("off-chain environment does not support contract invocation")
     }
 
     fn instantiate_contract<T, Args, Salt, C>(

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -215,45 +215,6 @@ impl EnvInstance {
         ext_fn(full_scope);
         scale::Decode::decode(&mut &full_scope[..]).map_err(Into::into)
     }
-
-    /// Reusable implementation for invoking another contract message.
-    fn invoke_contract_impl<T, Args, RetType, R>(
-        &mut self,
-        params: &CallParams<T, Args, RetType>,
-    ) -> Result<R>
-    where
-        T: Environment,
-        Args: scale::Encode,
-        R: scale::Decode,
-    {
-        let mut scope = self.scoped_buffer();
-        let gas_limit = params.gas_limit();
-        let enc_callee = scope.take_encoded(params.callee());
-        let enc_transferred_value = scope.take_encoded(params.transferred_value());
-        let call_flags = params.call_flags();
-        let enc_input = if !call_flags.forward_input() && !call_flags.clone_input() {
-            scope.take_encoded(params.exec_input())
-        } else {
-            &mut []
-        };
-        let output = &mut scope.take_rest();
-        let flags = params.call_flags().into_u32();
-        let call_result = ext::call(
-            flags,
-            enc_callee,
-            gas_limit,
-            enc_transferred_value,
-            enc_input,
-            output,
-        );
-        match call_result {
-            Ok(()) | Err(ext::Error::CalleeReverted) => {
-                let decoded = scale::Decode::decode(&mut &output[..])?;
-                Ok(decoded)
-            }
-            Err(actual_error) => Err(actual_error.into()),
-        }
-    }
 }
 
 impl EnvBackend for EnvInstance {
@@ -396,27 +357,43 @@ impl TypedEnvBackend for EnvInstance {
         ext::deposit_event(enc_topics, enc_data);
     }
 
-    fn invoke_contract<T, Args>(
+    fn invoke_contract<T, Args, R>(
         &mut self,
-        call_params: &CallParams<T, Args, ()>,
-    ) -> Result<()>
-    where
-        T: Environment,
-        Args: scale::Encode,
-    {
-        self.invoke_contract_impl(call_params)
-    }
-
-    fn eval_contract<T, Args, R>(
-        &mut self,
-        call_params: &CallParams<T, Args, ReturnType<R>>,
+        params: &CallParams<T, Args, ReturnType<R>>,
     ) -> Result<R>
     where
         T: Environment,
         Args: scale::Encode,
         R: scale::Decode,
     {
-        self.invoke_contract_impl(call_params)
+        let mut scope = self.scoped_buffer();
+        let gas_limit = params.gas_limit();
+        let enc_callee = scope.take_encoded(params.callee());
+        let enc_transferred_value = scope.take_encoded(params.transferred_value());
+        let call_flags = params.call_flags();
+        let enc_input = if !call_flags.forward_input() && !call_flags.clone_input() {
+            scope.take_encoded(params.exec_input())
+        } else {
+            &mut []
+        };
+        let output = &mut scope.take_rest();
+        let flags = params.call_flags().into_u32();
+        let call_result = ext::call(
+            flags,
+            enc_callee,
+            gas_limit,
+            enc_transferred_value,
+            enc_input,
+            output,
+        );
+        match call_result {
+            Ok(()) | Err(ext::Error::CalleeReverted) => {
+                let decoded = scale::Decode::decode(&mut &output[..])?;
+                Ok(decoded)
+            }
+            Err(actual_error) => Err(actual_error.into()),
+        }
+
     }
 
     fn instantiate_contract<T, Args, Salt, C>(

--- a/crates/lang/src/env_access.rs
+++ b/crates/lang/src/env_access.rs
@@ -504,62 +504,7 @@ where
         ink_env::instantiate_contract::<T, Args, Salt, C>(params)
     }
 
-    /// Invokes a contract message without fetching its result.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use ink_lang as ink;
-    /// # #[ink::contract]
-    /// # pub mod my_contract {
-    /// use ink_env::{
-    ///     DefaultEnvironment,
-    ///     call::{build_call, Selector, ExecutionInput}
-    /// };
-    ///
-    /// #
-    /// #     #[ink(storage)]
-    /// #     pub struct MyContract { }
-    /// #
-    /// #     impl MyContract {
-    /// #         #[ink(constructor)]
-    /// #         pub fn new() -> Self {
-    /// #             Self {}
-    /// #         }
-    /// #
-    /// /// Invokes another contract message without fetching the result.
-    /// #[ink(message)]
-    /// pub fn invoke_contract(&self) {
-    ///     let call_params = build_call::<DefaultEnvironment>()
-    ///         .callee(AccountId::from([0x42; 32]))
-    ///         .gas_limit(5000)
-    ///         .transferred_value(10)
-    ///         .exec_input(
-    ///             ExecutionInput::new(Selector::new([0xCA, 0xFE, 0xBA, 0xBE]))
-    ///                 .push_arg(42)
-    ///                 .push_arg(true)
-    ///                 .push_arg(&[0x10u8; 32])
-    ///         )
-    ///         .returns::<()>()
-    ///         .params();
-    ///     self.env().invoke_contract(&call_params).expect("call invocation must succeed");
-    /// }
-    /// #
-    /// #     }
-    /// # }
-    /// ```
-    ///
-    /// # Note
-    ///
-    /// For more details visit: [`ink_env::invoke_contract`]
-    pub fn invoke_contract<Args>(self, params: &CallParams<T, Args, ()>) -> Result<()>
-    where
-        Args: scale::Encode,
-    {
-        ink_env::invoke_contract::<T, Args>(params)
-    }
-
-    /// Evaluates a contract message and returns its result.
+    /// Invokes a contract message and returns its result.
     ///
     /// # Example
     ///
@@ -582,9 +527,9 @@ where
     /// #             Self {}
     /// #         }
     /// #
-    /// /// Evaluates a contract message and fetches the result.
+    /// /// Invokes a contract message and fetches the result.
     /// #[ink(message)]
-    /// pub fn evaluate_contract(&self) -> i32 {
+    /// pub fn invoke_contract(&self) -> i32 {
     ///     let call_params = build_call::<DefaultEnvironment>()
     ///         .callee(AccountId::from([0x42; 32]))
     ///         .gas_limit(5000)
@@ -597,7 +542,7 @@ where
     ///         )
     ///         .returns::<ReturnType<i32>>()
     ///         .params();
-    ///     self.env().eval_contract(&call_params).expect("call invocation must succeed")
+    ///     self.env().invoke_contract(&call_params).expect("call invocation must succeed")
     /// }
     /// #
     /// #     }
@@ -606,8 +551,8 @@ where
     ///
     /// # Note
     ///
-    /// For more details visit: [`ink_env::eval_contract`]
-    pub fn eval_contract<Args, R>(
+    /// For more details visit: [`ink_env::invoke_contract`]
+    pub fn invoke_contract<Args, R>(
         self,
         params: &CallParams<T, Args, ReturnType<R>>,
     ) -> Result<R>
@@ -615,7 +560,7 @@ where
         Args: scale::Encode,
         R: scale::Decode,
     {
-        ink_env::eval_contract::<T, Args, R>(params)
+        ink_env::invoke_contract::<T, Args, R>(params)
     }
 
     /// Terminates the existence of a contract.

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -381,7 +381,7 @@ mod erc1155 {
             value: Balance,
             data: Vec<u8>,
         ) {
-            // This is disabled during tests due to the use of `eval_contract()` not being
+            // This is disabled during tests due to the use of `invoke_contract()` not being
             // supported (tests end up panicking).
             #[cfg(not(test))]
             {
@@ -408,7 +408,7 @@ mod erc1155 {
                     .returns::<ReturnType<Vec<u8>>>()
                     .params();
 
-                match ink_env::eval_contract(&params) {
+                match ink_env::invoke_contract(&params) {
                     Ok(v) => {
                         ink_env::debug_println!(
                             "Received return value \"{:?}\" from contract {:?}",


### PR DESCRIPTION
WIP exploring how easy it is to unify those two functions and simplify the API. Requires explicitly setting of `()` as the return type on the call builder. 

If using the call builder API explicitly to invoke a message which does have a return value but you want to skip decoding it, as was the previous behaviour of `invoke_contract`,  the user can simply set the return type to `()`. 