### PR TITLE
Spellcheck config: allow commit hash pattern

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -104,5 +104,3 @@ natively
 payability
 unpayable
 initializer
-
-^#[0-9a-fA-F]{5,}$

--- a/.config/cargo_spellcheck.toml
+++ b/.config/cargo_spellcheck.toml
@@ -16,3 +16,4 @@ use_builtin = true
 [Hunspell.quirks]
 allow_concatenation = true
 allow_dashes = true
+transform_regex = ["^[0-9a-fA-F]{5,}$"]


### PR DESCRIPTION
Follow-up to #1295 where this was done wrong