### PR TITLE
limit codegen-units to get the maximum optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ exclude = [
 [profile.release]
 panic = "abort"
 lto = true
+# https://github.com/rust-lang/rust/issues/47745
+# https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
+codegen-units = 1


### PR DESCRIPTION
Hello,

There might be a performance regression due to enabling lto without limiting the number of code generation units (codegen-units = 1).

References:
https://github.com/rust-lang/rust/issues/47745
https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units