### PR TITLE
Remove redundant `TryFrom/Into` & `FromIterator` imports

### DIFF
--- a/crates/env/src/arithmetic.rs
+++ b/crates/env/src/arithmetic.rs
@@ -15,10 +15,6 @@
 //! Primitive traits for runtime arithmetic, copied from substrate
 
 use core::{
-    convert::{
-        TryFrom,
-        TryInto,
-    },
     ops::{
         Add,
         AddAssign,

--- a/crates/env/src/arithmetic.rs
+++ b/crates/env/src/arithmetic.rs
@@ -14,17 +14,15 @@
 
 //! Primitive traits for runtime arithmetic, copied from substrate
 
-use core::{
-    ops::{
-        Add,
-        AddAssign,
-        Div,
-        DivAssign,
-        Mul,
-        MulAssign,
-        Sub,
-        SubAssign,
-    },
+use core::ops::{
+    Add,
+    AddAssign,
+    Div,
+    DivAssign,
+    Mul,
+    MulAssign,
+    Sub,
+    SubAssign,
 };
 use num_traits::{
     checked_pow,

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -32,10 +32,7 @@
 //! the trait bounds on the `Environment` trait types.
 
 use super::arithmetic::AtLeast32BitUnsigned;
-use core::{
-    array::TryFromSliceError,
-    convert::TryFrom,
-};
+use core::array::TryFromSliceError;
 use derive_more::From;
 use scale::{
     Decode,

--- a/crates/lang/ir/src/ir/attrs.rs
+++ b/crates/lang/ir/src/ir/attrs.rs
@@ -20,10 +20,7 @@ use crate::{
         Selector,
     },
 };
-use core::{
-    convert::TryFrom,
-    result::Result,
-};
+use core::result::Result;
 use proc_macro2::{
     Group as Group2,
     Ident,

--- a/crates/lang/ir/src/ir/blake2.rs
+++ b/crates/lang/ir/src/ir/blake2.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::convert::TryFrom;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::spanned::Spanned as _;
 

--- a/crates/lang/ir/src/ir/chain_extension.rs
+++ b/crates/lang/ir/src/ir/chain_extension.rs
@@ -17,10 +17,7 @@ use crate::{
     ir,
     ir::idents_lint,
 };
-use core::{
-    convert::TryFrom,
-    slice::Iter as SliceIter,
-};
+use core::slice::Iter as SliceIter;
 use proc_macro2::TokenStream as TokenStream2;
 use std::collections::HashMap;
 use syn::{

--- a/crates/lang/ir/src/ir/config.rs
+++ b/crates/lang/ir/src/ir/config.rs
@@ -17,7 +17,6 @@ use crate::{
     ast::MetaNameValue,
     error::ExtError as _,
 };
-use core::convert::TryFrom;
 use std::collections::HashMap;
 use syn::spanned::Spanned;
 

--- a/crates/lang/ir/src/ir/contract.rs
+++ b/crates/lang/ir/src/ir/contract.rs
@@ -16,7 +16,6 @@ use crate::{
     ast,
     ir,
 };
-use core::convert::TryFrom;
 use proc_macro2::TokenStream as TokenStream2;
 
 /// An ink! contract definition consisting of the ink! configuration and module.

--- a/crates/lang/ir/src/ir/ink_test.rs
+++ b/crates/lang/ir/src/ir/ink_test.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::ir::idents_lint;
-use core::convert::TryFrom;
 use proc_macro2::TokenStream as TokenStream2;
 
 /// The ink! test with all required information.

--- a/crates/lang/ir/src/ir/item/event.rs
+++ b/crates/lang/ir/src/ir/item/event.rs
@@ -17,7 +17,6 @@ use crate::{
     ir,
     ir::utils,
 };
-use core::convert::TryFrom;
 use proc_macro2::{
     Ident,
     Span,
@@ -29,7 +28,6 @@ use syn::spanned::Spanned as _;
 /// # Example
 ///
 /// ```
-/// # use core::convert::TryFrom;
 /// # let event = <ink_lang_ir::Event as TryFrom<syn::ItemStruct>>::try_from(syn::parse_quote! {
 /// #[ink(event)]
 /// pub struct Transaction {

--- a/crates/lang/ir/src/ir/item/mod.rs
+++ b/crates/lang/ir/src/ir/item/mod.rs
@@ -28,7 +28,6 @@ use crate::{
     ir,
     ir::attrs::Attrs as _,
 };
-use core::convert::TryFrom;
 use syn::spanned::Spanned as _;
 
 /// An item in the root of the ink! module ([`ir::ItemMod`](`crate::ir::ItemMod`)).

--- a/crates/lang/ir/src/ir/item/storage.rs
+++ b/crates/lang/ir/src/ir/item/storage.rs
@@ -16,7 +16,6 @@ use crate::{
     ir,
     ir::utils,
 };
-use core::convert::TryFrom;
 use proc_macro2::Ident;
 use syn::spanned::Spanned as _;
 
@@ -32,7 +31,6 @@ use syn::spanned::Spanned as _;
 /// # Example
 ///
 /// ```
-/// # use core::convert::TryFrom;
 /// # <ink_lang_ir::Storage as TryFrom<syn::ItemStruct>>::try_from(syn::parse_quote! {
 /// #[ink(storage)]
 /// pub struct MyStorage {

--- a/crates/lang/ir/src/ir/item_impl/callable.rs
+++ b/crates/lang/ir/src/ir/item_impl/callable.rs
@@ -536,10 +536,7 @@ impl<'a> ExactSizeIterator for InputsIter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::{
-        convert::TryFrom,
-        fmt::Debug,
-    };
+    use core::fmt::Debug;
 
     pub enum ExpectedSelector {
         Raw([u8; 4]),

--- a/crates/lang/ir/src/ir/item_impl/constructor.rs
+++ b/crates/lang/ir/src/ir/item_impl/constructor.rs
@@ -23,7 +23,6 @@ use crate::{
     ir,
     ir::attrs::SelectorOrWildcard,
 };
-use core::convert::TryFrom;
 use proc_macro2::{
     Ident,
     Span,
@@ -37,7 +36,6 @@ use syn::spanned::Spanned as _;
 /// ## Inherent implementation constructor:
 ///
 /// ```
-/// # use core::convert::TryFrom;
 /// # let event = <ink_lang_ir::ItemImpl as TryFrom<syn::ItemImpl>>::try_from(syn::parse_quote! {
 /// impl MyStorage {
 ///     #[ink(constructor)]
@@ -52,7 +50,6 @@ use syn::spanned::Spanned as _;
 /// ## Trait implementation constructor:
 ///
 /// ```
-/// # use core::convert::TryFrom;
 /// # <ink_lang_ir::ItemImpl as TryFrom<syn::ItemImpl>>::try_from(syn::parse_quote! {
 /// impl MyTrait for MyStorage {
 ///     #[ink(constructor)]

--- a/crates/lang/ir/src/ir/item_impl/impl_item.rs
+++ b/crates/lang/ir/src/ir/item_impl/impl_item.rs
@@ -21,7 +21,6 @@ use crate::{
     ir,
     ir::attrs::Attrs as _,
 };
-use core::convert::TryFrom;
 use syn::spanned::Spanned as _;
 
 /// An item within an ink! implementation block.

--- a/crates/lang/ir/src/ir/item_impl/message.rs
+++ b/crates/lang/ir/src/ir/item_impl/message.rs
@@ -24,7 +24,6 @@ use crate::ir::{
     attrs::SelectorOrWildcard,
     utils,
 };
-use core::convert::TryFrom;
 use proc_macro2::{
     Ident,
     Span,
@@ -69,7 +68,6 @@ impl Receiver {
 /// ## Inherent implementation message:
 ///
 /// ```
-/// # use core::convert::TryFrom;
 /// # <ink_lang_ir::ItemImpl as TryFrom<syn::ItemImpl>>::try_from(syn::parse_quote! {
 /// impl MyStorage {
 ///     #[ink(message)]
@@ -84,7 +82,6 @@ impl Receiver {
 /// ## Trait implementation message:
 ///
 /// ```
-/// # use core::convert::TryFrom;
 /// # let event = <ink_lang_ir::ItemImpl as TryFrom<syn::ItemImpl>>::try_from(syn::parse_quote! {
 /// impl MyTrait for MyStorage {
 ///     #[ink(message)]

--- a/crates/lang/ir/src/ir/item_impl/mod.rs
+++ b/crates/lang/ir/src/ir/item_impl/mod.rs
@@ -17,7 +17,6 @@ use crate::{
     ir,
     ir::attrs::Attrs as _,
 };
-use core::convert::TryFrom;
 use proc_macro2::{
     Ident,
     Span,
@@ -124,7 +123,6 @@ impl ItemImpl {
     /// - The ink! implementation block has been annotated as in:
     ///
     /// ```
-    /// # use core::convert::TryFrom;
     /// # <ink_lang_ir::ItemImpl as TryFrom<syn::ItemImpl>>::try_from(syn::parse_quote! {
     /// #[ink(impl)]
     /// impl MyStorage {
@@ -140,7 +138,6 @@ impl ItemImpl {
     ///   specific annotations:
     ///
     /// ```
-    /// # use core::convert::TryFrom;
     /// # <ink_lang_ir::ItemImpl as TryFrom<syn::ItemImpl>>::try_from(syn::parse_quote! {
     /// impl MyStorage {
     ///     #[ink(constructor)]

--- a/crates/lang/ir/src/ir/item_impl/tests.rs
+++ b/crates/lang/ir/src/ir/item_impl/tests.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use crate::ir;
-use core::convert::TryFrom;
 
 #[test]
 fn is_ink_impl_block_eval_false_works() {

--- a/crates/lang/ir/src/ir/item_mod.rs
+++ b/crates/lang/ir/src/ir/item_mod.rs
@@ -17,7 +17,6 @@ use crate::{
     ir::idents_lint,
     Callable,
 };
-use core::convert::TryFrom;
 use proc_macro2::{
     Ident,
     Span,
@@ -41,7 +40,6 @@ use syn::{
 ///
 /// ```
 /// // #[ink::contract] <-- this line belongs to the ink! configuration!
-/// # use core::convert::TryFrom;
 /// # use ink_lang_ir as ir;
 /// # <ir::ItemMod as TryFrom<syn::ItemMod>>::try_from(syn::parse_quote! {
 /// mod my_contract {
@@ -413,7 +411,6 @@ impl ItemMod {
     /// least one `#[ink(message)]` or `#[ink(constructor)]` annotation, e.g.:
     ///
     /// ```
-    /// # use core::convert::TryFrom;
     /// # use ink_lang_ir as ir;
     /// # <ir::ItemMod as TryFrom<syn::ItemMod>>::try_from(syn::parse_quote! {
     /// # mod my_module {
@@ -442,7 +439,6 @@ impl ItemMod {
     /// e.g.:
     ///
     /// ```
-    /// # use core::convert::TryFrom;
     /// # use ink_lang_ir as ir;
     /// # <ir::ItemMod as TryFrom<syn::ItemMod>>::try_from(syn::parse_quote! {
     /// # mod my_module {

--- a/crates/lang/ir/src/ir/item_mod.rs
+++ b/crates/lang/ir/src/ir/item_mod.rs
@@ -587,7 +587,6 @@ impl<'a> Iterator for IterItemImpls<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate as ir;
 
     #[test]

--- a/crates/lang/ir/src/ir/selector.rs
+++ b/crates/lang/ir/src/ir/selector.rs
@@ -14,7 +14,6 @@
 
 use super::blake2::blake2b_256;
 use crate::literal::HexLiteral;
-use core::convert::TryFrom;
 use proc_macro2::TokenStream as TokenStream2;
 use std::marker::PhantomData;
 use syn::spanned::Spanned as _;

--- a/crates/lang/ir/src/ir/trait_def/config.rs
+++ b/crates/lang/ir/src/ir/trait_def/config.rs
@@ -17,7 +17,6 @@ use crate::{
     error::ExtError as _,
     ir::config::WhitelistedAttributes,
 };
-use core::convert::TryFrom;
 use syn::spanned::Spanned;
 
 /// The ink! configuration.

--- a/crates/lang/ir/src/ir/trait_def/item/mod.rs
+++ b/crates/lang/ir/src/ir/trait_def/item/mod.rs
@@ -32,8 +32,6 @@ use crate::{
     },
     Selector,
 };
-#[cfg(test)]
-use core::convert::TryFrom;
 use ir::TraitPrefix;
 use proc_macro2::{
     Ident,

--- a/crates/lang/ir/src/ir/trait_def/mod.rs
+++ b/crates/lang/ir/src/ir/trait_def/mod.rs
@@ -28,7 +28,6 @@ pub use self::{
     },
 };
 use super::attrs::InkAttribute;
-use core::convert::TryFrom;
 use proc_macro2::TokenStream as TokenStream2;
 use syn::Result;
 

--- a/crates/lang/macro/src/blake2b.rs
+++ b/crates/lang/macro/src/blake2b.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::convert::TryFrom as _;
 use ink_lang_codegen::generate_code;
 use ink_lang_ir::Blake2x256Macro;
 use proc_macro2::TokenStream as TokenStream2;

--- a/crates/lang/macro/src/selector.rs
+++ b/crates/lang/macro/src/selector.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::convert::TryFrom as _;
 use ink_lang_codegen::generate_code;
 use ink_lang_ir::{
     marker::{

--- a/crates/storage/src/collections/bitvec/impls.rs
+++ b/crates/storage/src/collections/bitvec/impls.rs
@@ -16,7 +16,6 @@ use super::{
     BitsIter,
     Bitvec as StorageBitvec,
 };
-use core::iter::FromIterator;
 
 impl Default for StorageBitvec {
     fn default() -> Self {

--- a/crates/storage/src/collections/hashmap/fuzz_tests.rs
+++ b/crates/storage/src/collections/hashmap/fuzz_tests.rs
@@ -31,10 +31,7 @@ use quickcheck::{
     Arbitrary,
     Gen,
 };
-use std::{
-    collections::HashMap,
-    iter::FromIterator,
-};
+use std::collections::HashMap;
 
 /// Conducts repeated insert and remove operations into the map by iterating
 /// over `xs`. For each odd `x` in `xs` a defined number of insert operations

--- a/crates/storage/src/collections/hashmap/impls.rs
+++ b/crates/storage/src/collections/hashmap/impls.rs
@@ -24,7 +24,6 @@ use core::{
         Ord,
         PartialEq,
     },
-    iter::FromIterator,
     ops,
 };
 use ink_env::hash::{

--- a/crates/storage/src/collections/vec/fuzz_tests.rs
+++ b/crates/storage/src/collections/vec/fuzz_tests.rs
@@ -30,10 +30,7 @@ use quickcheck::{
     Arbitrary,
     Gen,
 };
-use std::{
-    iter::FromIterator,
-    vec::Vec,
-};
+use std::vec::Vec;
 
 impl<T> Arbitrary for StorageVec<T>
 where

--- a/crates/storage/src/lazy/lazy_hmap.rs
+++ b/crates/storage/src/lazy/lazy_hmap.rs
@@ -36,7 +36,6 @@ use core::{
     },
     fmt,
     fmt::Debug,
-    iter::FromIterator,
     marker::PhantomData,
     ptr::NonNull,
 };


### PR DESCRIPTION
Since edition 2021 they are in the prelude