### PR TITLE
Remove `#[doc(hidden)]` from implementation section

### DIFF
--- a/crates/lang/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/lang/codegen/src/generator/as_dependency/contract_ref.rs
@@ -209,7 +209,6 @@ impl ContractRef<'_> {
         quote_spanned!(span=>
             #( #attrs )*
             impl #trait_path for #forwarder_ident {
-                #[doc(hidden)]
                 type __ink_TraitInfo = <::ink_lang::reflect::TraitDefinitionRegistry<Environment>
                     as #trait_path>::__ink_TraitInfo;
 

--- a/crates/lang/codegen/src/generator/trait_def/call_builder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_builder.rs
@@ -326,7 +326,6 @@ impl CallBuilder<'_> {
             where
                 E: ::ink_env::Environment,
             {
-                #[doc(hidden)]
                 #[allow(non_camel_case_types)]
                 type __ink_TraitInfo = #trait_info_ident<E>;
 

--- a/crates/lang/codegen/src/generator/trait_def/call_forwarder.rs
+++ b/crates/lang/codegen/src/generator/trait_def/call_forwarder.rs
@@ -354,7 +354,6 @@ impl CallForwarder<'_> {
             where
                 E: ::ink_env::Environment,
             {
-                #[doc(hidden)]
                 #[allow(non_camel_case_types)]
                 type __ink_TraitInfo = #trait_info_ident<E>;
 

--- a/crates/lang/codegen/src/generator/trait_def/trait_registry.rs
+++ b/crates/lang/codegen/src/generator/trait_def/trait_registry.rs
@@ -109,7 +109,6 @@ impl TraitRegistry<'_> {
                 E: ::ink_env::Environment,
             {
                 /// Holds general and global information about the trait.
-                #[doc(hidden)]
                 #[allow(non_camel_case_types)]
                 type __ink_TraitInfo = #trait_info_ident<E>;
 
@@ -211,7 +210,6 @@ impl TraitRegistry<'_> {
 
             #( #attrs )*
             #[cold]
-            #[doc(hidden)]
             fn #ident(
                 & #mut_token self
                 #( , #input_bindings : #input_types )*


### PR DESCRIPTION
Fixes https://github.com/paritytech/ink/issues/1269

Removed `#[doc(hidden)]` from the implementation section because now it fully depends on the trait definition. `__ink_TraitInfo` is hidden in the trait - it is enough.