### PR TITLE
Suppress unused variable warning for debug_print macros

### DIFF
--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -131,7 +131,7 @@ cfg_if::cfg_if! {
         /// `"pallet-contracts/unstable-interface"` feature to be enabled in the target runtime.
         #[macro_export]
         macro_rules! debug_print {
-            ($($arg:tt)*) => ($crate::debug_message(&$crate::format!($($arg)*)));
+            ($($arg:tt),*) => ($crate::debug_message(&$crate::format!($($arg0,)*)));
         }
 
         /// Appends a formatted string to the `debug_message` buffer, as per [`debug_print`] but
@@ -144,18 +144,18 @@ cfg_if::cfg_if! {
         #[macro_export]
         macro_rules! debug_println {
             () => ($crate::debug_print!("\n"));
-            ($($arg:tt)*) => (
-                $crate::debug_print!("{}\n", $crate::format!($($arg)*));
+            ($($arg:tt),*) => (
+                $crate::debug_print!("{}\n", $crate::format!($($arg),*));
             )
         }
     } else {
         #[macro_export]
         /// Debug messages disabled. Enable the `ink-debug` feature for contract debugging.
         macro_rules! debug_print {
-            ($($arg:tt)*) =>
+            ($($arg:tt),*) =>
             {
                 {
-                    let _ = || ($(&$arg)*);
+                    let _ = || ($(&$arg),*);
                 }
             };
         }
@@ -164,10 +164,10 @@ cfg_if::cfg_if! {
         /// Debug messages disabled. Enable the `ink-debug` feature for contract debugging.
         macro_rules! debug_println {
             () => {};
-            ($($arg:tt)*) =>
+            ($($arg:tt),*) =>
             {
                 {
-                    let _ = || ($(&$arg)*);
+                    let _ = || ($(&$arg),*);
                 }
             };
         }

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -152,14 +152,24 @@ cfg_if::cfg_if! {
         #[macro_export]
         /// Debug messages disabled. Enable the `ink-debug` feature for contract debugging.
         macro_rules! debug_print {
-            ($($arg:tt)*) => ();
+            ($($arg:tt)*) =>
+            {
+                {
+                    let _ = || ($(&$arg)*);
+                }
+            };
         }
 
         #[macro_export]
         /// Debug messages disabled. Enable the `ink-debug` feature for contract debugging.
         macro_rules! debug_println {
-            () => ();
-            ($($arg:tt)*) => ();
+            () => {};
+            ($($arg:tt)*) =>
+            {
+                {
+                    let _ = || ($(&$arg)*);
+                }
+            };
         }
     }
 }

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -131,7 +131,7 @@ cfg_if::cfg_if! {
         /// `"pallet-contracts/unstable-interface"` feature to be enabled in the target runtime.
         #[macro_export]
         macro_rules! debug_print {
-            ($($arg:tt),*) => ($crate::debug_message(&$crate::format!($($arg0,)*)));
+            ($($arg:expr),*) => ($crate::debug_message(&$crate::format!($($arg),*)));
         }
 
         /// Appends a formatted string to the `debug_message` buffer, as per [`debug_print`] but
@@ -144,7 +144,7 @@ cfg_if::cfg_if! {
         #[macro_export]
         macro_rules! debug_println {
             () => ($crate::debug_print!("\n"));
-            ($($arg:tt),*) => (
+            ($($arg:expr),*) => (
                 $crate::debug_print!("{}\n", $crate::format!($($arg),*));
             )
         }
@@ -152,7 +152,7 @@ cfg_if::cfg_if! {
         #[macro_export]
         /// Debug messages disabled. Enable the `ink-debug` feature for contract debugging.
         macro_rules! debug_print {
-            ($($arg:tt),*) =>
+            ($($arg:expr),*) =>
             {
                 {
                     let _ = || ($(&$arg),*);
@@ -164,7 +164,7 @@ cfg_if::cfg_if! {
         /// Debug messages disabled. Enable the `ink-debug` feature for contract debugging.
         macro_rules! debug_println {
             () => {};
-            ($($arg:tt),*) =>
+            ($($arg:expr),*) =>
             {
                 {
                     let _ = || ($(&$arg),*);


### PR DESCRIPTION
If a variable is only used in the `debug_print(ln)?` macro then a unused variable warning is emitted in case the `ink-debug` feature isn't used. This fixes this problem by always using the arguments without evaluating them: Capture them by reference in a closure that is never executed.

@agryaznov had this problem in his mother contract.