### PR TITLE
Add a list of changes breaking backwards compatibility to `RELEASES.md`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,8 +1,44 @@
 # [Unreleased]
-- Backward-incompatible piece of [#1233](https://github.com/paritytech/ink/pull/1233). This removes the `eth_compatibility crate`.
-- Backward-incompatible piece of [#1224](https://github.com/paritytech/ink/pull/1224]. Some old methods depend now on a new SEAL API (`[seal1] seal_set_storage`).
-- Backward-incompatible "Optimise deny_payment. Use eerywhere semantic of deny. ([#1267](https://github.com/paritytech/ink/pull/1267))"
-  (see @HCastano's SE [answer](https://substrate.stackexchange.com/a/3000/472) in this regard).
+
+There are a number of backwards incompatible changes which are on the `master` branch
+waiting to be released. These include:
+- Add Mapping::contains(key) and Mapping::insert_return_size(key, val) - [#1224](https://github.com/paritytech/ink/pull/1224)
+- Optimise deny_payment. Use everywhere semantic of deny. [#1267](https://github.com/paritytech/ink/pull/1267)
+- Implement ecdsa_to_eth_address() and remove eth_compatibility crate [#1233](https://github.com/paritytech/ink/pull/1233)
+
+# Version 3.3.0
+
+This release restores SemVer compatibility in the `v3.x` series of releases, as well as
+compatibility with the [`v0.13.0`](https://github.com/paritytech/substrate-contracts-node/releases/tag/v0.13.0)
+release of the `substrate-contracts-node`.
+
+## Compatibility
+This version will work fine with *substrate-contracts-node* versions from
+[0.13.0](https://github.com/paritytech/substrate-contracts-node/releases/tag/v0.13.0) up
+to [0.16.0](https://github.com/paritytech/substrate-contracts-node/releases/tag/v0.16.0).
+
+## Changed
+*Context: user-reported issues on our SE unveiled backward incompatibility introduced in 3.1.0 release.*
+1. [CodeRejected when using ink! v3.1.0](https://substrate.stackexchange.com/questions/2721/cargo-contract-3-0-1)
+1. [Incompatibility between ink! v3.0.1 and v3.2.0 ](https://substrate.stackexchange.com/questions/2870/cargo-contract-throws-error-about-supplied-arguments-in-inkconstructor-f)
+
+The following has been done to restore backward compatibility:
+- Reverted backward-incompatible piece of [#1224](https://github.com/paritytech/ink/pull/1224).
+    - The return signature of `ink_env::set_contract_storage()` was changed to return an
+      `Option<u32>`. This could have broken existing code, so this should've been done in
+      a `MAJOR` release.
+    - Under the hood the PR also changed `Mapping::insert()` to use a new SEAL API
+    (`[seal1] seal_set_storage`), which resulted in `CodeRejected` errors in nodes which
+    did not have this API (e.g `substrate-contracts-node@0.13.0`).
+- Reverted "Optimise deny_payment. Use everywhere semantic of deny ([#1267](https://github.com/paritytech/ink/pull/1267))"
+  - This one is to restore compatibility between minor versions of ink! crates; see
+    @HCastano's SE [answer](https://substrate.stackexchange.com/a/3000/472) in this
+    regard.
+- Reverted backward-incompatible piece of [#1233](https://github.com/paritytech/ink/pull/1233).
+    - The removal of the `eth_compatibility` crate should have been done in a `MAJOR`
+      release.
+
+All these breaking changes are subjects to the upcoming MAJOR *ink!* release 4.0.0.
 
 # Version 3.2.0
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,8 @@
 # [Unreleased]
+- Backward-incompatible piece of [#1233](https://github.com/paritytech/ink/pull/1233). This removes the `eth_compatibility crate`.
+- Backward-incompatible piece of [#1224](https://github.com/paritytech/ink/pull/1224]. Some old methods depend now on a new SEAL API (`[seal1] seal_set_storage`).
+- Backward-incompatible "Optimise deny_payment. Use eerywhere semantic of deny. ([#1267](https://github.com/paritytech/ink/pull/1267))"
+  (see @HCastano's SE [answer](https://substrate.stackexchange.com/a/3000/472) in this regard).
 
 # Version 3.2.0
 


### PR DESCRIPTION
These are the changes which break compatibility with elder nodes and have been reverted for 3.3.0 (see #1284). I think we should list them explicitly in the release notes of our next MAJOR ink! 4 release. 