### PR TITLE
Only specify `path` for `dev-dependencies`

### DIFF
--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -26,8 +26,8 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 
 [dev-dependencies]
-ink_lang_ir = { version = "4.0.0-alpha.1", path = "ir" }
-ink_metadata = { version = "4.0.0-alpha.1", default-features = false, path = "../metadata" }
+ink_lang_ir = { path = "ir" }
+ink_metadata = { default-features = false, path = "../metadata" }
 
 trybuild = { version = "1.0.60", features = ["diff"] }
 # Required for the doctest of `env_access::EnvAccess::instantiate_contract`

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -26,8 +26,8 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 
 [dev-dependencies]
-ink_lang_ir = { path = "ir" }
-ink_metadata = { default-features = false, path = "../metadata" }
+ink_lang_ir = { path = "./ir" }
+ink_metadata = { path = "../metadata", default-features = false }
 
 trybuild = { version = "1.0.60", features = ["diff"] }
 # Required for the doctest of `env_access::EnvAccess::instantiate_contract`

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -24,10 +24,10 @@ syn = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-ink_metadata = { version = "4.0.0-alpha.1", path = "../../metadata/" }
-ink_env = { version = "4.0.0-alpha.1", path = "../../env/" }
-ink_storage = { version = "4.0.0-alpha.1", path = "../../storage/" }
-ink_lang = { version = "4.0.0-alpha.1", path = ".." }
+ink_metadata = { path = "../../metadata/" }
+ink_env = { path = "../../env/" }
+ink_storage = { path = "../../storage/" }
+ink_lang = { path = ".." }
 scale-info = { version = "2", default-features = false, features = ["derive"] }
 
 [lib]

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -24,10 +24,10 @@ syn = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-ink_metadata = { path = "../../metadata/" }
-ink_env = { path = "../../env/" }
-ink_storage = { path = "../../storage/" }
+ink_env = { path = "../../env" }
 ink_lang = { path = ".." }
+ink_metadata = { path = "../../metadata" }
+ink_storage = { path = "../../storage" }
 scale-info = { version = "2", default-features = false, features = ["derive"] }
 
 [lib]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -33,7 +33,7 @@ quickcheck_macros = "1.0"
 itertools = "0.10"
 paste = "1.0"
 
-ink_lang = { path = "../lang/", default-features = false }
+ink_lang = { path = "../lang", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -33,7 +33,7 @@ quickcheck_macros = "1.0"
 itertools = "0.10"
 paste = "1.0"
 
-ink_lang = { version = "4.0.0-alpha.1", path = "../lang/", default-features = false }
+ink_lang = { path = "../lang/", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/storage/derive/Cargo.toml
+++ b/crates/storage/derive/Cargo.toml
@@ -24,9 +24,9 @@ proc-macro2 = "1"
 synstructure = "0.12.4"
 
 [dev-dependencies]
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 ink_env = { path = "../../env" }
-ink_primitives = { path = "../../primitives" }
 ink_metadata = { path = "../../metadata" }
-ink_prelude = { path = "../../prelude/" }
+ink_prelude = { path = "../../prelude" }
+ink_primitives = { path = "../../primitives" }
 ink_storage = { path = ".." }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }

--- a/crates/storage/derive/Cargo.toml
+++ b/crates/storage/derive/Cargo.toml
@@ -25,8 +25,8 @@ synstructure = "0.12.4"
 
 [dev-dependencies]
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
-ink_env = { version = "4.0.0-alpha.1", path = "../../env" }
-ink_primitives = { version = "4.0.0-alpha.1", path = "../../primitives" }
-ink_metadata = { version = "4.0.0-alpha.1", path = "../../metadata" }
-ink_prelude = { version = "4.0.0-alpha.1", path = "../../prelude/" }
-ink_storage = { version = "4.0.0-alpha.1", path = ".." }
+ink_env = { path = "../../env" }
+ink_primitives = { path = "../../primitives" }
+ink_metadata = { path = "../../metadata" }
+ink_prelude = { path = "../../prelude/" }
+ink_storage = { path = ".." }

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -28,11 +28,11 @@ regex = "1.5.4"
 dylint_testing = "2.0.0"
 
 # The following are ink! dependencies, they are only required for the `ui` tests.
-ink_env = { version = "4.0.0-alpha.1", path = "../crates/env", default-features = false }
-ink_storage = { version = "4.0.0-alpha.1", path = "../crates/storage", default-features = false }
-ink_primitives = { version = "4.0.0-alpha.1", path = "../crates/primitives", default-features = false }
-ink_lang = { version = "4.0.0-alpha.1", path = "../crates/lang", default-features = false }
-ink_metadata = { version = "4.0.0-alpha.1", path = "../crates/metadata", default-features = false }
+ink_env = { path = "../crates/env", default-features = false }
+ink_storage = { path = "../crates/storage", default-features = false }
+ink_primitives = { path = "../crates/primitives", default-features = false }
+ink_lang = { path = "../crates/lang", default-features = false }
+ink_metadata = { path = "../crates/metadata", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"] }
 

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -29,10 +29,10 @@ dylint_testing = "2.0.0"
 
 # The following are ink! dependencies, they are only required for the `ui` tests.
 ink_env = { path = "../crates/env", default-features = false }
-ink_storage = { path = "../crates/storage", default-features = false }
-ink_primitives = { path = "../crates/primitives", default-features = false }
 ink_lang = { path = "../crates/lang", default-features = false }
 ink_metadata = { path = "../crates/metadata", default-features = false }
+ink_primitives = { path = "../crates/primitives", default-features = false }
+ink_storage = { path = "../crates/storage", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"] }
 


### PR DESCRIPTION
Looks like Cargo decides to either use a local or published package
depending on the context (i.e `path` vs. `version`). Since we never publish
`dev-dependencies` we can stick to always using a local version (`path`).

Cargo book reference:
- https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations
