### PR TITLE
Fix overflow when creating `Layout` in bump allocator tests

### DIFF
--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -272,8 +272,7 @@ mod tests {
     }
 }
 
-#[cfg(test)]
-// #[cfg(all(test, feature = "ink-fuzz-tests"))]
+#[cfg(all(test, feature = "ink-fuzz-tests"))]
 mod fuzz_tests {
     use super::*;
     use quickcheck::{

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -272,7 +272,8 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature = "ink-fuzz-tests"))]
+#[cfg(test)]
+// #[cfg(all(test, feature = "ink-fuzz-tests"))]
 mod fuzz_tests {
     use super::*;
     use quickcheck::{
@@ -348,12 +349,14 @@ mod fuzz_tests {
         n: usize,
         align: usize,
     ) -> TestResult {
+        let (n, align): (usize, usize) = (9223372036854775297, 2053816183973205299);
+
         let aligns = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512];
         let align = aligns[align % aligns.len()];
 
         // If `n` is going to overflow we don't want to check it here (we'll check the overflow
         // case in another test)
-        if n.checked_add(PAGE_SIZE - 1).is_none() {
+        if dbg!(n.checked_add(PAGE_SIZE - 1)).is_none() {
             return TestResult::discard()
         }
 

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -325,7 +325,7 @@ mod fuzz_tests {
         let mut inner = InnerAlloc::new();
 
         // If we're going to end up creating an invalid `Layout` we don't want to use these test
-        // inputs. We'll check the case where `n` overflows in another test.
+        // inputs.
         let layout = match Layout::from_size_align(n, align) {
             Ok(l) => l,
             Err(_) => return TestResult::discard(),

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -356,13 +356,15 @@ mod fuzz_tests {
 
         // If `n` is going to overflow we don't want to check it here (we'll check the overflow
         // case in another test)
-        if dbg!(n.checked_add(PAGE_SIZE - 1)).is_none() {
+        let (n, align): (isize, isize) = (9223372036854775297, 2053816183973205299);
+        if dbg!(n.checked_add(PAGE_SIZE as isize - 1)).is_none() {
             return TestResult::discard()
         }
 
         let mut inner = InnerAlloc::new();
 
-        let layout = Layout::from_size_align(n, align).expect(FROM_SIZE_ALIGN_EXPECT);
+        let layout = Layout::from_size_align(n as usize, align as usize)
+            .expect(FROM_SIZE_ALIGN_EXPECT);
         let size = layout.pad_to_align().size();
         assert_eq!(
             inner.alloc(layout),

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -281,11 +281,6 @@ mod fuzz_tests {
     };
     use std::mem::size_of;
 
-    const FROM_SIZE_ALIGN_EXPECT: &str =
-        "The rounded value of `size` cannot be more than `usize::MAX` since we have
-        checked that it is a PAGE_SIZE less than `usize::MAX`; Alignment is a
-        non-zero, power of two.";
-
     #[quickcheck]
     fn should_allocate_arbitrary_sized_bytes(n: usize) -> TestResult {
         let mut inner = InnerAlloc::new();

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -321,28 +321,6 @@ mod fuzz_tests {
     }
 
     #[quickcheck]
-    fn should_not_allocate_arbitrary_bytes_if_they_overflow(n: usize) -> TestResult {
-        // In the previous test we ignored the overflow case, now we ignore the valid cases
-        if n.checked_add(PAGE_SIZE - 1).is_some() {
-            return TestResult::discard()
-        }
-
-        if let Ok(layout) = Layout::from_size_align(n, size_of::<usize>()) {
-            let mut inner = InnerAlloc::new();
-            assert_eq!(
-                inner.alloc(layout),
-                None,
-                "An allocation which overflows the heap was made."
-            );
-
-            TestResult::passed()
-        } else {
-            // We only want to test cases which can create a valid `Layout`
-            TestResult::discard()
-        }
-    }
-
-    #[quickcheck]
     fn should_allocate_regardless_of_alignment_size(
         n: usize,
         align: usize,


### PR DESCRIPTION
Looks like I didn't read the `Layout::from_size_align` docs carefully enough and I
should've been checking for `isize` overflows instead of `usize` overflows.

Instead of hand checking this I instead decided to use `from_size_align` directly to
determine if something is valid/invalid.

I've been running the fuzz tests on my machine for a few hours and nothing's failed yet.

Closes #1323.

~~Draft since I need to double check I'm not accidentally changing the intention of some
heap overflow tests.~~
