### PR TITLE
Fix clippy `let_unit_value` warnings

### DIFF
--- a/crates/lang/codegen/src/generator/dispatch.rs
+++ b/crates/lang/codegen/src/generator/dispatch.rs
@@ -807,7 +807,7 @@ impl Dispatch<'_> {
                 }
 
                 impl ::ink_lang::reflect::ExecuteDispatchable for __ink_MessageDecoder {
-                    #[allow(clippy::nonminimal_bool)]
+                    #[allow(clippy::nonminimal_bool, clippy::let_unit_value)]
                     fn execute_dispatchable(
                         self
                     ) -> ::core::result::Result<(), ::ink_lang::reflect::DispatchError> {

--- a/crates/lang/codegen/src/generator/ink_test.rs
+++ b/crates/lang/codegen/src/generator/ink_test.rs
@@ -47,7 +47,7 @@ impl GenerateCode for InkTest<'_> {
                     #vis fn #fn_name( #fn_args ) {
                         ::ink_env::test::run_test::<::ink_env::DefaultEnvironment, _>(|_| {
                             {
-                                let _: () = {
+                                {
                                     #fn_block
                                 };
                                 ::core::result::Result::Ok(())

--- a/crates/lang/codegen/src/generator/item_impls.rs
+++ b/crates/lang/codegen/src/generator/item_impls.rs
@@ -133,7 +133,7 @@ impl ItemImpls<'_> {
                     let span = input.span();
                     let input_type = &*input.ty;
                     quote_spanned!(span=>
-                        let _: () = ::ink_lang::codegen::utils::consume_type::<
+                        ::ink_lang::codegen::utils::consume_type::<
                             ::ink_lang::codegen::DispatchInput<#input_type>
                         >();
                     )
@@ -153,7 +153,7 @@ impl ItemImpls<'_> {
                     let span = input.span();
                     let input_type = &*input.ty;
                     quote_spanned!(span=>
-                        let _: () = ::ink_lang::codegen::utils::consume_type::<
+                        ::ink_lang::codegen::utils::consume_type::<
                             ::ink_lang::codegen::DispatchInput<#input_type>
                         >();
                     )
@@ -161,7 +161,7 @@ impl ItemImpls<'_> {
                 let message_output = message.output().map(|output_type| {
                     let span = output_type.span();
                     quote_spanned!(span=>
-                        let _: () = ::ink_lang::codegen::utils::consume_type::<
+                        ::ink_lang::codegen::utils::consume_type::<
                             ::ink_lang::codegen::DispatchOutput<#output_type>
                         >();
                     )

--- a/crates/lang/codegen/src/generator/trait_def/trait_registry.rs
+++ b/crates/lang/codegen/src/generator/trait_def/trait_registry.rs
@@ -137,7 +137,7 @@ impl TraitRegistry<'_> {
             let input_span = input.span();
             let input_type = &*input.ty;
             quote_spanned!(input_span=>
-                let _: () = ::ink_lang::codegen::utils::consume_type::<
+                ::ink_lang::codegen::utils::consume_type::<
                     ::ink_lang::codegen::DispatchInput<#input_type>
                 >();
             )
@@ -145,7 +145,7 @@ impl TraitRegistry<'_> {
         let message_output = message.output().map(|output_type| {
             let output_span = output_type.span();
             quote_spanned!(output_span=>
-                let _: () = ::ink_lang::codegen::utils::consume_type::<
+                ::ink_lang::codegen::utils::consume_type::<
                     ::ink_lang::codegen::DispatchOutput<#output_type>
                 >();
             )

--- a/crates/lang/src/codegen/utils/identity_type.rs
+++ b/crates/lang/src/codegen/utils/identity_type.rs
@@ -29,7 +29,7 @@
 /// pub struct RequiresCopy<T: Copy>(PhantomData<T>);
 ///
 /// // The following line of code works because `i32: Copy`.
-/// let _: () = consume_type::<RequiresCopy<i32>>();
+/// consume_type::<RequiresCopy<i32>>();
 /// ```
 ///
 /// # Usage: Compile Error
@@ -42,6 +42,6 @@
 ///
 /// // The following line of code fails to compile because
 /// // `String` does not implement `Copy`.
-/// let _: () = consume_type::<RequiresCopy<String>>();
+/// consume_type::<RequiresCopy<String>>();
 /// ```
 pub const fn consume_type<T>() {}


### PR DESCRIPTION
Clippy was complaining about unit let bindings in the `cargo-contract` CI: https://gitlab.parity.io/parity/mirrors/cargo-contract/-/jobs/1664716