### PR TITLE
Optimize `push_topic`: write prefix bytes directly to buffer

### DIFF
--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -134,7 +134,7 @@ where
     where
         T: scale::Encode,
     {
-        let mut encoded = topic_prefix.to_vec();
+        let mut encoded = scale::Encode::encode(topic_prefix);
         topic_value.encode_to(&mut encoded);
         let len_encoded = encoded.len();
         let mut result = <E as Environment>::Hash::clear();

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -130,7 +130,7 @@ where
 
     fn expect(&mut self, _expected_topics: usize) {}
 
-    fn push_topic<T>(&mut self, topic_value: &T)
+    fn push_topic<T>(&mut self, topic_prefix: &[u8], topic_value: &T)
     where
         T: scale::Encode,
     {

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -134,7 +134,8 @@ where
     where
         T: scale::Encode,
     {
-        let encoded = topic_value.encode();
+        let mut encoded = topic_prefix.to_vec();
+        topic_value.encode_to(&mut encoded);
         let len_encoded = encoded.len();
         let mut result = <E as Environment>::Hash::clear();
         let len_result = result.as_ref().len();

--- a/crates/env/src/engine/off_chain/tests.rs
+++ b/crates/env/src/engine/off_chain/tests.rs
@@ -43,7 +43,7 @@ fn topics_builder() -> Result<()> {
         let topics_len_encoded = scale::Encode::encode(&topics_len_compact);
         let output = TopicsBuilderBackend::<crate::DefaultEnvironment>::output(builder);
         #[rustfmt::skip]
-        let expected = vec![topics_len_encoded[0], 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let expected = vec![topics_len_encoded[0], 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         assert_eq!(output, expected);
 
         Ok(())

--- a/crates/env/src/engine/off_chain/tests.rs
+++ b/crates/env/src/engine/off_chain/tests.rs
@@ -25,8 +25,16 @@ fn topics_builder() -> Result<()> {
         let mut builder = TopicsBuilder::default();
 
         // when
-        TopicsBuilderBackend::<crate::DefaultEnvironment>::push_topic(&mut builder, &[], &13);
-        TopicsBuilderBackend::<crate::DefaultEnvironment>::push_topic(&mut builder, &[], &17);
+        TopicsBuilderBackend::<crate::DefaultEnvironment>::push_topic(
+            &mut builder,
+            &[],
+            &13,
+        );
+        TopicsBuilderBackend::<crate::DefaultEnvironment>::push_topic(
+            &mut builder,
+            &[],
+            &17,
+        );
 
         // then
         assert_eq!(builder.topics.len(), 2);

--- a/crates/env/src/engine/off_chain/tests.rs
+++ b/crates/env/src/engine/off_chain/tests.rs
@@ -25,8 +25,8 @@ fn topics_builder() -> Result<()> {
         let mut builder = TopicsBuilder::default();
 
         // when
-        TopicsBuilderBackend::<crate::DefaultEnvironment>::push_topic(&mut builder, &13);
-        TopicsBuilderBackend::<crate::DefaultEnvironment>::push_topic(&mut builder, &17);
+        TopicsBuilderBackend::<crate::DefaultEnvironment>::push_topic(&mut builder, &[], &13);
+        TopicsBuilderBackend::<crate::DefaultEnvironment>::push_topic(&mut builder, &[], &17);
 
         // then
         assert_eq!(builder.topics.len(), 2);

--- a/crates/env/src/engine/on_chain/buffer.rs
+++ b/crates/env/src/engine/on_chain/buffer.rs
@@ -152,6 +152,13 @@ impl<'a> ScopedBuffer<'a> {
         buffer
     }
 
+    /// todo
+    pub fn append_bytes(&mut self, bytes: &[u8]) {
+        debug_assert_eq!(self.offset, 0);
+        let buffer = self.take(bytes.len());
+        buffer.copy_from_slice(bytes);
+    }
+
     /// Encode the given value into the scoped buffer and return the sub slice
     /// containing all the encoded bytes.
     pub fn take_encoded<T>(&mut self, value: &T) -> &'a mut [u8]

--- a/crates/env/src/engine/on_chain/buffer.rs
+++ b/crates/env/src/engine/on_chain/buffer.rs
@@ -152,7 +152,7 @@ impl<'a> ScopedBuffer<'a> {
         buffer
     }
 
-    /// todo
+    /// Appends the given `bytes` to the scoped buffer.
     pub fn append_bytes(&mut self, bytes: &[u8]) {
         debug_assert_eq!(self.offset, 0);
         let buffer = self.take(bytes.len());

--- a/crates/env/src/engine/on_chain/buffer.rs
+++ b/crates/env/src/engine/on_chain/buffer.rs
@@ -193,7 +193,7 @@ impl<'a> ScopedBuffer<'a> {
     }
 
     /// Returns the buffer containing all encodings appended via [`append_encoded`]
-    /// in a single byte buffer.
+    /// and [`append_bytes`] in a single byte buffer.
     pub fn take_appended(&mut self) -> &'a mut [u8] {
         debug_assert_ne!(self.offset, 0);
         let offset = self.offset;

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -161,11 +161,11 @@ where
             result
         }
 
-        self.scoped_buffer
-            .append_encoded(&scale::Compact::<u64>(topic_prefix.len() as u64));
-        self.scoped_buffer.append_bytes(topic_prefix);
         let mut split = self.scoped_buffer.split();
-        let encoded = split.take_encoded(topic_value);
+        // split.append_encoded(&scale::Compact::<u64>(topic_prefix.len() as u64));
+        split.append_bytes(topic_prefix);
+        split.append_encoded(topic_value);
+        let encoded = split.take_appended();
         let result = inner::<E>(encoded);
         self.scoped_buffer.append_bytes(result.as_ref());
     }

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -161,11 +161,11 @@ where
             result
         }
 
-        let _ = self.scoped_buffer.take_bytes(topic_prefix);
+        self.scoped_buffer.append_bytes(topic_prefix);
         let mut split = self.scoped_buffer.split();
         let encoded = split.take_encoded(topic_value);
         let result = inner::<E>(encoded);
-        self.scoped_buffer.append_encoded(&result);
+        self.scoped_buffer.append_bytes(result.as_ref());
     }
 
     fn output(mut self) -> Self::Output {

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -142,7 +142,7 @@ where
             .append_encoded(&scale::Compact(expected_topics as u32));
     }
 
-    fn push_topic<T>(&mut self, topic_value: &T)
+    fn push_topic<T>(&mut self, topic_prefix: &[u8], topic_value: &T)
     where
         T: scale::Encode,
     {
@@ -161,6 +161,7 @@ where
             result
         }
 
+        let _ = self.scoped_buffer.take_bytes(topic_prefix);
         let mut split = self.scoped_buffer.split();
         let encoded = split.take_encoded(topic_value);
         let result = inner::<E>(encoded);

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -167,8 +167,6 @@ where
         let mut split = self.scoped_buffer.split();
         let encoded = split.take_encoded(topic_value);
         let result = inner::<E>(encoded);
-        self.scoped_buffer
-            .append_encoded(&scale::Compact::<u64>(result.as_ref().len() as u64));
         self.scoped_buffer.append_bytes(result.as_ref());
     }
 

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -161,10 +161,12 @@ where
             result
         }
 
+        self.scoped_buffer.append_encoded(&scale::Compact::<u64>(topic_prefix.len() as u64));
         self.scoped_buffer.append_bytes(topic_prefix);
         let mut split = self.scoped_buffer.split();
         let encoded = split.take_encoded(topic_value);
         let result = inner::<E>(encoded);
+        self.scoped_buffer.append_encoded(&scale::Compact::<u64>(result.as_ref().len() as u64));
         self.scoped_buffer.append_bytes(result.as_ref());
     }
 

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -161,12 +161,14 @@ where
             result
         }
 
-        self.scoped_buffer.append_encoded(&scale::Compact::<u64>(topic_prefix.len() as u64));
+        self.scoped_buffer
+            .append_encoded(&scale::Compact::<u64>(topic_prefix.len() as u64));
         self.scoped_buffer.append_bytes(topic_prefix);
         let mut split = self.scoped_buffer.split();
         let encoded = split.take_encoded(topic_value);
         let result = inner::<E>(encoded);
-        self.scoped_buffer.append_encoded(&scale::Compact::<u64>(result.as_ref().len() as u64));
+        self.scoped_buffer
+            .append_encoded(&scale::Compact::<u64>(result.as_ref().len() as u64));
         self.scoped_buffer.append_bytes(result.as_ref());
     }
 

