### PR TITLE
Fix build after SCALE `v3.1` update

### DIFF
--- a/crates/lang/codegen/src/generator/as_dependency/call_builder.rs
+++ b/crates/lang/codegen/src/generator/as_dependency/call_builder.rs
@@ -97,6 +97,7 @@ impl CallBuilder<'_> {
                 ::core::cmp::Eq,
                 ::core::clone::Clone,
             )]
+            #[codec(crate = ::scale)]
             pub struct #cb_ident {
                 account_id: AccountId,
             }

--- a/crates/lang/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/lang/codegen/src/generator/as_dependency/contract_ref.rs
@@ -101,6 +101,7 @@ impl ContractRef<'_> {
                 ::core::cmp::Eq,
                 ::core::clone::Clone,
             )]
+            #[codec(crate = ::scale)]
             #( #doc_attrs )*
             pub struct #ref_ident {
                 inner: <#storage_ident as ::ink_lang::codegen::ContractCallBuilder>::Type,

--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -95,6 +95,7 @@ impl<'a> Events<'a> {
         quote! {
             #[allow(non_camel_case_types)]
             #[derive(::scale::Encode, ::scale::Decode)]
+            #[codec(crate = ::scale)]
             #[cfg(not(feature = "__ink_dylint_EventBase"))]
             pub enum #base_event_ident {
                 #( #event_idents(#event_idents), )*

--- a/crates/lang/codegen/src/generator/trait_def/call_builder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_builder.rs
@@ -111,6 +111,7 @@ impl CallBuilder<'_> {
             #[doc(hidden)]
             #[allow(non_camel_case_types)]
             #[derive(::scale::Encode, ::scale::Decode)]
+            #[codec(crate = ::scale)]
             #[repr(transparent)]
             pub struct #call_builder_ident<E>
             where

--- a/crates/lang/codegen/src/generator/trait_def/call_forwarder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_forwarder.rs
@@ -115,6 +115,7 @@ impl CallForwarder<'_> {
             #[doc(hidden)]
             #[allow(non_camel_case_types)]
             #[derive(::scale::Encode, ::scale::Decode)]
+            #[codec(crate = ::scale)]
             #[repr(transparent)]
             pub struct #call_forwarder_ident<E>
             where

--- a/crates/lang/tests/ui/contract/fail/message-returns-non-codec.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-returns-non-codec.stderr
@@ -40,7 +40,7 @@ error[E0599]: the method `fire` exists for struct `ink_env::call::CallBuilder<De
     = note: the following trait bounds were not satisfied:
             `NonCodecType: parity_scale_codec::Decode`
 note: the following trait must be implemented
-   --> $CARGO/parity-scale-codec-3.0.0/src/codec.rs
+   --> $CARGO/parity-scale-codec-3.1.0/src/codec.rs
     |
     | / pub trait Decode: Sized {
     | |     // !INTERNAL USE ONLY!

--- a/crates/lang/tests/ui/trait_def/fail/message_output_non_codec.stderr
+++ b/crates/lang/tests/ui/trait_def/fail/message_output_non_codec.stderr
@@ -24,7 +24,7 @@ error[E0599]: the method `fire` exists for struct `CallBuilder<E, Set<Call<E>>, 
     = note: the following trait bounds were not satisfied:
             `NonCodec: parity_scale_codec::Decode`
 note: the following trait must be implemented
-   --> $CARGO/parity-scale-codec-3.0.0/src/codec.rs
+   --> $CARGO/parity-scale-codec-3.1.0/src/codec.rs
     |
     | / pub trait Decode: Sized {
     | |     // !INTERNAL USE ONLY!


### PR DESCRIPTION
Looks like `parity-scale-codec-(derive)` `v3.1` introduced a breaking change with
https://github.com/paritytech/parity-scale-codec/pull/325.

This PR specifies the path we use when pulling in the crate and fixes our failing
`master` build.
