### PR TITLE
Use `cargo-contract` `master` when building examples

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -355,7 +355,7 @@ examples-contract-build:
   <<:                              *test-refs
   script:
     - rustup component add rust-src --toolchain stable
-    - cargo install --git https://github.com/paritytech/cargo-contract.git --branch hc-versioned-metadata --force
+    - cargo install --git https://github.com/paritytech/cargo-contract.git --force
     - cargo contract -V
     - for example in examples/*/; do
         if [ "$example" = "examples/upgradeable-contracts/" ]; then continue; fi;


### PR DESCRIPTION
I was using a custom branch during development to appease the CI, but now that
https://github.com/paritytech/cargo-contract/pull/641 is merge we can move on to using
the `master` branch (until a new release for `cargo-contract` is cut).
