### PR TITLE
Fix ordering of message ids if the trait is implemented before the inherent section

### DIFF
--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -158,10 +158,9 @@ impl Dispatch<'_> {
             .contract
             .module()
             .impls()
-            .map(|item_impl| {
+            .flat_map(|item_impl| {
                 iter::repeat(item_impl.trait_path()).zip(item_impl.iter_messages())
             })
-            .flatten()
             .map(|(trait_path, message)| {
                 let span = message.span();
                 message_spans.push(span);

--- a/crates/lang/tests/ui/contract/pass/message-selector.rs
+++ b/crates/lang/tests/ui/contract/pass/message-selector.rs
@@ -6,20 +6,45 @@ mod contract {
     #[ink(storage)]
     pub struct Contract {}
 
+    #[ink_lang::trait_definition]
+    pub trait Messages {
+        #[ink(message)]
+        fn message_0(&self);
+
+        #[ink(message, selector = 1)]
+        fn message_1(&self);
+    }
+
+    impl Messages for Contract {
+        #[ink(message)]
+        fn message_0(&self) {}
+
+        #[ink(message, selector = 1)]
+        fn message_1(&self) {}
+    }
+
     impl Contract {
         #[ink(constructor)]
         pub fn constructor() -> Self {
             Self {}
         }
 
-        #[ink(message)]
-        pub fn message_0(&self) {}
-
-        #[ink(message, selector = 1)]
-        pub fn message_1(&self) {}
-
         #[ink(message, selector = 0xC0DE_CAFE)]
         pub fn message_2(&self) {}
+
+        #[ink(message, selector = _)]
+        pub fn message_3(&self) {}
+    }
+
+    #[ink_lang::trait_definition]
+    pub trait Messages2 {
+        #[ink(message, selector = 0x12345678)]
+        fn message_4(&self);
+    }
+
+    impl Messages2 for Contract {
+        #[ink(message, selector = 0x12345678)]
+        fn message_4(&self) {}
     }
 }
 
@@ -34,7 +59,7 @@ fn main() {
                 >>::IDS[0]
             },
         >>::SELECTOR,
-        [0x5A, 0x6A, 0xC1, 0x5D],
+        [0xFB, 0xAB, 0x03, 0xCE],
     );
     assert_eq!(
         <Contract as ::ink_lang::reflect::DispatchableMessageInfo<
@@ -59,5 +84,29 @@ fn main() {
             },
         >>::SELECTOR,
         0xC0DE_CAFE_u32.to_be_bytes(),
+    );
+    assert_eq!(
+        <Contract as ::ink_lang::reflect::DispatchableMessageInfo<
+            {
+                <Contract as ::ink_lang::reflect::ContractDispatchableMessages<
+                    {
+                        <Contract as ::ink_lang::reflect::ContractAmountDispatchables>::MESSAGES
+                    },
+                >>::IDS[3]
+            },
+        >>::SELECTOR,
+        [0xB6, 0xC3, 0x27, 0x49],
+    );
+    assert_eq!(
+        <Contract as ::ink_lang::reflect::DispatchableMessageInfo<
+            {
+                <Contract as ::ink_lang::reflect::ContractDispatchableMessages<
+                    {
+                        <Contract as ::ink_lang::reflect::ContractAmountDispatchables>::MESSAGES
+                    },
+                >>::IDS[4]
+            },
+        >>::SELECTOR,
+        0x12345678_u32.to_be_bytes(),
     );
 }

--- a/examples/upgradeable-contracts/forward-calls/lib.rs
+++ b/examples/upgradeable-contracts/forward-calls/lib.rs
@@ -33,14 +33,14 @@ pub mod proxy {
         admin: AccountId,
     }
 
-    /// The trait provides information about `Proxy`
+    /// The trait provides information about the forward pattern used in this contract.
     #[ink_lang::trait_definition]
     pub trait Forwarder {
-        /// Returns `AccountId` of contract that calls are forward to
+        /// Returns the `AccountId` of the contract that calls are forward to.
         #[ink(message)]
         fn forward_to(&self) -> AccountId;
 
-        /// Returns `AccountId` of administrator of current contract
+        /// Returns the `AccountId` of the admin of the current contract.
         #[ink(message)]
         fn admin(&self) -> AccountId;
     }

--- a/examples/upgradeable-contracts/forward-calls/lib.rs
+++ b/examples/upgradeable-contracts/forward-calls/lib.rs
@@ -33,30 +33,6 @@ pub mod proxy {
         admin: AccountId,
     }
 
-    /// The trait provides information about the forward pattern used in this contract.
-    #[ink_lang::trait_definition]
-    pub trait Forwarder {
-        /// Returns the `AccountId` of the contract that calls are forward to.
-        #[ink(message)]
-        fn forward_to(&self) -> AccountId;
-
-        /// Returns the `AccountId` of the admin of the current contract.
-        #[ink(message)]
-        fn admin(&self) -> AccountId;
-    }
-
-    impl Forwarder for Proxy {
-        #[ink(message)]
-        fn forward_to(&self) -> AccountId {
-            self.forward_to
-        }
-
-        #[ink(message)]
-        fn admin(&self) -> AccountId {
-            self.admin
-        }
-    }
-
     impl Proxy {
         /// Instantiate this contract with an address of the `logic` contract.
         ///

--- a/examples/upgradeable-contracts/forward-calls/lib.rs
+++ b/examples/upgradeable-contracts/forward-calls/lib.rs
@@ -33,7 +33,7 @@ pub mod proxy {
         admin: AccountId,
     }
 
-    /// The trait provides managing of forwarder methods.
+    /// The trait provides information about `Proxy`
     #[ink_lang::trait_definition]
     pub trait Forwarder {
         /// Returns `AccountId` of contract that calls are forward to
@@ -43,11 +43,6 @@ pub mod proxy {
         /// Returns `AccountId` of administrator of current contract
         #[ink(message)]
         fn admin(&self) -> AccountId;
-
-        /// Changes the `AccountId` of the contract where any call that does
-        /// not match a selector of this contract is forwarded to.
-        #[ink(message)]
-        fn change_forward_address(&mut self, new_address: AccountId);
     }
 
     impl Forwarder for Proxy {
@@ -59,18 +54,6 @@ pub mod proxy {
         #[ink(message)]
         fn admin(&self) -> AccountId {
             self.admin
-        }
-
-        #[ink(message)]
-        fn change_forward_address(&mut self, new_address: AccountId) {
-            assert_eq!(
-                self.env().caller(),
-                self.admin,
-                "caller {:?} does not have sufficient permissions, only {:?} does",
-                self.env().caller(),
-                self.admin,
-            );
-            self.forward_to = new_address;
         }
     }
 
@@ -85,6 +68,20 @@ pub mod proxy {
                 admin: Self::env().caller(),
                 forward_to,
             }
+        }
+
+        /// Changes the `AccountId` of the contract where any call that does
+        /// not match a selector of this contract is forwarded to.
+        #[ink(message)]
+        pub fn change_forward_address(&mut self, new_address: AccountId) {
+            assert_eq!(
+                self.env().caller(),
+                self.admin,
+                "caller {:?} does not have sufficient permissions, only {:?} does",
+                self.env().caller(),
+                self.admin,
+            );
+            self.forward_to = new_address;
         }
 
         /// Fallback message for a contract call that doesn't match any


### PR DESCRIPTION
Fixed the ordering of ids. Before it was sorted:
inherent_ids
traits_ids

Now the ordering is not changed. It is important for dispatching logic and wildcard. Dispatching takes the global index of the method but if the order is changed, it will use the wrong id. In the case of a wildcard, it breaks it at all if the trait was implemented before the inherent section.