### PR TITLE
remove single whitespace prefix from comments and docs

### DIFF
--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -14,7 +14,7 @@
 
 #![allow(clippy::new_ret_no_self)]
 
-use crate::serde_hex;
+use crate::{serde_hex, utils::trim_extra_whitespace};
 #[cfg(not(feature = "std"))]
 use alloc::{
     format,
@@ -367,7 +367,7 @@ impl<S, P> ConstructorSpecBuilder<S, P> {
     {
         let mut this = self;
         debug_assert!(this.spec.docs.is_empty());
-        this.spec.docs = docs.into_iter().map(str::trim).collect::<Vec<_>>();
+        this.spec.docs = docs.into_iter().map(trim_extra_whitespace).collect::<Vec<_>>();
         this
     }
 }
@@ -586,7 +586,7 @@ impl<S, M, P, R> MessageSpecBuilder<S, M, P, R> {
     {
         let mut this = self;
         debug_assert!(this.spec.docs.is_empty());
-        this.spec.docs = docs.into_iter().collect::<Vec<_>>();
+        this.spec.docs = docs.into_iter().map(trim_extra_whitespace).collect::<Vec<_>>();
         this
     }
 }

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -14,7 +14,10 @@
 
 #![allow(clippy::new_ret_no_self)]
 
-use crate::{serde_hex, utils::trim_extra_whitespace};
+use crate::{
+    serde_hex,
+    utils::trim_extra_whitespace,
+};
 #[cfg(not(feature = "std"))]
 use alloc::{
     format,
@@ -367,7 +370,10 @@ impl<S, P> ConstructorSpecBuilder<S, P> {
     {
         let mut this = self;
         debug_assert!(this.spec.docs.is_empty());
-        this.spec.docs = docs.into_iter().map(trim_extra_whitespace).collect::<Vec<_>>();
+        this.spec.docs = docs
+            .into_iter()
+            .map(trim_extra_whitespace)
+            .collect::<Vec<_>>();
         this
     }
 }
@@ -586,7 +592,10 @@ impl<S, M, P, R> MessageSpecBuilder<S, M, P, R> {
     {
         let mut this = self;
         debug_assert!(this.spec.docs.is_empty());
-        this.spec.docs = docs.into_iter().map(trim_extra_whitespace).collect::<Vec<_>>();
+        this.spec.docs = docs
+            .into_iter()
+            .map(trim_extra_whitespace)
+            .collect::<Vec<_>>();
         this
     }
 }

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -206,3 +206,48 @@ fn trim_docs() {
     );
     assert_eq!(deserialized.docs, compact_spec.docs);
 }
+
+#[test]
+fn trim_docs_with_code() {
+    // given
+    let label = "foo";
+    let cs = ConstructorSpec::from_label(label)
+        .selector(123_456_789u32.to_be_bytes())
+        .docs(vec![
+            " Example      ",
+            " ```",
+            " fn test() {",
+            "     \"Hello, World\"",
+            " }",
+            " ```",
+        ])
+        .payable(Default::default())
+        .done();
+    let mut registry = Registry::new();
+    let compact_spec = cs.into_portable(&mut registry);
+
+    // when
+    let json = serde_json::to_value(&compact_spec).unwrap();
+    let deserialized: ConstructorSpec<PortableForm> =
+        serde_json::from_value(json.clone()).unwrap();
+
+    // then
+    assert_eq!(
+        json,
+        json!({
+            "label": "foo",
+            "payable": false,
+            "selector": "0x075bcd15",
+            "args": [],
+            "docs": [
+                "Example",
+                "```",
+                "fn test() {",
+                "    \"Hello, World\"",
+                "}",
+                "```"
+            ]
+        })
+    );
+    assert_eq!(deserialized.docs, compact_spec.docs);
+}

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -176,6 +176,7 @@ fn spec_contract_json() {
     )
 }
 
+/// Tests correct trimming of a simple comment with extra spaces
 #[test]
 fn trim_docs() {
     // given
@@ -207,6 +208,7 @@ fn trim_docs() {
     assert_eq!(deserialized.docs, compact_spec.docs);
 }
 
+/// Tests correct trimming of a complex comment with a code snippet
 #[test]
 fn trim_docs_with_code() {
     // given

--- a/crates/metadata/src/utils.rs
+++ b/crates/metadata/src/utils.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::str;
 use crate::serde_hex;
 
 /// Serializes the given bytes as byte string.
@@ -55,4 +56,12 @@ where
     }
 
     deserializer.deserialize_str(Visitor)
+}
+
+pub fn trim_extra_whitespace(item: &'static str) -> &'static str {
+    if let Some(stripped) = item.strip_prefix(' ') {
+        stripped.trim_end()
+    } else {
+        item.trim_end()
+    }
 }

--- a/crates/metadata/src/utils.rs
+++ b/crates/metadata/src/utils.rs
@@ -58,6 +58,7 @@ where
     deserializer.deserialize_str(Visitor)
 }
 
+/// Strips a single whitespace at the start and removes trailing spaces
 pub fn trim_extra_whitespace(item: &str) -> &str {
     if let Some(stripped) = item.strip_prefix(' ') {
         stripped.trim_end()

--- a/crates/metadata/src/utils.rs
+++ b/crates/metadata/src/utils.rs
@@ -58,7 +58,7 @@ where
     deserializer.deserialize_str(Visitor)
 }
 
-pub fn trim_extra_whitespace(item: &'static str) -> &'static str {
+pub fn trim_extra_whitespace(item: &str) -> &str {
     if let Some(stripped) = item.strip_prefix(' ') {
         stripped.trim_end()
     } else {

--- a/crates/metadata/src/utils.rs
+++ b/crates/metadata/src/utils.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::str;
 use crate::serde_hex;
+use std::str;
 
 /// Serializes the given bytes as byte string.
 pub fn serialize_as_byte_str<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
Closes #613 

Only a single white space is removed which comes under the assumption that the user uses the standard cargo formatting style.

# Example of trimming
```json
...
"docs": [
  "# Flips the current value of the Flipper's boolean.",
  "Let's try to use some code",
  "```rust",
  "fn main() {",
  "    \"Hello, World!\"",
  "}",
  "```"
],
...
```