### PR TITLE
Stabilize `ecdsa` functions to `seal0`

### DIFF
--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -324,6 +324,19 @@ mod sys {
             output_ptr: Ptr32Mut<[u8]>,
             output_len_ptr: Ptr32Mut<u32>,
         ) -> ReturnCode;
+
+        pub fn seal_ecdsa_recover(
+            // 65 bytes of ecdsa signature
+            signature_ptr: Ptr32<[u8]>,
+            // 32 bytes hash of the message
+            message_hash_ptr: Ptr32<[u8]>,
+            output_ptr: Ptr32Mut<[u8]>,
+        ) -> ReturnCode;
+
+        pub fn seal_ecdsa_to_eth_address(
+            public_key_ptr: Ptr32<[u8]>,
+            output_ptr: Ptr32Mut<[u8]>,
+        ) -> ReturnCode;
     }
 
     #[link(wasm_import_module = "seal1")]
@@ -366,19 +379,6 @@ mod sys {
             key_ptr: Ptr32<[u8]>,
             value_ptr: Ptr32<[u8]>,
             value_len: u32,
-        ) -> ReturnCode;
-
-        pub fn seal_ecdsa_recover(
-            // 65 bytes of ecdsa signature
-            signature_ptr: Ptr32<[u8]>,
-            // 32 bytes hash of the message
-            message_hash_ptr: Ptr32<[u8]>,
-            output_ptr: Ptr32Mut<[u8]>,
-        ) -> ReturnCode;
-
-        pub fn seal_ecdsa_to_eth_address(
-            public_key_ptr: Ptr32<[u8]>,
-            output_ptr: Ptr32Mut<[u8]>,
         ) -> ReturnCode;
     }
 }


### PR DESCRIPTION
They were stabilized to `seal0`, not `seal1`.

https://github.com/paritytech/substrate/commit/77889d108c0ed17bd3c319d640249e68260bf15a