### PR TITLE
[`v3.x.x`] Add git commit hash pattern to the spellcheck dic

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -104,3 +104,5 @@ natively
 payability
 unpayable
 initializer
+
+^#[0-9a-fA-F]{5,}$


### PR DESCRIPTION
This is to make the spellcheck CI job (like [this](https://gitlab.parity.io/parity/mirrors/ink/-/jobs/1631225#L117) one) pass for the doc comments having commit hashes references 