### PR TITLE
Highlight StackExchange when creating an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Support & Troubleshooting with the Stack Exchange Community
+    url: https://substrate.stackexchange.com
+    about: |
+        For general questions you might already find an answer in our community.
+        We encourage everyone to also share their understanding by answering questions for others.


### PR DESCRIPTION
I noticed Substrate does the same here: https://github.com/paritytech/substrate/issues/new/choose.

I think it's a good idea.