### PR TITLE
Fix `clippy::only-used-in-recursion`

### DIFF
--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -57,8 +57,8 @@ impl FromLittleEndian for u8 {
     type Bytes = [u8; 1];
 
     #[inline]
-    fn from_le_bytes(bytes: Self::Bytes) -> Self {
-        Self::from_le_bytes(bytes)
+    fn from_le_bytes(_bytes: Self::Bytes) -> Self {
+        Self::from_le_bytes(_bytes)
     }
 }
 
@@ -66,8 +66,8 @@ impl FromLittleEndian for u16 {
     type Bytes = [u8; 2];
 
     #[inline]
-    fn from_le_bytes(bytes: Self::Bytes) -> Self {
-        Self::from_le_bytes(bytes)
+    fn from_le_bytes(_bytes: Self::Bytes) -> Self {
+        Self::from_le_bytes(_bytes)
     }
 }
 
@@ -75,8 +75,8 @@ impl FromLittleEndian for u32 {
     type Bytes = [u8; 4];
 
     #[inline]
-    fn from_le_bytes(bytes: Self::Bytes) -> Self {
-        Self::from_le_bytes(bytes)
+    fn from_le_bytes(_bytes: Self::Bytes) -> Self {
+        Self::from_le_bytes(_bytes)
     }
 }
 
@@ -84,8 +84,8 @@ impl FromLittleEndian for u64 {
     type Bytes = [u8; 8];
 
     #[inline]
-    fn from_le_bytes(bytes: Self::Bytes) -> Self {
-        Self::from_le_bytes(bytes)
+    fn from_le_bytes(_bytes: Self::Bytes) -> Self {
+        Self::from_le_bytes(_bytes)
     }
 }
 
@@ -93,8 +93,8 @@ impl FromLittleEndian for u128 {
     type Bytes = [u8; 16];
 
     #[inline]
-    fn from_le_bytes(bytes: Self::Bytes) -> Self {
-        Self::from_le_bytes(bytes)
+    fn from_le_bytes(_bytes: Self::Bytes) -> Self {
+        Self::from_le_bytes(_bytes)
     }
 }
 

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -57,8 +57,8 @@ impl FromLittleEndian for u8 {
     type Bytes = [u8; 1];
 
     #[inline]
-    fn from_le_bytes(_bytes: Self::Bytes) -> Self {
-        Self::from_le_bytes(_bytes)
+    fn from_le_bytes(bytes: Self::Bytes) -> Self {
+        u8::from_le_bytes(bytes)
     }
 }
 
@@ -66,8 +66,8 @@ impl FromLittleEndian for u16 {
     type Bytes = [u8; 2];
 
     #[inline]
-    fn from_le_bytes(_bytes: Self::Bytes) -> Self {
-        Self::from_le_bytes(_bytes)
+    fn from_le_bytes(bytes: Self::Bytes) -> Self {
+        u16::from_le_bytes(bytes)
     }
 }
 
@@ -75,8 +75,8 @@ impl FromLittleEndian for u32 {
     type Bytes = [u8; 4];
 
     #[inline]
-    fn from_le_bytes(_bytes: Self::Bytes) -> Self {
-        Self::from_le_bytes(_bytes)
+    fn from_le_bytes(bytes: Self::Bytes) -> Self {
+        u32::from_le_bytes(bytes)
     }
 }
 
@@ -84,8 +84,8 @@ impl FromLittleEndian for u64 {
     type Bytes = [u8; 8];
 
     #[inline]
-    fn from_le_bytes(_bytes: Self::Bytes) -> Self {
-        Self::from_le_bytes(_bytes)
+    fn from_le_bytes(bytes: Self::Bytes) -> Self {
+        u64::from_le_bytes(bytes)
     }
 }
 
@@ -93,8 +93,8 @@ impl FromLittleEndian for u128 {
     type Bytes = [u8; 16];
 
     #[inline]
-    fn from_le_bytes(_bytes: Self::Bytes) -> Self {
-        Self::from_le_bytes(_bytes)
+    fn from_le_bytes(bytes: Self::Bytes) -> Self {
+        u128::from_le_bytes(bytes)
     }
 }
 


### PR DESCRIPTION
`master` CI with latest nightly fails at https://gitlab.parity.io/parity/ink/-/jobs/1440908 with https://rust-lang.github.io/rust-clippy/master/index.html#only_used_in_recursion.