--- a/crates/env/src/topics.rs
+++ b/crates/env/src/topics.rs
@@ -31,7 +31,7 @@ where
     fn expect(&mut self, expected_topics: usize);
 
     /// Pushes another topic for serialization to the backend.
-    fn push_topic<T>(&mut self, topic_value: &T)
+    fn push_topic<T>(&mut self, topic_prefix: &[u8], topic_value: &T)
     where
         T: scale::Encode;
 
@@ -105,12 +105,13 @@ where
     /// than before the call.
     pub fn push_topic<T>(
         mut self,
+        prefix: &[u8],
         value: &T,
     ) -> TopicsBuilder<<S as SomeRemainingTopics>::Next, E, B>
     where
         T: scale::Encode,
     {
-        self.backend.push_topic(value);
+        self.backend.push_topic(prefix, value);
         TopicsBuilder {
             backend: self.backend,
             state: Default::default(),

--- a/crates/env/src/topics.rs
+++ b/crates/env/src/topics.rs
@@ -202,36 +202,3 @@ pub trait Topics {
         E: Environment,
         B: TopicsBuilderBackend<E>;
 }
-
-/// For each topic a hash is generated. This hash must be unique
-/// for a field and its value. The `prefix` is concatenated
-/// with the `value`. This result is then hashed.
-/// The `prefix` is typically set to the path a field has in
-/// an event struct plus the identifier of the event struct.
-///
-/// For example, in the case of our ERC-20 example contract the
-/// prefix `Erc20::Transfer::from` is concatenated with the
-/// field value of `from` and then hashed.
-/// In this example `Erc20` would be the contract identified,
-/// `Transfer` the event identifier, and `from` the field identifier.
-#[doc(hidden)]
-pub struct PrefixedValue<'a, 'b, T> {
-    pub prefix: &'a [u8],
-    pub value: &'b T,
-}
-
-impl<X> scale::Encode for PrefixedValue<'_, '_, X>
-where
-    X: scale::Encode,
-{
-    #[inline]
-    fn size_hint(&self) -> usize {
-        self.prefix.size_hint() + self.value.size_hint()
-    }
-
-    #[inline]
-    fn encode_to<T: scale::Output + ?Sized>(&self, dest: &mut T) {
-        self.prefix.encode_to(dest);
-        self.value.encode_to(dest);
-    }
-}

--- a/crates/lang/codegen/src/generator/events.rs
+++ b/crates/lang/codegen/src/generator/events.rs
@@ -208,18 +208,14 @@ impl<'a> Events<'a> {
                             field_ident
                         ).as_bytes(), span);
                     quote_spanned!(span =>
-                        .push_topic::<::ink_env::topics::PrefixedValue<#field_type>>(
-                            &::ink_env::topics::PrefixedValue { value: &self.#field_ident, prefix: #signature }
-                        )
+                        .push_topic::<#field_type>(#signature, &self.#field_ident)
                     )
                 });
             // Only include topic for event signature in case of non-anonymous event.
             let event_signature_topic = match event.anonymous {
                 true => None,
                 false => Some(quote_spanned!(span=>
-                    .push_topic::<::ink_env::topics::PrefixedValue<[u8; #len_event_signature]>>(
-                        &::ink_env::topics::PrefixedValue { value: #event_signature, prefix: b"" }
-                    )
+                    .push_topic::<[u8; #len_event_signature]>(b"", #event_signature)
                 ))
             };
             // Anonymous events require 1 fewer topics since they do not include their signature.

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -247,7 +247,7 @@ mod erc20 {
                 panic!("encountered unexpected event kind: expected a Transfer event")
             }
             let expected_topics = vec![
-                encoded_into_hash(b"Erc20::Transfer", &()),
+                encoded_into_hash(b"", b"Erc20::Transfer"),
                 encoded_into_hash(b"Erc20::Transfer::from", &expected_from),
                 encoded_into_hash(b"Erc20::Transfer::to", &expected_to),
                 encoded_into_hash(b"Erc20::Transfer::value", &expected_value),
@@ -490,7 +490,7 @@ mod erc20 {
             };
             let mut result = Hash::clear();
             let len_result = result.as_ref().len();
-            let mut encoded = prefix.to_vec();
+            let mut encoded = scale::Encode::encode(prefix);
             entity.encode_to(&mut encoded);
             let len_encoded = encoded.len();
             if len_encoded <= len_result {

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -301,7 +301,7 @@ mod erc20 {
             {
                 let mut result = Hash::clear();
                 let len_result = result.as_ref().len();
-                let mut encoded = prefix.to_vec();
+                let mut encoded = scale::Encode::encode(prefix);
                 entity.encode_to(&mut encoded);
                 let len_encoded = encoded.len();
                 if len_encoded <= len_result {
@@ -317,7 +317,7 @@ mod erc20 {
             }
 
             let expected_topics = vec![
-                encoded_into_hash(b"Erc20::Transfer", &()),
+                encoded_into_hash(b"", b"Erc20::Transfer"),
                 encoded_into_hash(b"Erc20::Transfer::from", &expected_from),
                 encoded_into_hash(b"Erc20::Transfer::to", &expected_to),
                 encoded_into_hash(b"Erc20::Transfer::value", &expected_value),

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -295,13 +295,14 @@ mod erc20 {
                 panic!("encountered unexpected event kind: expected a Transfer event")
             }
 
-            fn encoded_into_hash<T>(entity: &T) -> Hash
+            fn encoded_into_hash<T>(prefix: &[u8], entity: &T) -> Hash
             where
                 T: scale::Encode,
             {
                 let mut result = Hash::clear();
                 let len_result = result.as_ref().len();
-                let encoded = entity.encode();
+                let mut encoded = prefix.to_vec();
+                entity.encode_to(&mut encoded);
                 let len_encoded = encoded.len();
                 if len_encoded <= len_result {
                     result.as_mut()[..len_encoded].copy_from_slice(&encoded);
@@ -315,23 +316,11 @@ mod erc20 {
                 result
             }
 
-            let expected_topics = [
-                encoded_into_hash(&PrefixedValue {
-                    prefix: b"",
-                    value: b"Erc20::Transfer",
-                }),
-                encoded_into_hash(&PrefixedValue {
-                    prefix: b"Erc20::Transfer::from",
-                    value: &expected_from,
-                }),
-                encoded_into_hash(&PrefixedValue {
-                    prefix: b"Erc20::Transfer::to",
-                    value: &expected_to,
-                }),
-                encoded_into_hash(&PrefixedValue {
-                    prefix: b"Erc20::Transfer::value",
-                    value: &expected_value,
-                }),
+            let expected_topics = vec![
+                encoded_into_hash(b"Erc20::Transfer", &()),
+                encoded_into_hash(b"Erc20::Transfer::from", &expected_from),
+                encoded_into_hash(b"Erc20::Transfer::to", &expected_to),
+                encoded_into_hash(b"Erc20::Transfer::value", &expected_value),
             ];
             for (n, (actual_topic, expected_topic)) in
                 event.topics.iter().zip(expected_topics).enumerate()


### PR DESCRIPTION
While topics/events needs a broader overhaul to reduce code size, here is a smaller incremental change which reduces e.g. erc20 from `8.5KB` to `8.2KB`.

I removes the `PrefixedValue` type and passes the prefix bytes directly to `push_topic` so they can be appended to the buffer. So it saves on bringing in some unneeded `Encode` implementations.

Draft while we wait for CI to tell us improvements.