### PR TITLE
fix "cargo contract build" under example directory

### DIFF
--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -20,6 +20,7 @@
 //! FFI to interface with FRAME contracts and a primitive blockchain
 //! emulator for simple off-chain testing.
 
+#![feature(bool_to_option)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,


### PR DESCRIPTION
Within current master branch(commit hash: 268e80a99b19af93d13fc904b20ee69f3ac1f243), running "cargo contract build" under example directory(e.g. "examples/erc20") will cause:

  error[E0658]: use of unstable library feature 'bool_to_option'
     --> /Users/wuyang/src/github.com/paritytech/ink/crates/env/src/engine/on_chain/ext.rs:194:29
         |
  194 |         (code.0 < SENTINEL).then_some(code.0)
         |                             ^^^^^^^^^
         |
      = note: see issue #80967 <https://github.com/rust-lang/rust/issues/80967> for more information
      = help: add `#![feature(bool_to_option)]` to the crate attributes to enable
  
  For more information about this error, try `rustc --explain E0658`.
  error: could not compile `ink_env` due to previous error

This PR fix it by following its instruction.