### PR TITLE
Port "Bump secp256k1 (#1348)" to v3.x.x

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -25,7 +25,7 @@ blake2 = { version = "0.10" }
 rand = { version = "0.8" }
 
 # ECDSA for the off-chain environment.
-secp256k1 = { version = "0.22.0", features = ["recovery", "global-context"], optional = true }
+secp256k1 = { version = "0.24", features = ["recovery", "global-context"], optional = true }
 
 [features]
 default = ["std"]

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -40,7 +40,7 @@ sha3 = { version = "0.10", optional = true }
 blake2 = { version = "0.10", optional = true }
 
 # ECDSA for the off-chain environment.
-secp256k1 = { version = "0.22.0", features = ["recovery", "global-context"], optional = true }
+secp256k1 = { version = "0.24", features = ["recovery", "global-context"], optional = true }
 
 # Only used in the off-chain environment.
 #


### PR DESCRIPTION
This will block integrate current ink to polkadot-v0.9.27 Substrate

If this merged, could you made a new 3.3.x release?