### PR TITLE
Add helper for manually releasing the workspace crates

### DIFF
--- a/scripts/release-em-squids.sh
+++ b/scripts/release-em-squids.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Script for publishing the various ink! crates to `crates.io`.
+#
+# It is assumed that version numbers have already been bumped. It also doesn't do any Git
+# or Changelog related work.
+
+set -eux
+
+# This give us the "best" order in which to release our crates
+to_release=( $(cargo unleash to-release) )
+crates=()
+
+for element in "${to_release[@]}"
+do
+    # `to-release` also gives us the version number, we only care about the crate names
+    if [[ $element == *"ink_"* ]]; then
+       echo "${element}"
+       crates[${#crates[@]}]="${element}"
+    fi
+done
+
+for crate in "${crates[@]}"
+do
+    # Wait a little (15 sec) between publishing steps to allow the registry to catch up
+    sleep 15
+
+    # Need `--allow-dirty` here since `cargo unleash to-release` removes
+    # dev-dependencies when it runs
+    #
+    # NOTE: When you're ready to actually publish get rid of the `--dry-run` flag
+    cargo publish -p $crate --allow-dirty --dry-run
+done


### PR DESCRIPTION
While working on releasing `v3.0.1` (#1190) I wasn't able to get the `cargo unleash` step
working and had to resort to manually releasing the crates with `cargo publish`. As a
little bit of an aid I cobbled together this script. It's not very smart, but it's at
least more reliable at publishing than `cargo unleash`.

This basically replaces the `cargo unleash` step in the `RELEASES_CHECKLIST` document.
I'll update those instructions here once #1190 is merged.
