### PR TITLE
Update to new `ChainExtension` API

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,10 +1,20 @@
 # [Unreleased]
 
 There are a number of backwards incompatible changes which are on the `master` branch
-waiting to be released. These include:
-- Add Mapping::contains(key) and Mapping::insert_return_size(key, val) - [#1224](https://github.com/paritytech/ink/pull/1224)
-- Optimise deny_payment. Use everywhere semantic of deny. [#1267](https://github.com/paritytech/ink/pull/1267)
-- Implement ecdsa_to_eth_address() and remove eth_compatibility crate [#1233](https://github.com/paritytech/ink/pull/1233)
+waiting to be released. These are:
+
+- Add Mapping::contains(key) and Mapping::insert_return_size(key, val) ‒ [#1224](https://github.com/paritytech/ink/pull/1224)
+- Optimise deny_payment. Use everywhere semantic of deny ‒ [#1267](https://github.com/paritytech/ink/pull/1267)
+- Implement ecdsa_to_eth_address() and remove eth_compatibility crate ‒ [#1233](https://github.com/paritytech/ink/pull/1233)
+- The `rand-extension` example has been adapted to an updated version of the `ChainExtension` API ‒ [#1356](https://github.com/paritytech/ink/pull/1356)
+
+## Compatibility
+
+We recommend using a version of the [`pallet-contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
+later than [6b85535](https://github.com/paritytech/substrate/tree/6b8553511112afd5ae7e8e6877dc2f467850f155)
+(Aug 12, 2022) in your node.
+
+The compatibility issues will be with `ChainExtension`'s and the functions mentioned above.
 
 # Version 3.3.1
 

--- a/examples/rand-extension/runtime/chain-extension-example.rs
+++ b/examples/rand-extension/runtime/chain-extension-example.rs
@@ -15,17 +15,19 @@ use pallet_contracts::chain_extension::{
 use sp_runtime::DispatchError;
 
 /// Contract extension for `FetchRandom`
+#[derive(Default)]
 pub struct FetchRandomExtension;
 
 impl ChainExtension<Runtime> for FetchRandomExtension {
     fn call<E: Ext>(
-        func_id: u32,
+        &mut self,
         env: Environment<E, InitState>,
     ) -> Result<RetVal, DispatchError>
     where
         <E::T as SysConfig>::AccountId:
             UncheckedFrom<<E::T as SysConfig>::Hash> + AsRef<[u8]>,
     {
+        let func_id = env.func_id();
         match func_id {
             1101 => {
                 let mut env = env.buf_in_buf_out();


### PR DESCRIPTION
The `ink-waterfall` Docker image currently cannot be build because of this.