### PR TITLE
Allow reentrancy for multisig example contract

### DIFF
--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -64,10 +64,13 @@ use ink_lang as ink;
 
 #[ink::contract]
 mod multisig {
-    use ink_env::call::{
-        build_call,
-        Call,
-        ExecutionInput,
+    use ink_env::{
+        call::{
+            build_call,
+            Call,
+            ExecutionInput,
+        },
+        CallFlags,
     };
     use ink_prelude::vec::Vec;
     use ink_storage::{
@@ -546,6 +549,7 @@ mod multisig {
                         .gas_limit(t.gas_limit)
                         .transferred_value(t.transferred_value),
                 )
+                .call_flags(CallFlags::default().set_allow_reentry(true))
                 .exec_input(
                     ExecutionInput::new(t.selector.into()).push_arg(CallInput(&t.input)),
                 )
@@ -578,6 +582,7 @@ mod multisig {
                         .gas_limit(t.gas_limit)
                         .transferred_value(t.transferred_value),
                 )
+                .call_flags(CallFlags::default().set_allow_reentry(true))
                 .exec_input(
                     ExecutionInput::new(t.selector.into()).push_arg(CallInput(&t.input)),
                 )

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -139,6 +139,7 @@ mod multisig {
         /// Gas limit for the execution of the call.
         pub gas_limit: u64,
         /// If set to true the transaction will be allowed to re-enter the multisig contract.
+	/// Re-entrancy can lead to vulnerabilities. Use at your own risk.
         pub allow_reentry: bool,
     }
 

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -138,7 +138,7 @@ mod multisig {
         pub transferred_value: Balance,
         /// Gas limit for the execution of the call.
         pub gas_limit: u64,
-        /// The call flag allowing reentry
+        /// If set to true the transaction will be allowed to re-enter the multisig contract.
         pub allow_reentry: bool,
     }
 

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -138,6 +138,8 @@ mod multisig {
         pub transferred_value: Balance,
         /// Gas limit for the execution of the call.
         pub gas_limit: u64,
+        /// The call flag allowing reentry
+        pub allow_reentry: bool,
     }
 
     /// Errors that can occur upon calling this contract.
@@ -549,7 +551,7 @@ mod multisig {
                         .gas_limit(t.gas_limit)
                         .transferred_value(t.transferred_value),
                 )
-                .call_flags(CallFlags::default().set_allow_reentry(true))
+                .call_flags(CallFlags::default().set_allow_reentry(t.allow_reentry))
                 .exec_input(
                     ExecutionInput::new(t.selector.into()).push_arg(CallInput(&t.input)),
                 )
@@ -582,7 +584,7 @@ mod multisig {
                         .gas_limit(t.gas_limit)
                         .transferred_value(t.transferred_value),
                 )
-                .call_flags(CallFlags::default().set_allow_reentry(true))
+                .call_flags(CallFlags::default().set_allow_reentry(t.allow_reentry))
                 .exec_input(
                     ExecutionInput::new(t.selector.into()).push_arg(CallInput(&t.input)),
                 )

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -139,7 +139,7 @@ mod multisig {
         /// Gas limit for the execution of the call.
         pub gas_limit: u64,
         /// If set to true the transaction will be allowed to re-enter the multisig contract.
-	/// Re-entrancy can lead to vulnerabilities. Use at your own risk.
+        /// Re-entrancy can lead to vulnerabilities. Use at your own risk.
         pub allow_reentry: bool,
     }
 
@@ -742,6 +742,7 @@ mod multisig {
                     input: call_args.encode(),
                     transferred_value: 0,
                     gas_limit: 1000000,
+                    allow_reentry: false,
                 }
             }
         }


### PR DESCRIPTION
`examples/multisig`: Messages `invoke_transaction()` and `eval_transaction()` while making the call should have the `allow_reentry` call flag being set to true, otherwise the tx invocation fails with `contract:ReentranceDenied`.

_(this has been found while re-producing #1178 )_