### PR TITLE
Release `v4.0.0-alpha.1`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,7 @@ examples-fmt:
     - cargo fmt --verbose --manifest-path ./examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml -- --check
   allow_failure:                   true
 
-clippy-std:
+.clippy-std:
   stage:                           lint
   <<:                              *docker-env
   <<:                              *test-refs
@@ -134,7 +134,7 @@ clippy-std:
         cargo clippy --verbose --all-targets --all-features --manifest-path ./crates/${crate}/Cargo.toml -- -D warnings;
       done
 
-clippy-wasm:
+.clippy-wasm:
   stage:                           lint
   <<:                              *docker-env
   <<:                              *test-refs
@@ -144,7 +144,7 @@ clippy-wasm:
       done
   allow_failure:                   true
 
-examples-clippy-std:
+.examples-clippy-std:
   stage:                           lint
   <<:                              *docker-env
   <<:                              *test-refs
@@ -162,7 +162,7 @@ examples-clippy-std:
     - cargo clippy --verbose --all-targets --manifest-path ./examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml -- -D warnings;
   allow_failure:                   true
 
-examples-clippy-wasm:
+.examples-clippy-wasm:
   stage:                           lint
   <<:                              *docker-env
   <<:                              *test-refs
@@ -183,7 +183,7 @@ examples-clippy-wasm:
 
 #### stage:                        check
 
-check-std:
+.check-std:
   stage:                           check
   <<:                              *docker-env
   <<:                              *test-refs
@@ -192,7 +192,7 @@ check-std:
         cargo check --verbose --all-features --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
-check-wasm:
+.check-wasm:
   stage:                           check
   <<:                              *docker-env
   <<:                              *test-refs
@@ -201,7 +201,7 @@ check-wasm:
         cargo check --verbose --no-default-features --target wasm32-unknown-unknown --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
-dylint:
+.dylint:
     stage:                           check
     <<:                              *docker-env
     <<:                              *test-refs
@@ -219,7 +219,7 @@ dylint:
 
 #### stage:                        workspace
 
-build-std:
+.build-std:
   stage:                           workspace
   <<:                              *docker-env
   <<:                              *test-refs
@@ -231,7 +231,7 @@ build-std:
         cargo build --verbose --all-features --release --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
-build-wasm:
+.build-wasm:
   stage:                           workspace
   <<:                              *docker-env
   <<:                              *test-refs
@@ -243,7 +243,7 @@ build-wasm:
         cargo build --verbose --no-default-features --release --target wasm32-unknown-unknown --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
-test:
+.test:
   stage:                           workspace
   <<:                              *docker-env
   <<:                              *test-refs
@@ -260,7 +260,7 @@ test:
     - cargo test --verbose --all-features --no-fail-fast --workspace
     - cargo test --verbose --all-features --no-fail-fast --workspace --doc
 
-docs:
+.docs:
   stage:                           workspace
   <<:                              *docker-env
   <<:                              *test-refs
@@ -283,7 +283,7 @@ docs:
     - chown -R nonroot:nonroot ./crate-docs
 
 
-codecov:
+.codecov:
   stage:                           workspace
   <<:                              *docker-env
   <<:                              *test-refs
@@ -329,7 +329,7 @@ codecov:
 
 #### stage:                        examples
 
-examples-test:
+.examples-test:
   stage:                           examples
   <<:                              *docker-env
   <<:                              *test-refs
@@ -354,6 +354,7 @@ examples-contract-build:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
+    - rustup component add rust-src --toolchain stable
     - cargo install --git https://github.com/paritytech/cargo-contract.git --branch hc-versioned-metadata --force
     - cargo contract -V
     - for example in examples/*/; do
@@ -368,7 +369,7 @@ examples-contract-build:
       done
     - cargo +stable contract build --manifest-path ./examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
 
-examples-docs:
+.examples-docs:
   stage:                           examples
   <<:                              *docker-env
   <<:                              *test-refs
@@ -394,7 +395,7 @@ examples-docs:
 
 #### stage:                        ink-waterfall
 
-ink-waterfall:
+.ink-waterfall:
   stage:                           ink-waterfall
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-env
@@ -411,7 +412,7 @@ ink-waterfall:
 
 #### stage:                        publish
 
-publish-docs:
+.publish-docs:
   stage:                           publish
   <<:                              *kubernetes-env
   image:                           paritytech/tools:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -359,14 +359,14 @@ examples-contract-build:
     - for example in examples/*/; do
         if [ "$example" = "examples/upgradeable-contracts/" ]; then continue; fi;
         pushd $example &&
