### PR TITLE
Use stable way of aborting

### DIFF
--- a/crates/allocator/src/handlers.rs
+++ b/crates/allocator/src/handlers.rs
@@ -14,5 +14,5 @@
 
 #[alloc_error_handler]
 fn oom(_: core::alloc::Layout) -> ! {
-    core::intrinsics::abort()
+    core::arch::wasm32::unreachable()
 }

--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -19,7 +19,7 @@
 //! full-featured `wee_alloc` allocator by activating the `wee-alloc` crate feature.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc_error_handler, core_intrinsics))]
+#![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 
 // We use `wee_alloc` as the global allocator since it is optimized for binary file size
 // so that contracts compiled with it as allocator do not grow too much in size.


### PR DESCRIPTION
This code is only ever compiled for the wasm target. This will allow us to get rid of one unstable feature.