### PR TITLE
Stop using `CallData` in Multisig doc test

### DIFF
--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -715,7 +715,7 @@ mod multisig {
     mod tests {
         use super::*;
         use ink_env::{
-            call,
+            call::utils::ArgumentList,
             test,
         };
         use ink_lang as ink;
@@ -724,13 +724,14 @@ mod multisig {
 
         impl Transaction {
             fn change_requirement(requirement: u32) -> Self {
+                use scale::Encode;
+                let call_args = ArgumentList::empty().push_arg(&requirement);
+
                 // Multisig::change_requirement()
-                let mut call = test::CallData::new(call::Selector::new([0x00; 4]));
-                call.push_arg(&requirement);
                 Self {
                     callee: AccountId::from(WALLET),
-                    selector: call.selector().to_bytes(),
-                    input: call.params().to_owned(),
+                    selector: ink::selector_bytes!("change_requirement"),
+                    input: call_args.encode(),
                     transferred_value: 0,
                     gas_limit: 1000000,
                 }

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -309,7 +309,19 @@ mod multisig {
         /// Since this message must be send by the wallet itself it has to be build as a
         /// `Transaction` and dispatched through `submit_transaction` and `invoke_transaction`:
         /// ```should_panic
-        /// use ink_env::{DefaultEnvironment as Env, AccountId, call::{CallParams, Selector, ExecutionInput, Call}, test::CallData};
+        /// use ink_env::{
+        ///     call::{
+        ///         utils::ArgumentList,
+        ///         Call,
+        ///         CallParams,
+        ///         ExecutionInput,
+        ///         Selector,
+        ///     },
+        ///     AccountId,
+        ///     DefaultEnvironment as Env,
+        /// };
+        /// use ink_lang::selector_bytes;
+        /// use scale::Encode;
         /// use multisig::{Transaction, ConfirmationStatus};
         ///
         /// // address of an existing `Multisig` contract
@@ -317,14 +329,12 @@ mod multisig {
         ///
         /// // first create the transaction that adds `alice` through `add_owner`
         /// let alice: AccountId = [1u8; 32].into();
-        /// // Note: The selector bytes for `add_owner` are [166, 229, 27, 154]
-        /// let mut add_owner_call = CallData::new(Selector::new([166, 229, 27, 154]));
-        /// add_owner_call.push_arg(&alice);
+        /// let add_owner_args = ArgumentList::empty().push_arg(&alice);
         ///
         /// let transaction_candidate = Transaction {
         ///     callee: wallet_id,
-        ///     selector: add_owner_call.selector().to_bytes(),
-        ///     input: add_owner_call.params().to_owned(),
+        ///     selector: selector_bytes!("add_owner"),
+        ///     input: add_owner_args.encode(),
         ///     transferred_value: 0,
         ///     gas_limit: 0
         /// };


### PR DESCRIPTION
The example we were providing in the `add_owner` documentation of the Multisig example
used `CallData`, which is only available in the off-chain testing engine. This meant that
if contract authors used this example vertabim in their contracts (which is totally
reasonable in this case) their [contracts wouldn't compile](https://github.com/paritytech/ink/issues/1197#issuecomment-1078649279).

I've changed the example to use things that would be available to contract authors so
in order to make the example more copy-pastable.

Closes #1197 again 😅