-        cargo contract build &&
+        cargo +stable contract build &&
         popd;
       done
     - pushd ./examples/delegator/ && ./build-all.sh && popd
     - for contract in ${UPGRADEABLE_CONTRACTS}; do
-        cargo contract build --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml;
+        cargo +stable contract build --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml;
       done
-    - cargo contract build --manifest-path ./examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
+    - cargo +stable contract build --manifest-path ./examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
 
 examples-docs:
   stage:                           examples

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,7 @@ examples-fmt:
     - cargo fmt --verbose --manifest-path ./examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml -- --check
   allow_failure:                   true
 
-.clippy-std:
+clippy-std:
   stage:                           lint
   <<:                              *docker-env
   <<:                              *test-refs
@@ -134,7 +134,7 @@ examples-fmt:
         cargo clippy --verbose --all-targets --all-features --manifest-path ./crates/${crate}/Cargo.toml -- -D warnings;
       done
 
-.clippy-wasm:
+clippy-wasm:
   stage:                           lint
   <<:                              *docker-env
   <<:                              *test-refs
@@ -144,7 +144,7 @@ examples-fmt:
       done
   allow_failure:                   true
 
-.examples-clippy-std:
+examples-clippy-std:
   stage:                           lint
   <<:                              *docker-env
   <<:                              *test-refs
@@ -162,7 +162,7 @@ examples-fmt:
     - cargo clippy --verbose --all-targets --manifest-path ./examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml -- -D warnings;
   allow_failure:                   true
 
-.examples-clippy-wasm:
+examples-clippy-wasm:
   stage:                           lint
   <<:                              *docker-env
   <<:                              *test-refs
@@ -183,7 +183,7 @@ examples-fmt:
 
 #### stage:                        check
 
-.check-std:
+check-std:
   stage:                           check
   <<:                              *docker-env
   <<:                              *test-refs
@@ -192,7 +192,7 @@ examples-fmt:
         cargo check --verbose --all-features --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
-.check-wasm:
+check-wasm:
   stage:                           check
   <<:                              *docker-env
   <<:                              *test-refs
@@ -201,7 +201,7 @@ examples-fmt:
         cargo check --verbose --no-default-features --target wasm32-unknown-unknown --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
-.dylint:
+dylint:
     stage:                           check
     <<:                              *docker-env
     <<:                              *test-refs
@@ -219,7 +219,7 @@ examples-fmt:
 
 #### stage:                        workspace
 
-.build-std:
+build-std:
   stage:                           workspace
   <<:                              *docker-env
   <<:                              *test-refs
@@ -231,7 +231,7 @@ examples-fmt:
         cargo build --verbose --all-features --release --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
-.build-wasm:
+build-wasm:
   stage:                           workspace
   <<:                              *docker-env
   <<:                              *test-refs
@@ -243,7 +243,7 @@ examples-fmt:
         cargo build --verbose --no-default-features --release --target wasm32-unknown-unknown --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
-.test:
+test:
   stage:                           workspace
   <<:                              *docker-env
   <<:                              *test-refs
@@ -260,7 +260,7 @@ examples-fmt:
     - cargo test --verbose --all-features --no-fail-fast --workspace
     - cargo test --verbose --all-features --no-fail-fast --workspace --doc
 
-.docs:
+docs:
   stage:                           workspace
   <<:                              *docker-env
   <<:                              *test-refs
@@ -283,7 +283,7 @@ examples-fmt:
     - chown -R nonroot:nonroot ./crate-docs
 
 
-.codecov:
+codecov:
   stage:                           workspace
   <<:                              *docker-env
   <<:                              *test-refs
@@ -329,7 +329,7 @@ examples-fmt:
 
 #### stage:                        examples
 
-.examples-test:
+examples-test:
   stage:                           examples
   <<:                              *docker-env
   <<:                              *test-refs
@@ -369,7 +369,7 @@ examples-contract-build:
       done
     - cargo +stable contract build --manifest-path ./examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
 
-.examples-docs:
+examples-docs:
   stage:                           examples
   <<:                              *docker-env
   <<:                              *test-refs
@@ -395,7 +395,7 @@ examples-contract-build:
 
 #### stage:                        ink-waterfall
 
