### PR TITLE
Revert "Suppress unused variable warning for debug_print macros (#1258)"

### DIFF
--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -131,7 +131,7 @@ cfg_if::cfg_if! {
         /// `"pallet-contracts/unstable-interface"` feature to be enabled in the target runtime.
         #[macro_export]
         macro_rules! debug_print {
-            ($($arg:expr),*) => ($crate::debug_message(&$crate::format!($($arg),*)));
+            ($($arg:tt)*) => ($crate::debug_message(&$crate::format!($($arg)*)));
         }
 
         /// Appends a formatted string to the `debug_message` buffer, as per [`debug_print`] but
@@ -144,32 +144,22 @@ cfg_if::cfg_if! {
         #[macro_export]
         macro_rules! debug_println {
             () => ($crate::debug_print!("\n"));
-            ($($arg:expr),*) => (
-                $crate::debug_print!("{}\n", $crate::format!($($arg),*));
+            ($($arg:tt)*) => (
+                $crate::debug_print!("{}\n", $crate::format!($($arg)*));
             )
         }
     } else {
         #[macro_export]
         /// Debug messages disabled. Enable the `ink-debug` feature for contract debugging.
         macro_rules! debug_print {
-            ($($arg:expr),*) =>
-            {
-                {
-                    let _ = || ($(&$arg),*);
-                }
-            };
+            ($($arg:tt)*) => ();
         }
 
         #[macro_export]
         /// Debug messages disabled. Enable the `ink-debug` feature for contract debugging.
         macro_rules! debug_println {
-            () => {};
-            ($($arg:expr),*) =>
-            {
-                {
-                    let _ = || ($(&$arg),*);
-                }
-            };
+            () => ();
+            ($($arg:tt)*) => ();
         }
     }
 }

--- a/examples/mother/lib.rs
+++ b/examples/mother/lib.rs
@@ -219,8 +219,8 @@ mod mother {
 
         /// Prints the specified string into node's debug log.
         #[ink(message)]
-        pub fn debug_log(&mut self, message: String) {
-            ink_env::debug_println!("debug_log: {}", message);
+        pub fn debug_log(&mut self, _message: String) {
+            ink_env::debug_println!("debug_log: {}", _message);
         }
     }
 


### PR DESCRIPTION
This reverts commit b6dd935240b8140787593cbdc79a15f6fbca5f59.

See the discussion in https://github.com/paritytech/ink/pull/1258#issuecomment-1130311910, there is a regression now. We need to revisit this. I'll create an issue once we've merged this PR.