### PR TITLE
Add `version` field to ink! metadata

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -339,6 +339,7 @@ examples-contract-build:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
+    - cargo install --git https://github.com/paritytech/cargo-contract.git --branch hc-versioned-metadata --force
     - cargo contract -V
     - for example in examples/*/; do
         if [ "$example" = "examples/upgradeable-contracts/" ]; then continue; fi;

--- a/crates/lang/codegen/src/generator/metadata.rs
+++ b/crates/lang/codegen/src/generator/metadata.rs
@@ -45,10 +45,8 @@ impl GenerateCode for Metadata<'_> {
             #[cfg(not(feature = "ink-as-dependency"))]
             const _: () = {
                 #[no_mangle]
-                pub fn __ink_generate_metadata() -> ::ink_metadata::MetadataVersioned  {
-                    <::ink_metadata::InkProject as ::core::convert::Into<::ink_metadata::MetadataVersioned>>::into(
-                        ::ink_metadata::InkProject::new(#layout, #contract)
-                    )
+                pub fn __ink_generate_metadata() -> ::ink_metadata::InkProject  {
+                    ::ink_metadata::InkProject::new(#layout, #contract)
                 }
             };
         }

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -57,38 +57,32 @@ use serde::{
     Serialize,
 };
 
-/// Versioned ink! project metadata.
+/// The metadata version of the generated ink! contract.
+///
+/// The serialized metadata format (which this represents) is different from the
+/// version of this crate or the contract for Rust semantic versioning purposes.
 ///
 /// # Note
 ///
-/// Represents the version of the serialized metadata *format*, which is distinct from the version
-/// of this crate for Rust semantic versioning compatibility.
-#[derive(Debug, Serialize, Deserialize)]
-#[allow(clippy::large_enum_variant)]
-pub enum MetadataVersioned {
-    /// Version 0 placeholder. Represents the original non-versioned metadata format.
-    V0(MetadataVersionDeprecated),
-    /// Version 1 of the contract metadata.
-    V1(MetadataVersionDeprecated),
-    /// Version 2 of the contract metadata.
-    V2(MetadataVersionDeprecated),
-    /// Version 3 of the contract metadata.
-    V3(InkProject),
+/// Versions other than the `Default` are considered deprecated.
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub enum MetadataVersion {
+    /// Represents the original non-versioned metadata format.
+    #[serde(rename = "0")]
+    V0,
+    #[serde(rename = "1")]
+    V1,
+    #[serde(rename = "2")]
+    V2,
+    #[default]
+    #[serde(rename = "3")]
+    V3,
 }
-
-impl From<InkProject> for MetadataVersioned {
-    fn from(ink_project: InkProject) -> Self {
-        MetadataVersioned::V3(ink_project)
-    }
-}
-
-/// Enum to represent a deprecated metadata version that cannot be instantiated.
-#[derive(Debug, Serialize, Deserialize)]
-pub enum MetadataVersionDeprecated {}
 
 /// An entire ink! project for metadata file generation purposes.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InkProject {
+    version: MetadataVersion,
     #[serde(flatten)]
     registry: PortableRegistry,
     #[serde(rename = "storage")]
@@ -106,6 +100,7 @@ impl InkProject {
         let mut registry = Registry::new();
 
         Self {
+            version: Default::default(),
             layout: layout.into().into_portable(&mut registry),
             spec: spec.into().into_portable(&mut registry),
             registry: registry.into(),
@@ -114,6 +109,11 @@ impl InkProject {
 }
 
 impl InkProject {
+    /// Returns the metadata version used by the contract.
+    pub fn version(&self) -> &MetadataVersion {
+        &self.version
+    }
+
     /// Returns a read-only registry of types in the contract.
     pub fn registry(&self) -> &PortableRegistry {
         &self.registry

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -69,8 +69,6 @@ use serde::{
 /// this crate.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum MetadataVersion {
-    #[serde(rename = "3")]
-    V3,
     #[serde(rename = "4")]
     V4,
 }

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -64,16 +64,11 @@ use serde::{
 ///
 /// # Note
 ///
-/// Versions other than the `Default` are considered deprecated.
+/// Versions other than the `Default` are considered deprecated. If you want to
+/// deserialize legacy metadata versions you will need to use an old version of
+/// this crate.
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub enum MetadataVersion {
-    /// Represents the original non-versioned metadata format.
-    #[serde(rename = "0")]
-    V0,
-    #[serde(rename = "1")]
-    V1,
-    #[serde(rename = "2")]
-    V2,
     #[default]
     #[serde(rename = "3")]
     V3,

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -67,11 +67,16 @@ use serde::{
 /// Versions other than the `Default` are considered deprecated. If you want to
 /// deserialize legacy metadata versions you will need to use an old version of
 /// this crate.
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum MetadataVersion {
-    #[default]
     #[serde(rename = "3")]
     V3,
+}
+
+impl Default for MetadataVersion {
+    fn default() -> Self {
+        Self::V3
+    }
 }
 
 /// An entire ink! project for metadata file generation purposes.

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -71,11 +71,13 @@ use serde::{
 pub enum MetadataVersion {
     #[serde(rename = "3")]
     V3,
+    #[serde(rename = "4")]
+    V4,
 }
 
 impl Default for MetadataVersion {
     fn default() -> Self {
-        Self::V3
+        Self::V4
     }
 }
 


### PR DESCRIPTION
Up until now the version of the ink! metadata/ABI was specified using a version key which
wrapped the whole ink! metadata struct (`MetadataVersioned(InkProject)`).

However, it is nicer to have a proper `version` field as part of the ink! metadata object
so that it can be queried in a less-ambiguous way.

Closes #1289.
