### PR TITLE
Optimise `deny_payment`

### DIFF
--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -532,6 +532,8 @@ impl Dispatch<'_> {
                 }
             }
         };
+        let any_constructor_accept_payment =
+            self.any_constructor_accepts_payment_expr(constructor_spans);
 
         let constructor_execute = (0..count_constructors).map(|index| {
             let constructor_span = constructor_spans[index];
@@ -543,9 +545,8 @@ impl Dispatch<'_> {
                     }>>::IDS[#index]
                 }>>::CALLABLE
             );
-            let accepts_payment = quote_spanned!(constructor_span=>
-                false ||
-                <#storage_ident as ::ink_lang::reflect::DispatchableConstructorInfo<{
+            let deny_payment = quote_spanned!(constructor_span=>
+                !<#storage_ident as ::ink_lang::reflect::DispatchableConstructorInfo<{
                     <#storage_ident as ::ink_lang::reflect::ContractDispatchableConstructors<{
                         <#storage_ident as ::ink_lang::reflect::ContractAmountDispatchables>::CONSTRUCTORS
                     }>>::IDS[#index]
@@ -554,10 +555,12 @@ impl Dispatch<'_> {
 
             quote_spanned!(constructor_span=>
                 Self::#constructor_ident(input) => {
+                    if #any_constructor_accept_payment && #deny_payment {
+                        ::ink_lang::codegen::deny_payment::<
+                            <#storage_ident as ::ink_lang::reflect::ContractEnv>::Env>()?;
+                    }
+
                     ::ink_lang::codegen::execute_constructor::<#storage_ident, _, _>(
-                        ::ink_lang::codegen::ExecuteConstructorConfig {
-                            payable: #accepts_payment,
-                        },
                         move || { #constructor_callable(input) }
                     )
                 }
@@ -692,6 +695,8 @@ impl Dispatch<'_> {
                 }
             }
         };
+        let any_message_accept_payment =
+            self.any_message_accepts_payment_expr(message_spans);
 
         let message_execute = (0..count_messages).map(|index| {
             let message_span = message_spans[index];
@@ -729,7 +734,7 @@ impl Dispatch<'_> {
                 Self::#message_ident(input) => {
                     use ::core::default::Default;
 
-                    if #deny_payment {
+                    if #any_message_accept_payment && #deny_payment {
                         ::ink_lang::codegen::deny_payment::<
                             <#storage_ident as ::ink_lang::reflect::ContractEnv>::Env>()?;
                     }

--- a/crates/lang/src/codegen/dispatch/execution.rs
+++ b/crates/lang/src/codegen/dispatch/execution.rs
@@ -64,13 +64,6 @@ where
     Ok(())
 }
 
-/// Configuration for execution of ink! constructor.
-#[derive(Debug, Copy, Clone)]
-pub struct ExecuteConstructorConfig {
-    /// Yields `true` if the ink! constructor accepts payment.
-    pub payable: bool,
-}
-
 /// Executes the given ink! constructor.
 ///
 /// # Note
@@ -78,19 +71,13 @@ pub struct ExecuteConstructorConfig {
 /// The closure is supposed to already contain all the arguments that the real
 /// constructor message requires and forwards them.
 #[inline]
-pub fn execute_constructor<Contract, F, R>(
-    config: ExecuteConstructorConfig,
-    f: F,
-) -> Result<(), DispatchError>
+pub fn execute_constructor<Contract, F, R>(f: F) -> Result<(), DispatchError>
 where
     Contract: SpreadLayout + ContractRootKey + ContractEnv,
     F: FnOnce() -> R,
     <private::Seal<R> as ConstructorReturnType<Contract>>::ReturnValue: scale::Encode,
     private::Seal<R>: ConstructorReturnType<Contract>,
 {
-    if !config.payable {
-        deny_payment::<<Contract as ContractEnv>::Env>()?;
-    }
     let result = ManuallyDrop::new(private::Seal(f()));
     match result.as_result() {
         Ok(contract) => {

--- a/crates/lang/src/codegen/dispatch/mod.rs
+++ b/crates/lang/src/codegen/dispatch/mod.rs
@@ -22,7 +22,6 @@ pub use self::{
         execute_constructor,
         initialize_contract,
         ContractRootKey,
-        ExecuteConstructorConfig,
     },
     info::ContractCallBuilder,
     type_check::{

--- a/crates/lang/src/codegen/mod.rs
+++ b/crates/lang/src/codegen/mod.rs
@@ -30,7 +30,6 @@ pub use self::{
         ContractRootKey,
         DispatchInput,
         DispatchOutput,
-        ExecuteConstructorConfig,
     },
     env::{
         Env,


### PR DESCRIPTION
Seems we forgot to use optimization in cases if all constructors or methods don't accept payment.