-.ink-waterfall:
+ink-waterfall:
   stage:                           ink-waterfall
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-env
@@ -412,7 +412,7 @@ examples-contract-build:
 
 #### stage:                        publish
 
-.publish-docs:
+publish-docs:
   stage:                           publish
   <<:                              *kubernetes-env
   image:                           paritytech/tools:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Version 4.0.0-alpha.1
 
+## Breaking Changes
+This release contains a few breaking changes. These are indicated with the :x: emoji.
+Most of these were intitially introduced in `v3.1.0` and `v3.2.0` releases but
+compatibility was restored in `v3.3.0`.
+
 ## Added
-- Add Mapping::contains(key) and Mapping::insert_return_size(key, val) ‒ [#1224](https://github.com/paritytech/ink/pull/1224)
+- :x: Add Mapping::contains(key) and Mapping::insert_return_size(key, val) ‒ [#1224](https://github.com/paritytech/ink/pull/1224)
 - Add payment-channel example - [#1248](https://github.com/paritytech/ink/pull/1248)
-- Add `version` field to ink! metadata - [#1313](https://github.com/paritytech/ink/pull/1313)
+- :x: Add `version` field to ink! metadata - [#1313](https://github.com/paritytech/ink/pull/1313)
 - The `rand-extension` example has been adapted to an updated version of the `ChainExtension` API ‒ [#1356](https://github.com/paritytech/ink/pull/1356)
 
 ## Changed
-- Contract size optimization in case contract doesn't accept payment ‒ [#1267](https://github.com/paritytech/ink/pull/1267) (thanks [@xgreenx](https://github.com/xgreenx)).
+- :x: Contract size optimization in case contract doesn't accept payment ‒ [#1267](https://github.com/paritytech/ink/pull/1267) (thanks [@xgreenx](https://github.com/xgreenx)).
 
 ## Removed
-- Implement ecdsa_to_eth_address() and remove eth_compatibility crate ‒ [#1233](https://github.com/paritytech/ink/pull/1233)
+- :x: Implement ecdsa_to_eth_address() and remove eth_compatibility crate ‒ [#1233](https://github.com/paritytech/ink/pull/1233)
 
 ## Compatibility
 We recommend using a version of the [`pallet-contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-There are a number of backwards incompatible changes which are on the `master` branch
-waiting to be released. These are:
+# Version 4.0.0-alpha.1
 
+## Added
 - Add Mapping::contains(key) and Mapping::insert_return_size(key, val) ‒ [#1224](https://github.com/paritytech/ink/pull/1224)
-- Optimise deny_payment. Use everywhere semantic of deny ‒ [#1267](https://github.com/paritytech/ink/pull/1267)
-- Implement ecdsa_to_eth_address() and remove eth_compatibility crate ‒ [#1233](https://github.com/paritytech/ink/pull/1233)
+- Add payment-channel example - [#1248](https://github.com/paritytech/ink/pull/1248)
+- Add `version` field to ink! metadata - [#1313](https://github.com/paritytech/ink/pull/1313)
 - The `rand-extension` example has been adapted to an updated version of the `ChainExtension` API ‒ [#1356](https://github.com/paritytech/ink/pull/1356)
 
-### Compatibility
+## Changed
+- Contract size optimization in case contract doesn't accept payment ‒ [#1267](https://github.com/paritytech/ink/pull/1267) (thanks [@xgreenx](https://github.com/xgreenx)).
 
+## Removed
+- Implement ecdsa_to_eth_address() and remove eth_compatibility crate ‒ [#1233](https://github.com/paritytech/ink/pull/1233)
+
+## Compatibility
 We recommend using a version of the [`pallet-contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
 later than [6b85535](https://github.com/paritytech/substrate/tree/6b8553511112afd5ae7e8e6877dc2f467850f155)
 (Aug 12, 2022) in your node.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ return an `Option<u32>` instead of `()`.
 
 ### Added
 - :x: Add `Mapping::contains(key)` and `Mapping::insert_return_size(key, val)` ‒ [#1224](https://github.com/paritytech/ink/pull/1224)
-- Add [`payment-channel`](https://github.com/paritytech/ink/tree/master/examples/payment-channel) example - [#1248](https://github.com/paritytech/ink/pull/1248)
-- :x: Add `version` field to ink! metadata - [#1313](https://github.com/paritytech/ink/pull/1313)
+- Add [`payment-channel`](https://github.com/paritytech/ink/tree/master/examples/payment-channel) example ‒ [#1248](https://github.com/paritytech/ink/pull/1248)
+- :x: Add `version` field to ink! metadata ‒ [#1313](https://github.com/paritytech/ink/pull/1313)
 - The `rand-extension` example has been adapted to an updated version of the `ChainExtension` API ‒ [#1356](https://github.com/paritytech/ink/pull/1356)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 4.0.0-alpha.1
 
+### Compatibility
+We recommend using a version of the [`pallet-contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
+later than [6b85535](https://github.com/paritytech/substrate/tree/6b8553511112afd5ae7e8e6877dc2f467850f155)
+(Aug 12, 2022) in your node.
+
+The compatibility issues will be with `ChainExtension`'s and the functions mentioned above.
+
 ### Breaking Changes
 This release contains a few breaking changes. These are indicated with the :x: emoji.
 Most of these were intitially introduced in `v3.1.0` and `v3.2.0` releases but
@@ -34,13 +41,6 @@ return an `Option<u32>` instead of `()`.
 
 ### Removed
 - :x: Implement ecdsa_to_eth_address() and remove eth_compatibility crate ‒ [#1233](https://github.com/paritytech/ink/pull/1233)
-
-### Compatibility
-We recommend using a version of the [`pallet-contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
-later than [6b85535](https://github.com/paritytech/substrate/tree/6b8553511112afd5ae7e8e6877dc2f467850f155)
-(Aug 12, 2022) in your node.
-
-The compatibility issues will be with `ChainExtension`'s and the functions mentioned above.
 
 ## Version 3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Most of these were intitially introduced in `v3.1.0` and `v3.2.0` releases but
 compatibility was restored in `v3.3.0`.
 
 ### Added
-- :x: Add Mapping::contains(key) and Mapping::insert_return_size(key, val) ‒ [#1224](https://github.com/paritytech/ink/pull/1224)
-- Add payment-channel example - [#1248](https://github.com/paritytech/ink/pull/1248)
+- :x: Add `Mapping::contains(key)` and `Mapping::insert_return_size(key, val)` ‒ [#1224](https://github.com/paritytech/ink/pull/1224)
+- Add [`payment-channel`](https://github.com/paritytech/ink/tree/master/examples/payment-channel) example - [#1248](https://github.com/paritytech/ink/pull/1248)
 - :x: Add `version` field to ink! metadata - [#1313](https://github.com/paritytech/ink/pull/1313)
 - The `rand-extension` example has been adapted to an updated version of the `ChainExtension` API ‒ [#1356](https://github.com/paritytech/ink/pull/1356)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ return an `Option<u32>` instead of `()`.
 
 ### Changed
 - :x: Contract size optimization in case contract doesn't accept payment ‒ [#1267](https://github.com/paritytech/ink/pull/1267) (thanks [@xgreenx](https://github.com/xgreenx)).
-- Move linting into ink repo - [#1361](https://github.com/paritytech/ink/pull/1267)
+- Move ink! linter into `ink` repository ‒ [#1361](https://github.com/paritytech/ink/pull/1267)
 
 ### Removed
 - :x: Implement ecdsa_to_eth_address() and remove eth_compatibility crate ‒ [#1233](https://github.com/paritytech/ink/pull/1233)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ This release contains a few breaking changes. These are indicated with the :x: e
 Most of these were intitially introduced in `v3.1.0` and `v3.2.0` releases but
 compatibility was restored in `v3.3.0`.
 
+- As part of [#1224] the return type of `ink_env::set_contract_storage()` was changed to
+return an `Option<u32>` instead of `()`.
+- As part of [#1233] the `eth_compatibility` crate was removed. The
+  `ecdsa_to_eth_address()` function from it can now be found in the `ink_env` crate.
+- As part of [#1267] an argument to `ink_lang::codegen::execute_constructor()` (which is
+  used internally by the ink! macros) was removed.
+- As part of [#1313] the ink! ABI was changed so that the version was specified using a
+  dedicated `version` key instead of an implicit key which wrapped the entire ABI.
+
 ### Added
 - :x: Add `Mapping::contains(key)` and `Mapping::insert_return_size(key, val)` ‒ [#1224](https://github.com/paritytech/ink/pull/1224)
 - Add [`payment-channel`](https://github.com/paritytech/ink/tree/master/examples/payment-channel) example - [#1248](https://github.com/paritytech/ink/pull/1248)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ This release contains a few breaking changes. These are indicated with the :x: e
 Most of these were intitially introduced in `v3.1.0` and `v3.2.0` releases but
 compatibility was restored in `v3.3.0`.
 
-- As part of [#1224] the return type of `ink_env::set_contract_storage()` was changed to
+- As part of [#1224](https://github.com/paritytech/ink/pull/1224) the return type of `ink_env::set_contract_storage()` was changed to
 return an `Option<u32>` instead of `()`.
-- As part of [#1233] the `eth_compatibility` crate was removed. The
+- As part of [#1233](https://github.com/paritytech/ink/pull/1233) the `eth_compatibility` crate was removed. The
   `ecdsa_to_eth_address()` function from it can now be found in the `ink_env` crate.
-- As part of [#1267] an argument to `ink_lang::codegen::execute_constructor()` (which is
+- As part of [#1267](https://github.com/paritytech/ink/pull/1267) an argument to `ink_lang::codegen::execute_constructor()` (which is
   used internally by the ink! macros) was removed.
-- As part of [#1313] the ink! ABI was changed so that the version was specified using a
+- As part of [#1313](https://github.com/paritytech/ink/pull/1313) the ink! ABI was changed so that the version was specified using a
   dedicated `version` key instead of an implicit key which wrapped the entire ABI.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ return an `Option<u32>` instead of `()`.
 
 ### Changed
 - :x: Contract size optimization in case contract doesn't accept payment ‒ [#1267](https://github.com/paritytech/ink/pull/1267) (thanks [@xgreenx](https://github.com/xgreenx)).
+- Move linting into ink repo - [#1361](https://github.com/paritytech/ink/pull/1267)
 
 ### Removed
 - :x: Implement ecdsa_to_eth_address() and remove eth_compatibility crate ‒ [#1233](https://github.com/paritytech/ink/pull/1233)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-# Version 4.0.0-alpha.1
+## Version 4.0.0-alpha.1
 
-## Breaking Changes
+### Breaking Changes
 This release contains a few breaking changes. These are indicated with the :x: emoji.
 Most of these were intitially introduced in `v3.1.0` and `v3.2.0` releases but
 compatibility was restored in `v3.3.0`.
 
-## Added
+### Added
 - :x: Add Mapping::contains(key) and Mapping::insert_return_size(key, val) ‒ [#1224](https://github.com/paritytech/ink/pull/1224)
 - Add payment-channel example - [#1248](https://github.com/paritytech/ink/pull/1248)
 - :x: Add `version` field to ink! metadata - [#1313](https://github.com/paritytech/ink/pull/1313)
 - The `rand-extension` example has been adapted to an updated version of the `ChainExtension` API ‒ [#1356](https://github.com/paritytech/ink/pull/1356)
 
-## Changed
+### Changed
 - :x: Contract size optimization in case contract doesn't accept payment ‒ [#1267](https://github.com/paritytech/ink/pull/1267) (thanks [@xgreenx](https://github.com/xgreenx)).
 
-## Removed
+### Removed
 - :x: Implement ecdsa_to_eth_address() and remove eth_compatibility crate ‒ [#1233](https://github.com/paritytech/ink/pull/1233)
 
-## Compatibility
+### Compatibility
 We recommend using a version of the [`pallet-contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
 later than [6b85535](https://github.com/paritytech/substrate/tree/6b8553511112afd5ae7e8e6877dc2f467850f155)
 (Aug 12, 2022) in your node.

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_allocator"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_engine"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Michael Müller <michi@parity.io>"]
 edition = "2021"
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_env"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,10 +15,10 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "4.0.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_allocator = { version = "4.0.0", path = "../allocator/", default-features = false }
-ink_primitives = { version = "4.0.0", path = "../primitives/", default-features = false }
-ink_prelude = { version = "4.0.0", path = "../prelude/", default-features = false }
+ink_metadata = { version = "4.0.0-alpha.1", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_allocator = { version = "4.0.0-alpha.1", path = "../allocator/", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.1", path = "../primitives/", default-features = false }
+ink_prelude = { version = "4.0.0-alpha.1", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -32,7 +32,7 @@ static_assertions = "1.1"
 rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ink_engine = { version = "4.0.0", path = "../engine/", optional = true }
+ink_engine = { version = "4.0.0-alpha.1", path = "../engine/", optional = true }
 
 # Hashes for the off-chain environment.
 sha2 = { version = "0.10", optional = true }

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,19 +15,19 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.0.0", path = "../env", default-features = false }
-ink_storage = { version = "4.0.0", path = "../storage", default-features = false }
-ink_primitives = { version = "4.0.0", path = "../primitives", default-features = false }
-ink_metadata = { version = "4.0.0", path = "../metadata", default-features = false, optional = true }
-ink_prelude = { version = "4.0.0", path = "../prelude", default-features = false }
-ink_lang_macro = { version = "4.0.0", path = "macro", default-features = false }
+ink_env = { version = "4.0.0-alpha.1", path = "../env", default-features = false }
+ink_storage = { version = "4.0.0-alpha.1", path = "../storage", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.1", path = "../primitives", default-features = false }
+ink_metadata = { version = "4.0.0-alpha.1", path = "../metadata", default-features = false, optional = true }
+ink_prelude = { version = "4.0.0-alpha.1", path = "../prelude", default-features = false }
+ink_lang_macro = { version = "4.0.0-alpha.1", path = "macro", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 
 [dev-dependencies]
-ink_lang_ir = { version = "4.0.0", path = "ir" }
-ink_metadata = { version = "4.0.0", default-features = false, path = "../metadata" }
+ink_lang_ir = { version = "4.0.0-alpha.1", path = "ir" }
+ink_metadata = { version = "4.0.0-alpha.1", default-features = false, path = "../metadata" }
 
 trybuild = { version = "1.0.60", features = ["diff"] }
 # Required for the doctest of `env_access::EnvAccess::instantiate_contract`

--- a/crates/lang/codegen/Cargo.toml
+++ b/crates/lang/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_codegen"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -18,7 +18,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 name = "ink_lang_codegen"
 
 [dependencies]
-ir = { version = "4.0.0", package = "ink_lang_ir", path = "../ir", default-features = false }
+ir = { version = "4.0.0-alpha.1", package = "ink_lang_ir", path = "../ir", default-features = false }
 quote = "1"
 syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = "1.0"

--- a/crates/lang/ir/Cargo.toml
+++ b/crates/lang/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_ir"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_macro"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,19 +15,19 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_lang_ir = { version = "4.0.0", path = "../ir", default-features = false }
-ink_lang_codegen = { version = "4.0.0", path = "../codegen", default-features = false }
-ink_primitives = { version = "4.0.0", path = "../../primitives/", default-features = false }
+ink_lang_ir = { version = "4.0.0-alpha.1", path = "../ir", default-features = false }
+ink_lang_codegen = { version = "4.0.0-alpha.1", path = "../codegen", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.1", path = "../../primitives/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 syn = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-ink_metadata = { version = "4.0.0", path = "../../metadata/" }
-ink_env = { version = "4.0.0", path = "../../env/" }
-ink_storage = { version = "4.0.0", path = "../../storage/" }
-ink_lang = { version = "4.0.0", path = ".." }
+ink_metadata = { version = "4.0.0-alpha.1", path = "../../metadata/" }
+ink_env = { version = "4.0.0-alpha.1", path = "../../env/" }
+ink_storage = { version = "4.0.0-alpha.1", path = "../../storage/" }
+ink_lang = { version = "4.0.0-alpha.1", path = ".." }
 scale-info = { version = "2", default-features = false, features = ["derive"] }
 
 [lib]

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_metadata"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,8 +15,8 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "4.0.0", path = "../prelude/", default-features = false }
-ink_primitives = { version = "4.0.0", path = "../primitives/", default-features = false }
+ink_prelude = { version = "4.0.0-alpha.1", path = "../prelude/", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.1", path = "../primitives/", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.3.1"

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_prelude"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_primitives"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "4.0.0", path = "../prelude/", default-features = false }
+ink_prelude = { version = "4.0.0-alpha.1", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.0.0", path = "../env/", default-features = false }
-ink_metadata = { version = "4.0.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.0.0", path = "../primitives/", default-features = false }
-ink_storage_derive = { version = "4.0.0", path = "derive", default-features = false }
-ink_prelude = { version = "4.0.0", path = "../prelude/", default-features = false }
+ink_env = { version = "4.0.0-alpha.1", path = "../env/", default-features = false }
+ink_metadata = { version = "4.0.0-alpha.1", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "4.0.0-alpha.1", path = "../primitives/", default-features = false }
+ink_storage_derive = { version = "4.0.0-alpha.1", path = "derive", default-features = false }
+ink_prelude = { version = "4.0.0-alpha.1", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -33,7 +33,7 @@ quickcheck_macros = "1.0"
 itertools = "0.10"
 paste = "1.0"
 
-ink_lang = { version = "4.0.0", path = "../lang/", default-features = false }
+ink_lang = { version = "4.0.0-alpha.1", path = "../lang/", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/storage/derive/Cargo.toml
+++ b/crates/storage/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage_derive"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -25,8 +25,8 @@ synstructure = "0.12.4"
 
 [dev-dependencies]
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
-ink_env = { version = "4.0.0", path = "../../env" }
-ink_primitives = { version = "4.0.0", path = "../../primitives" }
-ink_metadata = { version = "4.0.0", path = "../../metadata" }
-ink_prelude = { version = "4.0.0", path = "../../prelude/" }
-ink_storage = { version = "4.0.0", path = ".." }
+ink_env = { version = "4.0.0-alpha.1", path = "../../env" }
+ink_primitives = { version = "4.0.0-alpha.1", path = "../../primitives" }
+ink_metadata = { version = "4.0.0-alpha.1", path = "../../metadata" }
+ink_prelude = { version = "4.0.0-alpha.1", path = "../../prelude/" }
+ink_storage = { version = "4.0.0-alpha.1", path = ".." }

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_terminate"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_transfer"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegator"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulator"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adder"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/build-all.sh
+++ b/examples/delegator/build-all.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-cargo contract build --manifest-path accumulator/Cargo.toml
-cargo contract build --manifest-path adder/Cargo.toml
-cargo contract build --manifest-path subber/Cargo.toml
-cargo contract build
+cargo +stable contract build --manifest-path accumulator/Cargo.toml
+cargo +stable contract build --manifest-path adder/Cargo.toml
+cargo +stable contract build --manifest-path subber/Cargo.toml
+cargo +stable contract build

--- a/examples/delegator/build-all.sh
+++ b/examples/delegator/build-all.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-cargo +nightly contract build --manifest-path accumulator/Cargo.toml
-cargo +nightly contract build --manifest-path adder/Cargo.toml
-cargo +nightly contract build --manifest-path subber/Cargo.toml
-cargo +nightly contract build
+cargo contract build --manifest-path accumulator/Cargo.toml
+cargo contract build --manifest-path adder/Cargo.toml
+cargo contract build --manifest-path subber/Cargo.toml
+cargo contract build

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subber"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc1155"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc20"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc721"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/mother/Cargo.toml
+++ b/examples/mother/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mother"
 description = "Mother of all contracts"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/payment-channel/Cargo.toml
+++ b/examples/payment-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payment_channel"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_extension"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_erc20"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_flipper"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/Cargo.toml
+++ b/examples/trait-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/traits/Cargo.toml
+++ b/examples/trait-incrementer/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traits"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/delegate-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/delegate-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegate_calls"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
+++ b/examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgradeable_flipper"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/forward-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/forward-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forward_calls"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated-incrementer"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_linting"
-version = "4.0.0"
+version = "4.0.0-alpha.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
@@ -28,11 +28,11 @@ regex = "1.5.4"
 dylint_testing = "2.0.0"
 
 # The following are ink! dependencies, they are only required for the `ui` tests.
-ink_env = { version = "4.0.0", path = "../crates/env", default-features = false }
-ink_storage = { version = "4.0.0", path = "../crates/storage", default-features = false }
-ink_primitives = { version = "4.0.0", path = "../crates/primitives", default-features = false }
-ink_lang = { version = "4.0.0", path = "../crates/lang", default-features = false }
-ink_metadata = { version = "4.0.0", path = "../crates/metadata", default-features = false }
+ink_env = { version = "4.0.0-alpha.1", path = "../crates/env", default-features = false }
+ink_storage = { version = "4.0.0-alpha.1", path = "../crates/storage", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.1", path = "../crates/primitives", default-features = false }
+ink_lang = { version = "4.0.0-alpha.1", path = "../crates/lang", default-features = false }
+ink_metadata = { version = "4.0.0-alpha.1", path = "../crates/metadata", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"] }
 


### PR DESCRIPTION
Two main reasons I want to get this out.

1. It's the beginning of some changes related to the metadata, and we need an ink!
   release in order to make `cargo-contract` releases which can understand this.
2. Green's storage PR is going to get merged soon, and I'd prefer if that was in a
   standalone release.
