### PR TITLE
Remove version from examples path dependencies

### DIFF
--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false, features = [ "ink-debug" ] }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
-ink_prelude = { version = "3.0.1", path = "../../crates/prelude", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false, features = [ "ink-debug" ] }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
+ink_prelude = { path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 
-adder = { version = "3.0.1", path = "adder", default-features = false, features = ["ink-as-dependency"] }
-subber = { version = "3.0.1", path = "subber", default-features = false, features = ["ink-as-dependency"] }
-accumulator = { version = "3.0.1", path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
+adder = { path = "adder", default-features = false, features = ["ink-as-dependency"] }
+subber = { path = "subber", default-features = false, features = ["ink-as-dependency"] }
+accumulator = { path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 [lib]

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../../crates/lang", default-features = false }
+ink_primitives = { path = "../../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../../crates/env", default-features = false }
+ink_storage = { path = "../../../crates/storage", default-features = false }
+ink_lang = { path = "../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../../crates/lang", default-features = false }
+ink_primitives = { path = "../../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../../crates/env", default-features = false }
+ink_storage = { path = "../../../crates/storage", default-features = false }
+ink_lang = { path = "../../../crates/lang", default-features = false }
 
-accumulator = { version = "3.0.1", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
+accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -5,13 +5,13 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../../crates/lang", default-features = false }
+ink_primitives = { path = "../../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../../crates/env", default-features = false }
+ink_storage = { path = "../../../crates/storage", default-features = false }
+ink_lang = { path = "../../../crates/lang", default-features = false }
 
-accumulator = { version = "3.0.1", path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
+accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
-ink_prelude = { version = "3.0.1", path = "../../crates/prelude", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
+ink_prelude = { path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
-ink_prelude = { version = "3.0.1", path = "../../crates/prelude", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
+ink_prelude = { path = "../../crates/prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/trait-incrementer/Cargo.toml
+++ b/examples/trait-incrementer/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../crates/lang", default-features = false }
+ink_primitives = { path = "../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../crates/env", default-features = false }
+ink_storage = { path = "../../crates/storage", default-features = false }
+ink_lang = { path = "../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/trait-incrementer/traits/Cargo.toml
+++ b/examples/trait-incrementer/traits/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../../crates/lang", default-features = false }
+ink_primitives = { path = "../../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../../crates/env", default-features = false }
+ink_storage = { path = "../../../crates/storage", default-features = false }
+ink_lang = { path = "../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/upgradeable-contracts/delegate-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/delegate-calls/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../../crates/primitives", default-features = false }
-ink_prelude = { version = "3.0.1", path = "../../../crates/prelude", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../../crates/lang", default-features = false }
+ink_primitives = { path = "../../../crates/primitives", default-features = false }
+ink_prelude = { path = "../../../crates/prelude", default-features = false }
+ink_metadata = { path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../../crates/env", default-features = false }
+ink_storage = { path = "../../../crates/storage", default-features = false }
+ink_lang = { path = "../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
+++ b/examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../../../crates/env", default-features = false, features = ["ink-debug"] }
-ink_storage = { version = "3.0.1", path = "../../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../../../crates/lang", default-features = false }
+ink_primitives = { path = "../../../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../../../crates/env", default-features = false, features = ["ink-debug"] }
+ink_storage = { path = "../../../../crates/storage", default-features = false }
+ink_lang = { path = "../../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/upgradeable-contracts/forward-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/forward-calls/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../../crates/primitives", default-features = false }
-ink_prelude = { version = "3.0.1", path = "../../../crates/prelude", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../../crates/lang", default-features = false }
+ink_primitives = { path = "../../../crates/primitives", default-features = false }
+ink_prelude = { path = "../../../crates/prelude", default-features = false }
+ink_metadata = { path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../../crates/env", default-features = false }
+ink_storage = { path = "../../../crates/storage", default-features = false }
+ink_lang = { path = "../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -8,12 +8,12 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../../crates/primitives", default-features = false }
-ink_prelude = { version = "3.0.1", path = "../../../crates/prelude", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../../crates/env", default-features = false }
-ink_storage = { version = "3.0.1", path = "../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../../crates/lang", default-features = false }
+ink_primitives = { path = "../../../crates/primitives", default-features = false }
+ink_prelude = { path = "../../../crates/prelude", default-features = false }
+ink_metadata = { path = "../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../../crates/env", default-features = false }
+ink_storage = { path = "../../../crates/storage", default-features = false }
+ink_lang = { path = "../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ink_primitives = { version = "3.0.1", path = "../../../../crates/primitives", default-features = false }
-ink_metadata = { version = "3.0.1", path = "../../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.1", path = "../../../../crates/env", default-features = false, features = ["ink-debug"] }
-ink_storage = { version = "3.0.1", path = "../../../../crates/storage", default-features = false }
-ink_lang = { version = "3.0.1", path = "../../../../crates/lang", default-features = false }
+ink_primitives = { path = "../../../../crates/primitives", default-features = false }
+ink_metadata = { path = "../../../../crates/metadata", default-features = false, features = ["derive"], optional = true }
+ink_env = { path = "../../../../crates/env", default-features = false, features = ["ink-debug"] }
+ink_storage = { path = "../../../../crates/storage", default-features = false }
+ink_lang = { path = "../../../../crates/lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
Versions are useless for path dependencies which are not released to crates.io. They only add churn on versions bumps.