### PR TITLE
Extracted push and pull of the contract in the dispatching logic

### DIFF
--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -740,6 +740,8 @@ impl Dispatch<'_> {
 
             quote_spanned!(message_span=>
                 Self::#message_ident(input) => {
+                    use ::core::default::Default;
+
                     if #deny_payment {
                         ::ink_lang::codegen::deny_payment::<
                             <#storage_ident as ::ink_lang::reflect::ContractEnv>::Env>()?;

--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -722,8 +722,8 @@ impl Dispatch<'_> {
                     }>>::IDS[#index]
                 }>>::Output
             );
-            let accepts_payment = quote_spanned!(message_span=>
-                false ||
+            let deny_payment = quote_spanned!(message_span=>
+                true &&
                 <#storage_ident as ::ink_lang::reflect::DispatchableMessageInfo<{
                     <#storage_ident as ::ink_lang::reflect::ContractDispatchableMessages<{
                         <#storage_ident as ::ink_lang::reflect::ContractAmountDispatchables>::MESSAGES
@@ -740,7 +740,7 @@ impl Dispatch<'_> {
 
             quote_spanned!(message_span=>
                 Self::#message_ident(input) => {
-                    if !#accepts_payment {
+                    if #deny_payment {
                         ::ink_lang::codegen::deny_payment::<
                             <#storage_ident as ::ink_lang::reflect::ContractEnv>::Env>()?;
                     }

--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -804,6 +804,7 @@ impl Dispatch<'_> {
                 impl ::ink_lang::reflect::ExecuteDispatchable for __ink_MessageDecoder {
                     #[allow(clippy::nonminimal_bool)]
                     fn execute_dispatchable(self) -> ::core::result::Result<(), ::ink_lang::reflect::DispatchError> {
+                        use ::core::convert::From;
                         let root_key = ::ink_primitives::Key::from([0x00; 32]);
 
                         let mut contract: ::core::mem::ManuallyDrop<#storage_ident> =

--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -751,8 +751,9 @@ impl Dispatch<'_> {
                         && ::ink_lang::is_result_err!(result);
 
                     if failure {
-                        // There is no need to push back the intermediate results of the
-                        // contract since the transaction is going to be reverted.
+                        // We return early here since there is no need to push back the
+                        // intermediate results of the contract - the transaction is going to be
+                        // reverted anyways.
                         ::ink_env::return_value::<#message_output>(
                             ::ink_env::ReturnFlags::default().set_reverted(true), &result
                         )
@@ -804,7 +805,9 @@ impl Dispatch<'_> {
 
                 impl ::ink_lang::reflect::ExecuteDispatchable for __ink_MessageDecoder {
                     #[allow(clippy::nonminimal_bool)]
-                    fn execute_dispatchable(self) -> ::core::result::Result<(), ::ink_lang::reflect::DispatchError> {
+                    fn execute_dispatchable(
+                        self
+                    ) -> ::core::result::Result<(), ::ink_lang::reflect::DispatchError> {
                         use ::core::convert::From;
                         let root_key = ::ink_primitives::Key::from([0x00; 32]);
 

--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -803,26 +803,25 @@ impl Dispatch<'_> {
                     }
                 }
 
+                static ROOT_KEY: ::ink_primitives::Key = ::ink_primitives::Key::new([0x00; 32]);
+
+                fn push_contract(contract: ::core::mem::ManuallyDrop<#storage_ident>, mutates: bool) {
+                    if mutates {
+                        ::ink_storage::traits::push_spread_root::<#storage_ident>(
+                            &contract, &ROOT_KEY
+                        );
+                    }
+                }
+
                 impl ::ink_lang::reflect::ExecuteDispatchable for __ink_MessageDecoder {
                     #[allow(clippy::nonminimal_bool)]
                     fn execute_dispatchable(
                         self
                     ) -> ::core::result::Result<(), ::ink_lang::reflect::DispatchError> {
-                        use ::core::convert::From;
-                        let root_key = ::ink_primitives::Key::from([0x00; 32]);
-
                         let mut contract: ::core::mem::ManuallyDrop<#storage_ident> =
                             ::core::mem::ManuallyDrop::new(
-                                ::ink_storage::traits::pull_spread_root::<#storage_ident>(&root_key)
+                                ::ink_storage::traits::pull_spread_root::<#storage_ident>(&ROOT_KEY)
                             );
-
-                        let push_contract = |contract: ::core::mem::ManuallyDrop<#storage_ident>, mutates: bool| {
-                            if mutates {
-                                ::ink_storage::traits::push_spread_root::<#storage_ident>(
-                                    &contract, &root_key
-                                );
-                            }
-                        };
 
                         match self {
                             #( #message_execute ),*

--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -723,8 +723,7 @@ impl Dispatch<'_> {
                 }>>::Output
             );
             let deny_payment = quote_spanned!(message_span=>
-                true &&
-                <#storage_ident as ::ink_lang::reflect::DispatchableMessageInfo<{
+                !<#storage_ident as ::ink_lang::reflect::DispatchableMessageInfo<{
                     <#storage_ident as ::ink_lang::reflect::ContractDispatchableMessages<{
                         <#storage_ident as ::ink_lang::reflect::ContractAmountDispatchables>::MESSAGES
                     }>>::IDS[#index]

--- a/crates/lang/src/codegen/dispatch/execution.rs
+++ b/crates/lang/src/codegen/dispatch/execution.rs
@@ -17,7 +17,6 @@ use crate::reflect::{
     DispatchError,
 };
 use core::{
-    any::TypeId,
     convert::Infallible,
     mem::ManuallyDrop,
 };
@@ -30,7 +29,6 @@ use ink_primitives::{
     KeyPtr,
 };
 use ink_storage::traits::{
-    pull_spread_root,
     push_spread_root,
     SpreadAllocate,
     SpreadLayout,
@@ -263,105 +261,4 @@ impl<C, E> InitializerReturnType<C> for Result<(), E> {
     fn into_wrapped(self, wrapped: C) -> Self::Wrapped {
         self.map(|_| wrapped)
     }
-}
-
-/// Configuration for execution of ink! messages.
-#[derive(Debug, Copy, Clone)]
-pub struct ExecuteMessageConfig {
-    /// Yields `true` if the ink! message accepts payment.
-    pub payable: bool,
-    /// Yields `true` if the ink! message might mutate contract storage.
-    ///
-    /// # Note
-    ///
-    /// This is usually true for `&mut self` ink! messages.
-    pub mutates: bool,
-}
-
-/// Initiates an ink! message call with the given configuration.
-///
-/// Returns the contract state pulled from the root storage region upon success.
-///
-/// # Note
-///
-/// This work around that splits executing an ink! message into initiate
-/// and finalize phases was needed due to the fact that `is_result_type`
-/// and `is_result_err` macros do not work in generic contexts.
-#[inline]
-pub fn initiate_message<Contract>(
-    config: ExecuteMessageConfig,
-) -> Result<Contract, DispatchError>
-where
-    Contract: SpreadLayout + ContractEnv,
-{
-    if !config.payable {
-        deny_payment::<<Contract as ContractEnv>::Env>()?;
-    }
-    let root_key = Key::from([0x00; 32]);
-    let contract = pull_spread_root::<Contract>(&root_key);
-    Ok(contract)
-}
-
-/// Finalizes an ink! message call with the given configuration.
-///
-/// This dispatches into fallible and infallible message finalization
-/// depending on the given `success` state.
-///
-/// - If the message call was successful the return value is simply returned
-///   and cached storage is pushed back to the contract storage.
-/// - If the message call failed the return value result is returned instead
-///   and the transaction is signalled to be reverted.
-///
-/// # Note
-///
-/// This work around that splits executing an ink! message into initiate
-/// and finalize phases was needed due to the fact that `is_result_type`
-/// and `is_result_err` macros do not work in generic contexts.
-#[inline]
-pub fn finalize_message<Contract, R>(
-    success: bool,
-    contract: &Contract,
-    config: ExecuteMessageConfig,
-    result: &R,
-) -> Result<(), DispatchError>
-where
-    Contract: SpreadLayout,
-    R: scale::Encode + 'static,
-{
-    if success {
-        finalize_infallible_message(contract, config, result)
-    } else {
-        finalize_fallible_message(result)
-    }
-}
-
-#[inline]
-fn finalize_infallible_message<Contract, R>(
-    contract: &Contract,
-    config: ExecuteMessageConfig,
-    result: &R,
-) -> Result<(), DispatchError>
-where
-    Contract: SpreadLayout,
-    R: scale::Encode + 'static,
-{
-    if config.mutates {
-        let root_key = Key::from([0x00; 32]);
-        push_spread_root::<Contract>(contract, &root_key);
-    }
-    if TypeId::of::<R>() != TypeId::of::<()>() {
-        // In case the return type is `()` we do not return a value.
-        ink_env::return_value::<R>(ReturnFlags::default(), result)
-    }
-    Ok(())
-}
-
-#[inline]
-fn finalize_fallible_message<R>(result: &R) -> !
-where
-    R: scale::Encode + 'static,
-{
-    // There is no need to push back the intermediate results of the
-    // contract since the transaction is going to be reverted.
-    ink_env::return_value::<R>(ReturnFlags::default().set_reverted(true), result)
 }

--- a/crates/lang/src/codegen/dispatch/mod.rs
+++ b/crates/lang/src/codegen/dispatch/mod.rs
@@ -20,12 +20,9 @@ pub use self::{
     execution::{
         deny_payment,
         execute_constructor,
-        finalize_message,
         initialize_contract,
-        initiate_message,
         ContractRootKey,
         ExecuteConstructorConfig,
-        ExecuteMessageConfig,
     },
     info::ContractCallBuilder,
     type_check::{

--- a/crates/lang/src/codegen/mod.rs
+++ b/crates/lang/src/codegen/mod.rs
@@ -25,15 +25,12 @@ pub use self::{
     dispatch::{
         deny_payment,
         execute_constructor,
-        finalize_message,
         initialize_contract,
-        initiate_message,
         ContractCallBuilder,
         ContractRootKey,
         DispatchInput,
         DispatchOutput,
         ExecuteConstructorConfig,
-        ExecuteMessageConfig,
     },
     env::{
         Env,

--- a/crates/lang/tests/ui/contract/fail/message-returns-non-codec.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-returns-non-codec.stderr
@@ -20,11 +20,11 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
     | |_________^ the trait `WrapperTypeEncode` is not implemented for `NonCodecType`
     |
     = note: required because of the requirements on the impl of `Encode` for `NonCodecType`
-note: required by a bound in `finalize_message`
-   --> src/codegen/dispatch/execution.rs
+note: required by a bound in `return_value`
+   --> $WORKSPACE/crates/env/src/api.rs
     |
-    |     R: scale::Encode + 'static,
-    |        ^^^^^^^^^^^^^ required by this bound in `finalize_message`
+    |     R: scale::Encode,
+    |        ^^^^^^^^^^^^^ required by this bound in `return_value`
 
 error[E0599]: the method `fire` exists for struct `ink_env::call::CallBuilder<DefaultEnvironment, Set<Call<DefaultEnvironment>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodecType>>>`, but its trait bounds were not satisfied
    --> tests/ui/contract/fail/message-returns-non-codec.rs:18:9


### PR DESCRIPTION
Extracted push and pull of the contract in the dispatching logic to reduce the size of the contracts.

It is part of the https://github.com/paritytech/ink/pull/1017. It is easy to review and it can be part of a stable release=)