### PR TITLE
Remove deprecated rustfmt configuration options

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,8 +102,8 @@ fmt:
   script:
     - cargo fmt --verbose --all -- --check
     # For the UI tests we need to disable the license check
-    - cargo fmt --verbose --all -- --check --config=license_template_path="" ./crates/lang/tests/ui/contract/{pass,fail}/*.rs
-    - cargo fmt --verbose --all -- --check --config=license_template_path="" ./crates/lang/tests/ui/trait_def/{pass,fail}/*.rs
+    - cargo fmt --verbose --all -- --check ./crates/lang/tests/ui/contract/{pass,fail}/*.rs
+    - cargo fmt --verbose --all -- --check ./crates/lang/tests/ui/trait_def/{pass,fail}/*.rs
   allow_failure:                   true
 
 examples-fmt:
@@ -114,15 +114,15 @@ examples-fmt:
     # Note that we disable the license header check for the examples, since they are unlicensed.
     - for example in examples/*/; do
         if [ "$example" = "examples/upgradeable-contracts/" ]; then continue; fi;
-        cargo fmt --verbose --manifest-path ${example}/Cargo.toml -- --check --config=license_template_path="";
+        cargo fmt --verbose --manifest-path ${example}/Cargo.toml -- --check;
       done
     - for contract in ${DELEGATOR_SUBCONTRACTS}; do
-        cargo fmt --verbose --manifest-path ./examples/delegator/${contract}/Cargo.toml -- --check --config=license_template_path="";
+        cargo fmt --verbose --manifest-path ./examples/delegator/${contract}/Cargo.toml -- --check;
       done
     - for contract in ${UPGRADEABLE_CONTRACTS}; do
-        cargo fmt --verbose --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml -- --check --config=license_template_path="";
+        cargo fmt --verbose --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml -- --check;
       done
-    - cargo fmt --verbose --manifest-path ./examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml -- --check --config=license_template_path=""
+    - cargo fmt --verbose --manifest-path ./examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml -- --check
   allow_failure:                   true
 
 clippy-std:

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -9,7 +9,6 @@ format_code_in_doc_comments = false
 comment_width = 80
 normalize_comments = true # changed
 normalize_doc_attributes = false
-license_template_path = "FILE_HEADER" # changed
 format_strings = false
 format_macro_matchers = false
 format_macro_bodies = true
@@ -57,8 +56,6 @@ skip_children = false
 hide_parse_errors = false
 error_on_line_overflow = false
 error_on_unformatted = false
-report_todo = "Always"
-report_fixme = "Always"
 ignore = []
 
 # Below are `rustfmt` internal settings


### PR DESCRIPTION
Removes [`report_todo`](https://github.com/rust-lang/rustfmt/issues/5101), [`report_fixme`](https://github.com/rust-lang/rustfmt/issues/5102) and [`license_template_path`](https://github.com/rust-lang/rustfmt/commit/79515f17ed4661da864347c90c76c51f9bf86069).

Should we consider with replacing these options with alterantives? Certainly we could just do a simple grep for detecting `todo` and `fixme`.