### PR TITLE
Pin Github Actions Versions

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -56,13 +56,13 @@ jobs:
           override: true
 
       - name: Install cargo-dylint
-        uses: baptiste0928/cargo-install@vbf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
+        uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
         with:
           crate: cargo-dylint
           version: 1
 
       - name: Install dylint-link
-        uses: baptiste0928/cargo-install@vbf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
+        uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
         with:
           crate: dylint-link
           version: 1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -41,14 +41,14 @@ jobs:
       - run: npm install wasm-opt -g
 
       - name: Checkout sources & submodules
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
           submodules: recursive
 
       - name: Install toolchain
         id: toolchain
-        uses: actions-rs/toolchain@master
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -56,13 +56,13 @@ jobs:
           override: true
 
       - name: Install cargo-dylint
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@vbf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
         with:
           crate: cargo-dylint
           version: 1
 
       - name: Install dylint-link
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@vbf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
         with:
           crate: dylint-link
           version: 1


### PR DESCRIPTION
In order to improve our security posture with GitHub Actions usage. I've made a version pinning ether to commit hash or to specific version.

Related issues and policy:
https://github.com/paritytech/ci_cd/issues/464
https://github.com/paritytech/ci_cd/wiki/Policies-and-regulations:-GitHub-Actions-usage-policies