### PR TITLE
Bump crate versions to 4.0

### DIFF
--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_allocator"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_engine"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Michael Müller <michi@parity.io>"]
 edition = "2021"
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_env"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,10 +15,10 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "3.2.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_allocator = { version = "3.2.0", path = "../allocator/", default-features = false }
-ink_primitives = { version = "3.2.0", path = "../primitives/", default-features = false }
-ink_prelude = { version = "3.2.0", path = "../prelude/", default-features = false }
+ink_metadata = { version = "4.0.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_allocator = { version = "4.0.0", path = "../allocator/", default-features = false }
+ink_primitives = { version = "4.0.0", path = "../primitives/", default-features = false }
+ink_prelude = { version = "4.0.0", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -32,7 +32,7 @@ static_assertions = "1.1"
 rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ink_engine = { version = "3.2.0", path = "../engine/", optional = true }
+ink_engine = { version = "4.0.0", path = "../engine/", optional = true }
 
 # Hashes for the off-chain environment.
 sha2 = { version = "0.10", optional = true }

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,19 +15,19 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "3.2.0", path = "../env", default-features = false }
-ink_storage = { version = "3.2.0", path = "../storage", default-features = false }
-ink_primitives = { version = "3.2.0", path = "../primitives", default-features = false }
-ink_metadata = { version = "3.2.0", path = "../metadata", default-features = false, optional = true }
-ink_prelude = { version = "3.2.0", path = "../prelude", default-features = false }
-ink_lang_macro = { version = "3.2.0", path = "macro", default-features = false }
+ink_env = { version = "4.0.0", path = "../env", default-features = false }
+ink_storage = { version = "4.0.0", path = "../storage", default-features = false }
+ink_primitives = { version = "4.0.0", path = "../primitives", default-features = false }
+ink_metadata = { version = "4.0.0", path = "../metadata", default-features = false, optional = true }
+ink_prelude = { version = "4.0.0", path = "../prelude", default-features = false }
+ink_lang_macro = { version = "4.0.0", path = "macro", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 
 [dev-dependencies]
-ink_lang_ir = { version = "3.2.0", path = "ir" }
-ink_metadata = { version = "3.2.0", default-features = false, path = "../metadata" }
+ink_lang_ir = { version = "4.0.0", path = "ir" }
+ink_metadata = { version = "4.0.0", default-features = false, path = "../metadata" }
 
 trybuild = { version = "1.0.60", features = ["diff"] }
 # Required for the doctest of `env_access::EnvAccess::instantiate_contract`

--- a/crates/lang/codegen/Cargo.toml
+++ b/crates/lang/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_codegen"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -18,7 +18,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 name = "ink_lang_codegen"
 
 [dependencies]
-ir = { version = "3.2.0", package = "ink_lang_ir", path = "../ir", default-features = false }
+ir = { version = "4.0.0", package = "ink_lang_ir", path = "../ir", default-features = false }
 quote = "1"
 syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = "1.0"

--- a/crates/lang/ir/Cargo.toml
+++ b/crates/lang/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_ir"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_macro"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,19 +15,19 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_lang_ir = { version = "3.2.0", path = "../ir", default-features = false }
-ink_lang_codegen = { version = "3.2.0", path = "../codegen", default-features = false }
-ink_primitives = { version = "3.2.0", path = "../../primitives/", default-features = false }
+ink_lang_ir = { version = "4.0.0", path = "../ir", default-features = false }
+ink_lang_codegen = { version = "4.0.0", path = "../codegen", default-features = false }
+ink_primitives = { version = "4.0.0", path = "../../primitives/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 syn = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-ink_metadata = { version = "3.2.0", path = "../../metadata/" }
-ink_env = { version = "3.2.0", path = "../../env/" }
-ink_storage = { version = "3.2.0", path = "../../storage/" }
-ink_lang = { version = "3.2.0", path = ".." }
+ink_metadata = { version = "4.0.0", path = "../../metadata/" }
+ink_env = { version = "4.0.0", path = "../../env/" }
+ink_storage = { version = "4.0.0", path = "../../storage/" }
+ink_lang = { version = "4.0.0", path = ".." }
 scale-info = { version = "2", default-features = false, features = ["derive"] }
 
 [lib]

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_metadata"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,8 +15,8 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "3.2.0", path = "../prelude/", default-features = false }
-ink_primitives = { version = "3.2.0", path = "../primitives/", default-features = false }
+ink_prelude = { version = "4.0.0", path = "../prelude/", default-features = false }
+ink_primitives = { version = "4.0.0", path = "../primitives/", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.3.1"

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_prelude"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_primitives"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "3.2.0", path = "../prelude/", default-features = false }
+ink_prelude = { version = "4.0.0", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "3.2.0", path = "../env/", default-features = false }
-ink_metadata = { version = "3.2.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "3.2.0", path = "../primitives/", default-features = false }
-ink_storage_derive = { version = "3.2.0", path = "derive", default-features = false }
-ink_prelude = { version = "3.2.0", path = "../prelude/", default-features = false }
+ink_env = { version = "4.0.0", path = "../env/", default-features = false }
+ink_metadata = { version = "4.0.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "4.0.0", path = "../primitives/", default-features = false }
+ink_storage_derive = { version = "4.0.0", path = "derive", default-features = false }
+ink_prelude = { version = "4.0.0", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -33,7 +33,7 @@ quickcheck_macros = "1.0"
 itertools = "0.10"
 paste = "1.0"
 
-ink_lang = { version = "3.2.0", path = "../lang/", default-features = false }
+ink_lang = { version = "4.0.0", path = "../lang/", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/storage/derive/Cargo.toml
+++ b/crates/storage/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage_derive"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -25,8 +25,8 @@ synstructure = "0.12.4"
 
 [dev-dependencies]
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
-ink_env = { version = "3.2.0", path = "../../env" }
-ink_primitives = { version = "3.2.0", path = "../../primitives" }
-ink_metadata = { version = "3.2.0", path = "../../metadata" }
-ink_prelude = { version = "3.2.0", path = "../../prelude/" }
-ink_storage = { version = "3.2.0", path = ".." }
+ink_env = { version = "4.0.0", path = "../../env" }
+ink_primitives = { version = "4.0.0", path = "../../primitives" }
+ink_metadata = { version = "4.0.0", path = "../../metadata" }
+ink_prelude = { version = "4.0.0", path = "../../prelude/" }
+ink_storage = { version = "4.0.0", path = ".." }

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_terminate"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_transfer"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegator"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulator"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adder"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subber"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc1155"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc20"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc721"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_extension"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_erc20"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_flipper"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/Cargo.toml
+++ b/examples/trait-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/traits/Cargo.toml
+++ b/examples/trait-incrementer/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traits"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/delegate-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/delegate-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegate_calls"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
+++ b/examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgradeable_flipper"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/forward-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/forward-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forward_calls"
-version = "3.2.0"
+version = "4.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated-incrementer"
-version = "3.2.0"
+version = "4.0.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false


### PR DESCRIPTION
While working on https://github.com/paritytech/cargo-contract/pull/641 I realized that
ink!'s `master` branch was still based on 3.2. This makes for a strange situation in
which we're "downgrading" from ink! 3.3 to 3.2 in order to work off `master`.

I figured since the `master` branch already includes breaking changes it would be
appropriate to bump all the version numbers anyways.
