### PR TITLE
Make `spellcheck` less verbose

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,8 +91,8 @@ spellcheck:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - cargo spellcheck check -vvvv --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive .
-    - cargo spellcheck check -vvvv --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive ./examples/
+    - cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive .
+    - cargo spellcheck check -v --cfg=.config/cargo_spellcheck.toml --checkers hunspell --code 1 -- recursive ./examples/
   allow_failure:                   true
 
 fmt:


### PR DESCRIPTION
Causes issues currently:

https://gitlab.parity.io/parity/mirrors/ink/-/jobs/1560920

```
Job's log exceeded limit of 33554432 bytes.
Job execution will continue but no more output will be collected.
```