### PR TITLE
CI: Use stable for `clippy` and `cargo test`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -269,8 +269,8 @@ test:
       # at the same time, hence we use this workaround.
       QUICKCHECK_TESTS:            0
   script:
-    - cargo +nightly test --verbose --all-features --no-fail-fast --workspace
-    - cargo +nightly test --verbose --all-features --no-fail-fast --workspace --doc
+    - cargo test --verbose --all-features --no-fail-fast --workspace
+    - cargo test --verbose --all-features --no-fail-fast --workspace --doc
 
 docs:
   stage:                           workspace
@@ -326,7 +326,7 @@ codecov:
   script:
     # RUSTFLAGS are the cause target cache can't be used here
     - cargo build --verbose --all-features --workspace
-    - cargo +nightly test --verbose --all-features --no-fail-fast --workspace
+    - cargo test --verbose --all-features --no-fail-fast --workspace
     # coverage with branches
     - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm --branch
         --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,6 +39,11 @@ variables:
   # `cargo-contract`, but in our CI here we also use e.g.
   # `cargo check` directly.
   RUSTC_BOOTSTRAP:                 "1"
+  # TODO `cargo clippy --verbose --all-targets --all-features` for this crate
+  # currently fails on `stable`, but succeeds on `nightly`. This is due to
+  # this fix not yet in stable: https://github.com/rust-lang/rust-clippy/issues/8895.
+  # Remove the following line again as soon as `clippy` on stable succeeds again.
+  CLIPPY_ALLOWED:                  "clippy::extra_unused_lifetimes"
 
 workflow:
   rules:
@@ -138,7 +143,7 @@ clippy-std:
   <<:                              *test-refs
   script:
     - for crate in ${ALL_CRATES}; do
-        cargo +nightly clippy --verbose --all-targets --all-features --manifest-path ./crates/${crate}/Cargo.toml -- -D warnings;
+        cargo clippy --verbose --all-targets --all-features --manifest-path ./crates/${crate}/Cargo.toml -- -D warnings -A $CLIPPY_ALLOWED;
       done
 
 clippy-wasm:
@@ -147,7 +152,7 @@ clippy-wasm:
   <<:                              *test-refs
   script:
     - for crate in ${ALSO_WASM_CRATES}; do
-        cargo +nightly clippy --verbose --no-default-features --manifest-path ./crates/${crate}/Cargo.toml --target wasm32-unknown-unknown -- -D warnings;
+        cargo clippy --verbose --no-default-features --manifest-path ./crates/${crate}/Cargo.toml --target wasm32-unknown-unknown -- -D warnings -A $CLIPPY_ALLOWED;
       done
   allow_failure:                   true
 
@@ -158,15 +163,15 @@ examples-clippy-std:
   script:
     - for example in examples/*/; do
         if [ "$example" = "examples/upgradeable-contracts/" ]; then continue; fi;
-        cargo +nightly clippy --verbose --all-targets --manifest-path ${example}/Cargo.toml -- -D warnings;
+        cargo clippy --verbose --all-targets --manifest-path ${example}/Cargo.toml -- -D warnings -A $CLIPPY_ALLOWED;
       done
     - for contract in ${DELEGATOR_SUBCONTRACTS}; do
-        cargo +nightly clippy --verbose --all-targets --manifest-path ./examples/delegator/${contract}/Cargo.toml -- -D warnings;
+        cargo clippy --verbose --all-targets --manifest-path ./examples/delegator/${contract}/Cargo.toml -- -D warnings -A $CLIPPY_ALLOWED;
       done
     - for contract in ${UPGRADEABLE_CONTRACTS}; do
-        cargo +nightly clippy --verbose --all-targets --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml -- -D warnings;
+        cargo clippy --verbose --all-targets --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml -- -D warnings -A $CLIPPY_ALLOWED;
       done
-    - cargo +nightly clippy --verbose --all-targets --manifest-path ./examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml -- -D warnings;
+    - cargo clippy --verbose --all-targets --manifest-path ./examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml -- -D warnings -A $CLIPPY_ALLOWED;
   allow_failure:                   true
 
 examples-clippy-wasm:
@@ -176,15 +181,15 @@ examples-clippy-wasm:
   script:
     - for example in examples/*/; do
         if [ "$example" = "examples/upgradeable-contracts/" ]; then continue; fi;
-        cargo +nightly clippy --verbose --manifest-path ${example}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
+        cargo clippy --verbose --manifest-path ${example}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings -A $CLIPPY_ALLOWED;
       done
     - for contract in ${DELEGATOR_SUBCONTRACTS}; do
-        cargo +nightly clippy --verbose --manifest-path ./examples/delegator/${contract}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
+        cargo clippy --verbose --manifest-path ./examples/delegator/${contract}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings -A $CLIPPY_ALLOWED;
       done
     - for contract in ${UPGRADEABLE_CONTRACTS}; do
-        cargo +nightly clippy --verbose --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
+        cargo clippy --verbose --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings -A $CLIPPY_ALLOWED;
       done
-    - cargo +nightly clippy --verbose --manifest-path ./examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings;
+    - cargo clippy --verbose --manifest-path ./examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml --no-default-features --target wasm32-unknown-unknown -- -D warnings -A $CLIPPY_ALLOWED;
   allow_failure:                   true
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,11 @@ You can have a look at the [PR#1284](https://github.com/paritytech/ink/pull/1284
 
 Our [continuous integration (CI)](https://github.com/paritytech/ink/blob/master/.gitlab-ci.yml) will check for the following properties of all changes.
 
+*Note:* We use Rust `stable` together with `export RUSTC_BOOTSTRAP=1` in our CI.
+So you have to export this environment variable locally too!
+Setting it will enable nightly features in stable Rust. So it's definitely a hack,
+but we decided on it since using nightly in the CI came with a lot of maintenance burden.
+
 1. Is `rustfmt` happy with it ?
     - `cargo fmt --all`
 1. Is `clippy` happy with it?
@@ -104,13 +109,13 @@ Our [continuous integration (CI)](https://github.com/paritytech/ink/blob/master/
 1. Does the code still compile?
     - `cargo check --all-features`
 1. Do all the examples still compile?
-    - `cargo +nightly contract check --manifest-path ./examples/.../Cargo.toml`
+    - `cargo contract check --manifest-path ./examples/.../Cargo.toml`
 1. Is the `wasm-32` target still compiling?
     - `cargo check --no-default-features --target wasm32-unknown-unknown`
 1. Are all the tests passing?
     - `cargo test --all-features --workspace`
 1. Are all the tests for the examples passing?
-    - `cargo +nightly test --manifest-path ./examples/.../Cargo.toml`
+    - `cargo test --manifest-path ./examples/.../Cargo.toml`
 1. Is the test code coverage increasing or at least stable?
 1. Has the size of the example contract binaries changed?
 

--- a/crates/lang/tests/ui/contract/fail/constructor-input-non-codec.stderr
+++ b/crates/lang/tests/ui/contract/fail/constructor-input-non-codec.stderr
@@ -2,13 +2,14 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeDecode` is not satisfied
   --> tests/ui/contract/fail/constructor-input-non-codec.rs:13:28
    |
 13 |         pub fn constructor(_input: NonCodecType) -> Self {
-   |                            ^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `NonCodecType`
+   |                            ^^^^^^ the trait `WrapperTypeDecode` is not implemented for `NonCodecType`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
              Box<T>
              Rc<T>
-   = note: required for `NonCodecType` to implement `parity_scale_codec::Decode`
+             sp_core::Bytes
+   = note: required because of the requirements on the impl of `parity_scale_codec::Decode` for `NonCodecType`
 note: required by a bound in `DispatchInput`
   --> src/codegen/dispatch/type_check.rs
    |
@@ -18,27 +19,21 @@ note: required by a bound in `DispatchInput`
 error[E0277]: the trait bound `NonCodecType: WrapperTypeDecode` is not satisfied
   --> tests/ui/contract/fail/constructor-input-non-codec.rs:13:9
    |
-13 | /         pub fn constructor(_input: NonCodecType) -> Self {
-14 | |             Self {}
-15 | |         }
-   | |_________^ the trait `WrapperTypeDecode` is not implemented for `NonCodecType`
+13 |         pub fn constructor(_input: NonCodecType) -> Self {
+   |         ^^^ the trait `WrapperTypeDecode` is not implemented for `NonCodecType`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
              Box<T>
              Rc<T>
-   = note: required for `NonCodecType` to implement `parity_scale_codec::Decode`
+             sp_core::Bytes
+   = note: required because of the requirements on the impl of `parity_scale_codec::Decode` for `NonCodecType`
 
 error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
-  --> tests/ui/contract/fail/constructor-input-non-codec.rs:3:1
+  --> tests/ui/contract/fail/constructor-input-non-codec.rs:13:9
    |
-3  |   #[ink::contract]
-   |   ^^^^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NonCodecType`
-...
-13 | /         pub fn constructor(_input: NonCodecType) -> Self {
-14 | |             Self {}
-15 | |         }
-   | |_________- required by a bound introduced by this call
+13 |         pub fn constructor(_input: NonCodecType) -> Self {
+   |         ^^^ the trait `WrapperTypeEncode` is not implemented for `NonCodecType`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
@@ -49,8 +44,8 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
              Rc<T>
              String
              Vec<T>
-             parity_scale_codec::Ref<'a, T, U>
-   = note: required for `NonCodecType` to implement `Encode`
+           and 2 others
+   = note: required because of the requirements on the impl of `Encode` for `NonCodecType`
 note: required by a bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd>>::push_arg`
   --> $WORKSPACE/crates/env/src/call/execution_input.rs
    |

--- a/crates/lang/tests/ui/contract/fail/constructor-multiple-wildcard-selectors.stderr
+++ b/crates/lang/tests/ui/contract/fail/constructor-multiple-wildcard-selectors.stderr
@@ -1,15 +1,11 @@
 error: encountered ink! constructor with overlapping wildcard selectors
   --> tests/ui/contract/fail/constructor-multiple-wildcard-selectors.rs:15:9
    |
-15 | /         pub fn constructor2() -> Self {
-16 | |             Self {}
-17 | |         }
-   | |_________^
+15 |         pub fn constructor2() -> Self {
+   |         ^^^
 
 error: first ink! constructor with overlapping wildcard selector here
   --> tests/ui/contract/fail/constructor-multiple-wildcard-selectors.rs:10:9
    |
-10 | /         pub fn constructor1() -> Self {
-11 | |             Self {}
-12 | |         }
-   | |_________^
+10 |         pub fn constructor1() -> Self {
+   |         ^^^

--- a/crates/lang/tests/ui/contract/fail/constructor-selector-and-wildcard-selector.stderr
+++ b/crates/lang/tests/ui/contract/fail/constructor-selector-and-wildcard-selector.stderr
@@ -2,10 +2,10 @@ error: encountered ink! attribute arguments with equal kinds
  --> tests/ui/contract/fail/constructor-selector-and-wildcard-selector.rs:9:51
   |
 9 |         #[ink(constructor, selector = 0xCAFEBABA, selector = _)]
-  |                                                   ^^^^^^^^^^^^
+  |                                                   ^^^^^^^^
 
 error: first equal ink! attribute argument with equal kind here
  --> tests/ui/contract/fail/constructor-selector-and-wildcard-selector.rs:9:28
   |
 9 |         #[ink(constructor, selector = 0xCAFEBABA, selector = _)]
-  |                            ^^^^^^^^^^^^^^^^^^^^^
+  |                            ^^^^^^^^

--- a/crates/lang/tests/ui/contract/fail/constructor-self-receiver-03.stderr
+++ b/crates/lang/tests/ui/contract/fail/constructor-self-receiver-03.stderr
@@ -1,14 +1,8 @@
-error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> tests/ui/contract/fail/constructor-self-receiver-03.rs:10:34
-   |
-10 |         pub fn constructor(this: &Self) -> Self {
-   |                                  ^ explicit lifetime name needed here
-
 error[E0411]: cannot find type `Self` in this scope
   --> tests/ui/contract/fail/constructor-self-receiver-03.rs:10:35
    |
 6  |     pub struct Contract {}
-   |     ---------------------- `Self` not allowed in a constant item
+   |     --- `Self` not allowed in a constant item
 ...
 10 |         pub fn constructor(this: &Self) -> Self {
    |                                   ^^^^ `Self` is only available in impls, traits, and type definitions
@@ -22,16 +16,13 @@ error[E0411]: cannot find type `Self` in this scope
 10 |         pub fn constructor(this: &Self) -> Self {
    |                                   ^^^^ `Self` is only available in impls, traits, and type definitions
 
-error[E0277]: the trait bound `&'static Contract: WrapperTypeDecode` is not satisfied
-  --> tests/ui/contract/fail/constructor-self-receiver-03.rs:10:9
+error[E0106]: missing lifetime specifier
+  --> tests/ui/contract/fail/constructor-self-receiver-03.rs:10:34
    |
-10 | /         pub fn constructor(this: &Self) -> Self {
-11 | |             Self {}
-12 | |         }
-   | |_________^ the trait `WrapperTypeDecode` is not implemented for `&'static Contract`
+10 |         pub fn constructor(this: &Self) -> Self {
+   |                                  ^ expected named lifetime parameter
    |
-   = help: the following other types implement trait `WrapperTypeDecode`:
-             Arc<T>
-             Box<T>
-             Rc<T>
-   = note: required for `&'static Contract` to implement `parity_scale_codec::Decode`
+help: consider introducing a named lifetime parameter
+   |
+10 |         pub<'a> fn constructor(this: &'a Self) -> Self {
+   |            ++++                       ++

--- a/crates/lang/tests/ui/contract/fail/event-too-many-topics-anonymous.stderr
+++ b/crates/lang/tests/ui/contract/fail/event-too-many-topics-anonymous.stderr
@@ -1,24 +1,18 @@
-error[E0277]: the trait bound `EventTopics<4>: RespectTopicLimit<2>` is not satisfied
+error[E0277]: the trait bound `EventTopics<4_usize>: RespectTopicLimit<2_usize>` is not satisfied
   --> tests/ui/contract/fail/event-too-many-topics-anonymous.rs:26:5
    |
-26 | /     pub struct Event {
-27 | |         #[ink(topic)]
-28 | |         arg_1: i8,
-29 | |         #[ink(topic)]
-...  |
-34 | |         arg_4: i32,
-35 | |     }
-   | |_____^ the trait `RespectTopicLimit<2>` is not implemented for `EventTopics<4>`
+26 |     pub struct Event {
+   |     ^^^ the trait `RespectTopicLimit<2_usize>` is not implemented for `EventTopics<4_usize>`
    |
    = help: the following other types implement trait `RespectTopicLimit<N>`:
-             <EventTopics<0> as RespectTopicLimit<0>>
-             <EventTopics<0> as RespectTopicLimit<10>>
-             <EventTopics<0> as RespectTopicLimit<11>>
-             <EventTopics<0> as RespectTopicLimit<12>>
-             <EventTopics<0> as RespectTopicLimit<1>>
-             <EventTopics<0> as RespectTopicLimit<2>>
-             <EventTopics<0> as RespectTopicLimit<3>>
-             <EventTopics<0> as RespectTopicLimit<4>>
+             <EventTopics<0_usize> as RespectTopicLimit<0_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<10_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<11_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<12_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<1_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<2_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<3_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<4_usize>>
            and 83 others
 note: required by a bound in `EventRespectsTopicLimit`
   --> src/codegen/event/topics.rs

--- a/crates/lang/tests/ui/contract/fail/event-too-many-topics.stderr
+++ b/crates/lang/tests/ui/contract/fail/event-too-many-topics.stderr
@@ -1,24 +1,18 @@
-error[E0277]: the trait bound `EventTopics<3>: RespectTopicLimit<2>` is not satisfied
+error[E0277]: the trait bound `EventTopics<3_usize>: RespectTopicLimit<2_usize>` is not satisfied
   --> tests/ui/contract/fail/event-too-many-topics.rs:26:5
    |
-26 | /     pub struct Event {
-27 | |         #[ink(topic)]
-28 | |         arg_1: i8,
-29 | |         #[ink(topic)]
-...  |
-32 | |         arg_3: i32,
-33 | |     }
-   | |_____^ the trait `RespectTopicLimit<2>` is not implemented for `EventTopics<3>`
+26 |     pub struct Event {
+   |     ^^^ the trait `RespectTopicLimit<2_usize>` is not implemented for `EventTopics<3_usize>`
    |
    = help: the following other types implement trait `RespectTopicLimit<N>`:
-             <EventTopics<0> as RespectTopicLimit<0>>
-             <EventTopics<0> as RespectTopicLimit<10>>
-             <EventTopics<0> as RespectTopicLimit<11>>
-             <EventTopics<0> as RespectTopicLimit<12>>
-             <EventTopics<0> as RespectTopicLimit<1>>
-             <EventTopics<0> as RespectTopicLimit<2>>
-             <EventTopics<0> as RespectTopicLimit<3>>
-             <EventTopics<0> as RespectTopicLimit<4>>
+             <EventTopics<0_usize> as RespectTopicLimit<0_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<10_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<11_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<12_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<1_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<2_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<3_usize>>
+             <EventTopics<0_usize> as RespectTopicLimit<4_usize>>
            and 83 others
 note: required by a bound in `EventRespectsTopicLimit`
   --> src/codegen/event/topics.rs

--- a/crates/lang/tests/ui/contract/fail/impl-block-for-non-storage-01.stderr
+++ b/crates/lang/tests/ui/contract/fail/impl-block-for-non-storage-01.stderr
@@ -11,7 +11,7 @@ error[E0599]: no function or associated item named `constructor_2` found for str
   --> tests/ui/contract/fail/impl-block-for-non-storage-01.rs:22:16
    |
 6  |     pub struct Contract {}
-   |     ------------------- function or associated item `constructor_2` not found for this struct
+   |     --- function or associated item `constructor_2` not found for this
 ...
 22 |         pub fn constructor_2() -> Self {
    |                ^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ error[E0599]: no function or associated item named `message_2` found for struct 
   --> tests/ui/contract/fail/impl-block-for-non-storage-01.rs:27:16
    |
 6  |     pub struct Contract {}
-   |     ------------------- function or associated item `message_2` not found for this struct
+   |     --- function or associated item `message_2` not found for this
 ...
 27 |         pub fn message_2(&self) {}
    |                ^^^^^^^^^

--- a/crates/lang/tests/ui/contract/fail/impl-block-namespace-invalid-type.stderr
+++ b/crates/lang/tests/ui/contract/fail/impl-block-namespace-invalid-type.stderr
@@ -2,4 +2,4 @@ error: expected string type for `namespace` argument, e.g. #[ink(namespace = "he
  --> tests/ui/contract/fail/impl-block-namespace-invalid-type.rs:8:11
   |
 8 |     #[ink(namespace = true)]
-  |           ^^^^^^^^^^^^^^^^
+  |           ^^^^^^^^^

--- a/crates/lang/tests/ui/contract/fail/impl-block-using-static-env-no-marker.stderr
+++ b/crates/lang/tests/ui/contract/fail/impl-block-using-static-env-no-marker.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `env` found for struct `Contr
   --> tests/ui/contract/fail/impl-block-using-static-env-no-marker.rs:22:27
    |
 6  |     pub struct Contract {}
-   |     ------------------- function or associated item `env` not found for this struct
+   |     --- function or associated item `env` not found for this
 ...
 22 |             let _ = Self::env().caller();
    |                           ^^^ function or associated item not found in `Contract`

--- a/crates/lang/tests/ui/contract/fail/message-input-non-codec.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-input-non-codec.stderr
@@ -2,13 +2,14 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeDecode` is not satisfied
   --> tests/ui/contract/fail/message-input-non-codec.rs:18:31
    |
 18 |         pub fn message(&self, _input: NonCodecType) {}
-   |                               ^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `NonCodecType`
+   |                               ^^^^^^ the trait `WrapperTypeDecode` is not implemented for `NonCodecType`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
              Box<T>
              Rc<T>
-   = note: required for `NonCodecType` to implement `parity_scale_codec::Decode`
+             sp_core::Bytes
+   = note: required because of the requirements on the impl of `parity_scale_codec::Decode` for `NonCodecType`
 note: required by a bound in `DispatchInput`
   --> src/codegen/dispatch/type_check.rs
    |
@@ -19,22 +20,20 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeDecode` is not satisfied
   --> tests/ui/contract/fail/message-input-non-codec.rs:18:9
    |
 18 |         pub fn message(&self, _input: NonCodecType) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `NonCodecType`
+   |         ^^^ the trait `WrapperTypeDecode` is not implemented for `NonCodecType`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
              Box<T>
              Rc<T>
-   = note: required for `NonCodecType` to implement `parity_scale_codec::Decode`
+             sp_core::Bytes
+   = note: required because of the requirements on the impl of `parity_scale_codec::Decode` for `NonCodecType`
 
 error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
-  --> tests/ui/contract/fail/message-input-non-codec.rs:3:1
+  --> tests/ui/contract/fail/message-input-non-codec.rs:18:9
    |
-3  | #[ink::contract]
-   | ^^^^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NonCodecType`
-...
 18 |         pub fn message(&self, _input: NonCodecType) {}
-   |         ---------------------------------------------- required by a bound introduced by this call
+   |         ^^^ the trait `WrapperTypeEncode` is not implemented for `NonCodecType`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
@@ -45,8 +44,8 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
              Rc<T>
              String
              Vec<T>
-             parity_scale_codec::Ref<'a, T, U>
-   = note: required for `NonCodecType` to implement `Encode`
+           and 2 others
+   = note: required because of the requirements on the impl of `Encode` for `NonCodecType`
 note: required by a bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd>>::push_arg`
   --> $WORKSPACE/crates/env/src/call/execution_input.rs
    |
@@ -57,7 +56,7 @@ error[E0599]: the method `fire` exists for struct `ink_env::call::CallBuilder<De
   --> tests/ui/contract/fail/message-input-non-codec.rs:18:9
    |
 18 |         pub fn message(&self, _input: NonCodecType) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `ink_env::call::CallBuilder<DefaultEnvironment, Set<Call<DefaultEnvironment>>, Set<ExecutionInput<ArgumentList<ink_env::call::utils::Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>>>, Set<ReturnType<()>>>` due to unsatisfied trait bounds
+   |         ^^^ method cannot be called on `ink_env::call::CallBuilder<DefaultEnvironment, Set<Call<DefaultEnvironment>>, Set<ExecutionInput<ArgumentList<ink_env::call::utils::Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>>>, Set<ReturnType<()>>>` due to unsatisfied trait bounds
    |
   ::: $WORKSPACE/crates/env/src/call/execution_input.rs
    |

--- a/crates/lang/tests/ui/contract/fail/message-multiple-wildcard-selectors.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-multiple-wildcard-selectors.stderr
@@ -2,10 +2,10 @@ error: encountered ink! messages with overlapping wildcard selectors
   --> tests/ui/contract/fail/message-multiple-wildcard-selectors.rs:18:9
    |
 18 |         pub fn message2(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^
 
 error: first ink! message with overlapping wildcard selector here
   --> tests/ui/contract/fail/message-multiple-wildcard-selectors.rs:15:9
    |
 15 |         pub fn message1(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         ^^^

--- a/crates/lang/tests/ui/contract/fail/message-returns-non-codec.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-returns-non-codec.stderr
@@ -13,8 +13,8 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
              Rc<T>
              String
              Vec<T>
-             parity_scale_codec::Ref<'a, T, U>
-   = note: required for `NonCodecType` to implement `Encode`
+           and 2 others
+   = note: required because of the requirements on the impl of `Encode` for `NonCodecType`
 note: required by a bound in `DispatchOutput`
   --> src/codegen/dispatch/type_check.rs
    |
@@ -24,10 +24,8 @@ note: required by a bound in `DispatchOutput`
 error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
    --> tests/ui/contract/fail/message-returns-non-codec.rs:18:9
     |
-18  | /         pub fn message(&self) -> NonCodecType {
-19  | |             NonCodecType
-20  | |         }
-    | |_________^ the trait `WrapperTypeEncode` is not implemented for `NonCodecType`
+18  |         pub fn message(&self) -> NonCodecType {
+    |         ^^^ the trait `WrapperTypeEncode` is not implemented for `NonCodecType`
     |
     = help: the following other types implement trait `WrapperTypeEncode`:
               &T
@@ -38,8 +36,8 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
               Rc<T>
               String
               Vec<T>
-              parity_scale_codec::Ref<'a, T, U>
-    = note: required for `NonCodecType` to implement `Encode`
+            and 2 others
+    = note: required because of the requirements on the impl of `Encode` for `NonCodecType`
 note: required by a bound in `return_value`
    --> $WORKSPACE/crates/env/src/api.rs
     |
@@ -49,18 +47,22 @@ note: required by a bound in `return_value`
 error[E0599]: the method `fire` exists for struct `ink_env::call::CallBuilder<DefaultEnvironment, Set<Call<DefaultEnvironment>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodecType>>>`, but its trait bounds were not satisfied
    --> tests/ui/contract/fail/message-returns-non-codec.rs:18:9
     |
-6   |       pub struct NonCodecType;
-    |       ----------------------- doesn't satisfy `NonCodecType: parity_scale_codec::Decode`
+6   |     pub struct NonCodecType;
+    |     ------------------------ doesn't satisfy `NonCodecType: parity_scale_codec::Decode`
 ...
-18  | /         pub fn message(&self) -> NonCodecType {
-19  | |             NonCodecType
-20  | |         }
-    | |_________^ method cannot be called on `ink_env::call::CallBuilder<DefaultEnvironment, Set<Call<DefaultEnvironment>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodecType>>>` due to unsatisfied trait bounds
+18  |         pub fn message(&self) -> NonCodecType {
+    |         ^^^ method cannot be called on `ink_env::call::CallBuilder<DefaultEnvironment, Set<Call<DefaultEnvironment>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodecType>>>` due to unsatisfied trait bounds
     |
     = note: the following trait bounds were not satisfied:
             `NonCodecType: parity_scale_codec::Decode`
 note: the following trait must be implemented
    --> $CARGO/parity-scale-codec-3.1.5/src/codec.rs
     |
-    | pub trait Decode: Sized {
-    | ^^^^^^^^^^^^^^^^^^^^^^^
+    | / pub trait Decode: Sized {
+    | |     // !INTERNAL USE ONLY!
+    | |     // This const helps SCALE to optimize the encoding/decoding by doing fake specialization.
+    | |     #[doc(hidden)]
+...   |
+    | |     }
+    | | }
+    | |_^

--- a/crates/lang/tests/ui/contract/fail/message-selector-and-wildcard-selector.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-selector-and-wildcard-selector.stderr
@@ -2,10 +2,10 @@ error: encountered ink! attribute arguments with equal kinds
   --> tests/ui/contract/fail/message-selector-and-wildcard-selector.rs:14:47
    |
 14 |         #[ink(message, selector = 0xCAFEBABA, selector = _)]
-   |                                               ^^^^^^^^^^^^
+   |                                               ^^^^^^^^
 
 error: first equal ink! attribute argument with equal kind here
   --> tests/ui/contract/fail/message-selector-and-wildcard-selector.rs:14:24
    |
 14 |         #[ink(message, selector = 0xCAFEBABA, selector = _)]
-   |                        ^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^

--- a/crates/lang/tests/ui/contract/fail/message-selector-invalid-type-01.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-selector-invalid-type-01.stderr
@@ -2,4 +2,4 @@ error: #[ink(selector = ..)] attributes with string inputs are deprecated. use a
   --> tests/ui/contract/fail/message-selector-invalid-type-01.rs:14:24
    |
 14 |         #[ink(message, selector = "0xC0DECAFE")]
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^

--- a/crates/lang/tests/ui/contract/fail/message-selector-invalid-type-02.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-selector-invalid-type-02.stderr
@@ -2,4 +2,4 @@ error: expected 4-digit hexcode for `selector` argument, e.g. #[ink(selector = 0
   --> tests/ui/contract/fail/message-selector-invalid-type-02.rs:14:24
    |
 14 |         #[ink(message, selector = true)]
-   |                        ^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^

--- a/crates/lang/tests/ui/contract/fail/message-self-receiver-invalid-01.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-self-receiver-invalid-01.stderr
@@ -2,4 +2,4 @@ error: ink! messages must have `&self` or `&mut self` receiver
   --> tests/ui/contract/fail/message-self-receiver-invalid-01.rs:15:24
    |
 15 |         pub fn message(this: &Self) {}
-   |                        ^^^^^^^^^^^
+   |                        ^^^^

--- a/crates/lang/tests/ui/contract/fail/message-self-receiver-invalid-02.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-self-receiver-invalid-02.stderr
@@ -2,4 +2,4 @@ error: ink! messages must have `&self` or `&mut self` receiver
   --> tests/ui/contract/fail/message-self-receiver-invalid-02.rs:15:24
    |
 15 |         pub fn message(this: &mut Self) {}
-   |                        ^^^^^^^^^^^^^^^
+   |                        ^^^^

--- a/crates/lang/tests/ui/contract/fail/message-self-receiver-missing.stderr
+++ b/crates/lang/tests/ui/contract/fail/message-self-receiver-missing.stderr
@@ -1,6 +1,5 @@
 error: ink! messages must have `&self` or `&mut self` receiver
   --> tests/ui/contract/fail/message-self-receiver-missing.rs:14:9
    |
-14 | /         #[ink(message)]
-15 | |         pub fn message() {}
-   | |___________________________^
+14 |         #[ink(message)]
+   |         ^

--- a/crates/lang/tests/ui/contract/fail/module-missing-constructor.stderr
+++ b/crates/lang/tests/ui/contract/fail/module-missing-constructor.stderr
@@ -1,11 +1,5 @@
 error: missing ink! constructor
-  --> tests/ui/contract/fail/module-missing-constructor.rs:4:1
-   |
-4  | / mod contract {
-5  | |     #[ink(storage)]
-6  | |     pub struct Contract {}
-7  | |
-...  |
-11 | |     }
-12 | | }
-   | |_^
+ --> tests/ui/contract/fail/module-missing-constructor.rs:4:1
+  |
+4 | mod contract {
+  | ^^^

--- a/crates/lang/tests/ui/contract/fail/module-missing-message.stderr
+++ b/crates/lang/tests/ui/contract/fail/module-missing-message.stderr
@@ -1,11 +1,5 @@
 error: missing ink! message
-  --> tests/ui/contract/fail/module-missing-message.rs:4:1
-   |
-4  | / mod contract {
-5  | |     #[ink(storage)]
-6  | |     pub struct Contract {}
-7  | |
-...  |
-13 | |     }
-14 | | }
-   | |_^
+ --> tests/ui/contract/fail/module-missing-message.rs:4:1
+  |
+4 | mod contract {
+  | ^^^

--- a/crates/lang/tests/ui/contract/fail/module-missing-storage.stderr
+++ b/crates/lang/tests/ui/contract/fail/module-missing-storage.stderr
@@ -1,11 +1,5 @@
 error: missing ink! storage struct
-  --> tests/ui/contract/fail/module-missing-storage.rs:4:1
-   |
-4  | / mod contract {
-5  | |     // #[ink(storage)]
-6  | |     pub struct Contract {}
-7  | |
-...  |
-14 | |     }
-15 | | }
-   | |_^
+ --> tests/ui/contract/fail/module-missing-storage.rs:4:1
+  |
+4 | mod contract {
+  | ^^^

--- a/crates/lang/tests/ui/contract/fail/module-multiple-storages.stderr
+++ b/crates/lang/tests/ui/contract/fail/module-multiple-storages.stderr
@@ -1,23 +1,17 @@
 error: encountered multiple ink! storage structs, expected exactly one
-  --> tests/ui/contract/fail/module-multiple-storages.rs:4:1
-   |
-4  | / mod contract {
-5  | |     #[ink(storage)]
-6  | |     pub struct Contract {}
-7  | |
-...  |
-29 | |     }
-30 | | }
-   | |_^
+ --> tests/ui/contract/fail/module-multiple-storages.rs:4:1
+  |
+4 | mod contract {
+  | ^^^
 
 error: ink! storage struct here
  --> tests/ui/contract/fail/module-multiple-storages.rs:6:5
   |
 6 |     pub struct Contract {}
-  |     ^^^^^^^^^^^^^^^^^^^^^^
+  |     ^^^
 
 error: ink! storage struct here
   --> tests/ui/contract/fail/module-multiple-storages.rs:19:5
    |
 19 |     pub struct Contract2 {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^

--- a/crates/lang/tests/ui/contract/fail/trait-impl-namespace-invalid.stderr
+++ b/crates/lang/tests/ui/contract/fail/trait-impl-namespace-invalid.stderr
@@ -1,9 +1,5 @@
 error: namespace ink! property is not allowed on ink! trait implementation blocks
   --> tests/ui/contract/fail/trait-impl-namespace-invalid.rs:23:5
    |
-23 | /     #[ink(namespace = "namespace")]
-24 | |     impl TraitDefinition for Contract {
-25 | |         #[ink(message)]
-26 | |         fn message(&self) {}
-27 | |     }
-   | |_____^
+23 |     #[ink(namespace = "namespace")]
+   |     ^

--- a/crates/lang/tests/ui/contract/fail/trait-message-payable-mismatch.stderr
+++ b/crates/lang/tests/ui/contract/fail/trait-message-payable-mismatch.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> tests/ui/contract/fail/trait-message-payable-mismatch.rs:25:9
    |
 25 |         fn message(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^ expected `false`, found `true`
+   |         ^^ expected `false`, found `true`
    |
    = note: expected struct `TraitMessagePayable<false>`
               found struct `TraitMessagePayable<true>`

--- a/crates/lang/tests/ui/contract/fail/trait-message-selector-mismatch.stderr
+++ b/crates/lang/tests/ui/contract/fail/trait-message-selector-mismatch.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> tests/ui/contract/fail/trait-message-selector-mismatch.rs:25:9
    |
 25 |         fn message(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^ expected `1`, found `2`
+   |         ^^ expected `1_u32`, found `2_u32`
    |
-   = note: expected struct `TraitMessageSelector<1>`
-              found struct `TraitMessageSelector<2>`
+   = note: expected struct `TraitMessageSelector<1_u32>`
+              found struct `TraitMessageSelector<2_u32>`

--- a/crates/lang/tests/ui/contract/fail/trait-message-selector-overlap-1.stderr
+++ b/crates/lang/tests/ui/contract/fail/trait-message-selector-overlap-1.stderr
@@ -1,23 +1,17 @@
-error[E0119]: conflicting implementations of trait `ink_lang::reflect::DispatchableMessageInfo<1083895717>` for type `contract::Contract`
+error[E0119]: conflicting implementations of trait `ink_lang::reflect::DispatchableMessageInfo<1083895717_u32>` for type `contract::Contract`
   --> tests/ui/contract/fail/trait-message-selector-overlap-1.rs:47:9
    |
 42 |         fn message(&self) {}
-   |         -------------------- first implementation here
+   |         -- first implementation here
 ...
 47 |         fn message(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `contract::Contract`
+   |         ^^ conflicting implementation for `contract::Contract`
 
-error[E0119]: conflicting implementations of trait `ink_lang::codegen::TraitCallForwarderFor<1083895717>` for type `contract::_::CallBuilder`
+error[E0119]: conflicting implementations of trait `ink_lang::codegen::TraitCallForwarderFor<1083895717_u32>` for type `contract::_::CallBuilder`
   --> tests/ui/contract/fail/trait-message-selector-overlap-1.rs:45:5
    |
-40 | /     impl TraitDefinition1 for Contract {
-41 | |         #[ink(message)]
-42 | |         fn message(&self) {}
-43 | |     }
-   | |_____- first implementation here
-44 |
-45 | /     impl TraitDefinition2 for Contract {
-46 | |         #[ink(message)]
-47 | |         fn message(&self) {}
-48 | |     }
-   | |_____^ conflicting implementation for `contract::_::CallBuilder`
+40 |     impl TraitDefinition1 for Contract {
+   |     ---- first implementation here
+...
+45 |     impl TraitDefinition2 for Contract {
+   |     ^^^^ conflicting implementation for `contract::_::CallBuilder`

--- a/crates/lang/tests/ui/contract/fail/trait-message-selector-overlap-2.stderr
+++ b/crates/lang/tests/ui/contract/fail/trait-message-selector-overlap-2.stderr
@@ -1,23 +1,17 @@
-error[E0119]: conflicting implementations of trait `ink_lang::reflect::DispatchableMessageInfo<1518209067>` for type `contract::Contract`
+error[E0119]: conflicting implementations of trait `ink_lang::reflect::DispatchableMessageInfo<1518209067_u32>` for type `contract::Contract`
   --> tests/ui/contract/fail/trait-message-selector-overlap-2.rs:47:9
    |
 42 |         fn message(&self) {}
-   |         -------------------- first implementation here
+   |         -- first implementation here
 ...
 47 |         fn message(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `contract::Contract`
+   |         ^^ conflicting implementation for `contract::Contract`
 
-error[E0119]: conflicting implementations of trait `ink_lang::codegen::TraitCallForwarderFor<1518209067>` for type `contract::_::CallBuilder`
+error[E0119]: conflicting implementations of trait `ink_lang::codegen::TraitCallForwarderFor<1518209067_u32>` for type `contract::_::CallBuilder`
   --> tests/ui/contract/fail/trait-message-selector-overlap-2.rs:45:5
    |
-40 | /     impl TraitDefinition1 for Contract {
-41 | |         #[ink(message)]
-42 | |         fn message(&self) {}
-43 | |     }
-   | |_____- first implementation here
-44 |
-45 | /     impl TraitDefinition2 for Contract {
-46 | |         #[ink(message)]
-47 | |         fn message(&self) {}
-48 | |     }
-   | |_____^ conflicting implementation for `contract::_::CallBuilder`
+40 |     impl TraitDefinition1 for Contract {
+   |     ---- first implementation here
+...
+45 |     impl TraitDefinition2 for Contract {
+   |     ^^^^ conflicting implementation for `contract::_::CallBuilder`

--- a/crates/lang/tests/ui/contract/fail/trait-message-selector-overlap-3.stderr
+++ b/crates/lang/tests/ui/contract/fail/trait-message-selector-overlap-3.stderr
@@ -1,23 +1,17 @@
-error[E0119]: conflicting implementations of trait `ink_lang::reflect::DispatchableMessageInfo<42>` for type `contract::Contract`
+error[E0119]: conflicting implementations of trait `ink_lang::reflect::DispatchableMessageInfo<42_u32>` for type `contract::Contract`
   --> tests/ui/contract/fail/trait-message-selector-overlap-3.rs:47:9
    |
 42 |         fn message1(&self) {}
-   |         --------------------- first implementation here
+   |         -- first implementation here
 ...
 47 |         fn message2(&self) {}
-   |         ^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `contract::Contract`
+   |         ^^ conflicting implementation for `contract::Contract`
 
-error[E0119]: conflicting implementations of trait `ink_lang::codegen::TraitCallForwarderFor<42>` for type `contract::_::CallBuilder`
+error[E0119]: conflicting implementations of trait `ink_lang::codegen::TraitCallForwarderFor<42_u32>` for type `contract::_::CallBuilder`
   --> tests/ui/contract/fail/trait-message-selector-overlap-3.rs:45:5
    |
-40 | /     impl TraitDefinition1 for Contract {
-41 | |         #[ink(message)]
-42 | |         fn message1(&self) {}
-43 | |     }
-   | |_____- first implementation here
-44 |
-45 | /     impl TraitDefinition2 for Contract {
-46 | |         #[ink(message)]
-47 | |         fn message2(&self) {}
-48 | |     }
-   | |_____^ conflicting implementation for `contract::_::CallBuilder`
+40 |     impl TraitDefinition1 for Contract {
+   |     ---- first implementation here
+...
+45 |     impl TraitDefinition2 for Contract {
+   |     ^^^^ conflicting implementation for `contract::_::CallBuilder`

--- a/crates/lang/tests/ui/contract/fail/trait-message-wildcard-selector.stderr
+++ b/crates/lang/tests/ui/contract/fail/trait-message-wildcard-selector.stderr
@@ -2,13 +2,13 @@ error: encountered conflicting ink! attribute argument
  --> tests/ui/contract/fail/trait-message-wildcard-selector.rs:6:24
   |
 6 |         #[ink(message, selector = _)]
-  |                        ^^^^^^^^^^^^
+  |                        ^^^^^^^^
 
 error: wildcard selectors are only supported for inherent ink! messages or constructors, not for traits.
  --> tests/ui/contract/fail/trait-message-wildcard-selector.rs:6:24
   |
 6 |         #[ink(message, selector = _)]
-  |                        ^^^^^^^^^^^^
+  |                        ^^^^^^^^
 
 error[E0432]: unresolved import `super::foo::TraitDefinition`
   --> tests/ui/contract/fail/trait-message-wildcard-selector.rs:15:9

--- a/crates/lang/tests/ui/storage_item/fail/collections_only_packed_1.stderr
+++ b/crates/lang/tests/ui/storage_item/fail/collections_only_packed_1.stderr
@@ -2,26 +2,26 @@ error[E0277]: the trait bound `Vec<NonPacked>: Decode` is not satisfied
   --> tests/ui/storage_item/fail/collections_only_packed_1.rs:11:8
    |
 11 |     a: Vec<NonPacked>,
-   |        ^^^^^^^^^^^^^^ the trait `Decode` is not implemented for `Vec<NonPacked>`
+   |        ^^^ the trait `Decode` is not implemented for `Vec<NonPacked>`
    |
    = help: the trait `Decode` is implemented for `Vec<T>`
-   = note: required for `Vec<NonPacked>` to implement `Packed`
-   = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
-   = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+   = note: required because of the requirements on the impl of `Packed` for `Vec<NonPacked>`
+   = note: required because of the requirements on the impl of `StorableHint<()>` for `Vec<NonPacked>`
+   = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `Vec<NonPacked>`
 
 error[E0277]: the trait bound `[NonPacked]: Encode` is not satisfied
   --> tests/ui/storage_item/fail/collections_only_packed_1.rs:11:8
    |
 11 |     a: Vec<NonPacked>,
-   |        ^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `[NonPacked]`
+   |        ^^^ the trait `Encode` is not implemented for `[NonPacked]`
    |
    = help: the following other types implement trait `Encode`:
              [T; N]
              [T]
-   = note: required for `Vec<NonPacked>` to implement `Encode`
-   = note: required for `Vec<NonPacked>` to implement `Packed`
-   = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
-   = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+   = note: required because of the requirements on the impl of `Encode` for `Vec<NonPacked>`
+   = note: required because of the requirements on the impl of `Packed` for `Vec<NonPacked>`
+   = note: required because of the requirements on the impl of `StorableHint<()>` for `Vec<NonPacked>`
+   = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `Vec<NonPacked>`
 
 error[E0277]: the trait bound `Vec<NonPacked>: Decode` is not satisfied
   --> tests/ui/storage_item/fail/collections_only_packed_1.rs:9:1
@@ -30,9 +30,9 @@ error[E0277]: the trait bound `Vec<NonPacked>: Decode` is not satisfied
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Decode` is not implemented for `Vec<NonPacked>`
    |
    = help: the trait `Decode` is implemented for `Vec<T>`
-   = note: required for `Vec<NonPacked>` to implement `Packed`
-   = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
-   = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+   = note: required because of the requirements on the impl of `Packed` for `Vec<NonPacked>`
+   = note: required because of the requirements on the impl of `StorableHint<()>` for `Vec<NonPacked>`
+   = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `Vec<NonPacked>`
 note: required because it appears within the type `Contract`
   --> tests/ui/storage_item/fail/collections_only_packed_1.rs:10:8
    |
@@ -54,10 +54,10 @@ error[E0277]: the trait bound `[NonPacked]: Encode` is not satisfied
    = help: the following other types implement trait `Encode`:
              [T; N]
              [T]
-   = note: required for `Vec<NonPacked>` to implement `Encode`
-   = note: required for `Vec<NonPacked>` to implement `Packed`
-   = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
-   = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+   = note: required because of the requirements on the impl of `Encode` for `Vec<NonPacked>`
+   = note: required because of the requirements on the impl of `Packed` for `Vec<NonPacked>`
+   = note: required because of the requirements on the impl of `StorableHint<()>` for `Vec<NonPacked>`
+   = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `Vec<NonPacked>`
 note: required because it appears within the type `Contract`
   --> tests/ui/storage_item/fail/collections_only_packed_1.rs:10:8
    |
@@ -77,9 +77,9 @@ error[E0277]: the trait bound `Vec<NonPacked>: Decode` is not satisfied
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Decode` is not implemented for `Vec<NonPacked>`
     |
     = help: the trait `Decode` is implemented for `Vec<T>`
-    = note: required for `Vec<NonPacked>` to implement `Packed`
-    = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
-    = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+    = note: required because of the requirements on the impl of `Packed` for `Vec<NonPacked>`
+    = note: required because of the requirements on the impl of `StorableHint<()>` for `Vec<NonPacked>`
+    = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `Vec<NonPacked>`
 note: required because it appears within the type `Contract`
    --> tests/ui/storage_item/fail/collections_only_packed_1.rs:10:8
     |
@@ -101,10 +101,10 @@ error[E0277]: the trait bound `[NonPacked]: Encode` is not satisfied
     = help: the following other types implement trait `Encode`:
               [T; N]
               [T]
-    = note: required for `Vec<NonPacked>` to implement `Encode`
-    = note: required for `Vec<NonPacked>` to implement `Packed`
-    = note: required for `Vec<NonPacked>` to implement `StorableHint<()>`
-    = note: required for `Vec<NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+    = note: required because of the requirements on the impl of `Encode` for `Vec<NonPacked>`
+    = note: required because of the requirements on the impl of `Packed` for `Vec<NonPacked>`
+    = note: required because of the requirements on the impl of `StorableHint<()>` for `Vec<NonPacked>`
+    = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `Vec<NonPacked>`
 note: required because it appears within the type `Contract`
    --> tests/ui/storage_item/fail/collections_only_packed_1.rs:10:8
     |

--- a/crates/lang/tests/ui/storage_item/fail/collections_only_packed_2.stderr
+++ b/crates/lang/tests/ui/storage_item/fail/collections_only_packed_2.stderr
@@ -2,23 +2,23 @@ error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Decode` is not satisfi
   --> tests/ui/storage_item/fail/collections_only_packed_2.rs:11:8
    |
 11 |     a: BTreeMap<u128, NonPacked>,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Decode` is not implemented for `BTreeMap<u128, NonPacked>`
+   |        ^^^^^^^^ the trait `Decode` is not implemented for `BTreeMap<u128, NonPacked>`
    |
    = help: the trait `Decode` is implemented for `BTreeMap<K, V>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+   = note: required because of the requirements on the impl of `Packed` for `BTreeMap<u128, NonPacked>`
+   = note: required because of the requirements on the impl of `StorableHint<()>` for `BTreeMap<u128, NonPacked>`
+   = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `BTreeMap<u128, NonPacked>`
 
 error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Encode` is not satisfied
   --> tests/ui/storage_item/fail/collections_only_packed_2.rs:11:8
    |
 11 |     a: BTreeMap<u128, NonPacked>,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `BTreeMap<u128, NonPacked>`
+   |        ^^^^^^^^ the trait `Encode` is not implemented for `BTreeMap<u128, NonPacked>`
    |
    = help: the trait `Encode` is implemented for `BTreeMap<K, V>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+   = note: required because of the requirements on the impl of `Packed` for `BTreeMap<u128, NonPacked>`
+   = note: required because of the requirements on the impl of `StorableHint<()>` for `BTreeMap<u128, NonPacked>`
+   = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `BTreeMap<u128, NonPacked>`
 
 error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Decode` is not satisfied
   --> tests/ui/storage_item/fail/collections_only_packed_2.rs:9:1
@@ -27,9 +27,9 @@ error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Decode` is not satisfi
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Decode` is not implemented for `BTreeMap<u128, NonPacked>`
    |
    = help: the trait `Decode` is implemented for `BTreeMap<K, V>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+   = note: required because of the requirements on the impl of `Packed` for `BTreeMap<u128, NonPacked>`
+   = note: required because of the requirements on the impl of `StorableHint<()>` for `BTreeMap<u128, NonPacked>`
+   = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `BTreeMap<u128, NonPacked>`
 note: required because it appears within the type `Contract`
   --> tests/ui/storage_item/fail/collections_only_packed_2.rs:10:8
    |
@@ -49,9 +49,9 @@ error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Encode` is not satisfi
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `BTreeMap<u128, NonPacked>`
    |
    = help: the trait `Encode` is implemented for `BTreeMap<K, V>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
-   = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+   = note: required because of the requirements on the impl of `Packed` for `BTreeMap<u128, NonPacked>`
+   = note: required because of the requirements on the impl of `StorableHint<()>` for `BTreeMap<u128, NonPacked>`
+   = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `BTreeMap<u128, NonPacked>`
 note: required because it appears within the type `Contract`
   --> tests/ui/storage_item/fail/collections_only_packed_2.rs:10:8
    |
@@ -71,9 +71,9 @@ error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Decode` is not satisfi
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Decode` is not implemented for `BTreeMap<u128, NonPacked>`
     |
     = help: the trait `Decode` is implemented for `BTreeMap<K, V>`
-    = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
-    = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
-    = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+    = note: required because of the requirements on the impl of `Packed` for `BTreeMap<u128, NonPacked>`
+    = note: required because of the requirements on the impl of `StorableHint<()>` for `BTreeMap<u128, NonPacked>`
+    = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `BTreeMap<u128, NonPacked>`
 note: required because it appears within the type `Contract`
    --> tests/ui/storage_item/fail/collections_only_packed_2.rs:10:8
     |
@@ -93,9 +93,9 @@ error[E0277]: the trait bound `BTreeMap<u128, NonPacked>: Encode` is not satisfi
     | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `BTreeMap<u128, NonPacked>`
     |
     = help: the trait `Encode` is implemented for `BTreeMap<K, V>`
-    = note: required for `BTreeMap<u128, NonPacked>` to implement `Packed`
-    = note: required for `BTreeMap<u128, NonPacked>` to implement `StorableHint<()>`
-    = note: required for `BTreeMap<u128, NonPacked>` to implement `AutoStorableHint<ManualKey<2085512762>>`
+    = note: required because of the requirements on the impl of `Packed` for `BTreeMap<u128, NonPacked>`
+    = note: required because of the requirements on the impl of `StorableHint<()>` for `BTreeMap<u128, NonPacked>`
+    = note: required because of the requirements on the impl of `AutoStorableHint<ManualKey<2085512762_u32>>` for `BTreeMap<u128, NonPacked>`
 note: required because it appears within the type `Contract`
    --> tests/ui/storage_item/fail/collections_only_packed_2.rs:10:8
     |

--- a/crates/lang/tests/ui/storage_item/fail/packed_is_not_derived_automatically.stderr
+++ b/crates/lang/tests/ui/storage_item/fail/packed_is_not_derived_automatically.stderr
@@ -8,8 +8,9 @@ error[E0277]: the trait bound `NonPacked: WrapperTypeDecode` is not satisfied
              Arc<T>
              Box<T>
              Rc<T>
-   = note: required for `NonPacked` to implement `Decode`
-   = note: required for `NonPacked` to implement `Packed`
+             sp_core::Bytes
+   = note: required because of the requirements on the impl of `Decode` for `NonPacked`
+   = note: required because of the requirements on the impl of `Packed` for `NonPacked`
 note: required by a bound in `consume_packed`
   --> tests/ui/storage_item/fail/packed_is_not_derived_automatically.rs:12:22
    |
@@ -31,9 +32,9 @@ error[E0277]: the trait bound `NonPacked: WrapperTypeEncode` is not satisfied
              Rc<T>
              String
              Vec<T>
-             parity_scale_codec::Ref<'a, T, U>
-   = note: required for `NonPacked` to implement `Encode`
-   = note: required for `NonPacked` to implement `Packed`
+           and 2 others
+   = note: required because of the requirements on the impl of `Encode` for `NonPacked`
+   = note: required because of the requirements on the impl of `Packed` for `NonPacked`
 note: required by a bound in `consume_packed`
   --> tests/ui/storage_item/fail/packed_is_not_derived_automatically.rs:12:22
    |

--- a/crates/lang/tests/ui/trait_def/fail/definition_constructor.stderr
+++ b/crates/lang/tests/ui/trait_def/fail/definition_constructor.stderr
@@ -1,6 +1,5 @@
 error: ink! trait definitions must not have constructors
  --> tests/ui/trait_def/fail/definition_constructor.rs:5:5
   |
-5 | /     #[ink(constructor)]
-6 | |     fn constructor() -> Self;
-  | |_____________________________^
+5 |     #[ink(constructor)]
+  |     ^

--- a/crates/lang/tests/ui/trait_def/fail/definition_empty.stderr
+++ b/crates/lang/tests/ui/trait_def/fail/definition_empty.stderr
@@ -2,4 +2,4 @@ error: encountered invalid empty ink! trait definition
  --> tests/ui/trait_def/fail/definition_empty.rs:4:1
   |
 4 | pub trait TraitDefinition {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^^

--- a/crates/lang/tests/ui/trait_def/fail/message_input_non_codec.stderr
+++ b/crates/lang/tests/ui/trait_def/fail/message_input_non_codec.stderr
@@ -2,13 +2,14 @@ error[E0277]: the trait bound `NonCodec: WrapperTypeDecode` is not satisfied
   --> tests/ui/trait_def/fail/message_input_non_codec.rs:8:23
    |
 8  |     fn message(&self, input: NonCodec);
-   |                       ^^^^^^^^^^^^^^^ the trait `WrapperTypeDecode` is not implemented for `NonCodec`
+   |                       ^^^^^ the trait `WrapperTypeDecode` is not implemented for `NonCodec`
    |
    = help: the following other types implement trait `WrapperTypeDecode`:
              Arc<T>
              Box<T>
              Rc<T>
-   = note: required for `NonCodec` to implement `parity_scale_codec::Decode`
+             sp_core::Bytes
+   = note: required because of the requirements on the impl of `parity_scale_codec::Decode` for `NonCodec`
 note: required by a bound in `DispatchInput`
   --> src/codegen/dispatch/type_check.rs
    |
@@ -16,14 +17,10 @@ note: required by a bound in `DispatchInput`
    |        ^^^^^^^^^^^^^ required by this bound in `DispatchInput`
 
 error[E0277]: the trait bound `NonCodec: WrapperTypeEncode` is not satisfied
-  --> tests/ui/trait_def/fail/message_input_non_codec.rs:5:1
+  --> tests/ui/trait_def/fail/message_input_non_codec.rs:7:5
    |
-5  |   #[ink::trait_definition]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NonCodec`
-6  |   pub trait TraitDefinition {
-7  | /     #[ink(message)]
-8  | |     fn message(&self, input: NonCodec);
-   | |_______________________________________- required by a bound introduced by this call
+7  |     #[ink(message)]
+   |     ^ the trait `WrapperTypeEncode` is not implemented for `NonCodec`
    |
    = help: the following other types implement trait `WrapperTypeEncode`:
              &T
@@ -34,8 +31,8 @@ error[E0277]: the trait bound `NonCodec: WrapperTypeEncode` is not satisfied
              Rc<T>
              String
              Vec<T>
-             parity_scale_codec::Ref<'a, T, U>
-   = note: required for `NonCodec` to implement `Encode`
+           and 2 others
+   = note: required because of the requirements on the impl of `Encode` for `NonCodec`
 note: required by a bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd>>::push_arg`
   --> $WORKSPACE/crates/env/src/call/execution_input.rs
    |
@@ -45,14 +42,13 @@ note: required by a bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, Arg
 error[E0599]: the method `fire` exists for struct `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<ink_env::call::utils::Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>>>, Set<ReturnType<()>>>`, but its trait bounds were not satisfied
   --> tests/ui/trait_def/fail/message_input_non_codec.rs:7:5
    |
-7  | /     #[ink(message)]
-8  | |     fn message(&self, input: NonCodec);
-   | |_______________________________________^ method cannot be called on `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<ink_env::call::utils::Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>>>, Set<ReturnType<()>>>` due to unsatisfied trait bounds
+7  |     #[ink(message)]
+   |     ^ method cannot be called on `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<ink_env::call::utils::Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>>>, Set<ReturnType<()>>>` due to unsatisfied trait bounds
    |
   ::: $WORKSPACE/crates/env/src/call/execution_input.rs
    |
-   |   pub struct ArgumentList<Head, Rest> {
-   |   ----------------------------------- doesn't satisfy `_: Encode`
+   | pub struct ArgumentList<Head, Rest> {
+   | ----------------------------------- doesn't satisfy `_: Encode`
    |
    = note: the following trait bounds were not satisfied:
            `ArgumentList<ink_env::call::utils::Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>: Encode`

--- a/crates/lang/tests/ui/trait_def/fail/message_output_non_codec.stderr
+++ b/crates/lang/tests/ui/trait_def/fail/message_output_non_codec.stderr
@@ -13,8 +13,8 @@ error[E0277]: the trait bound `NonCodec: WrapperTypeEncode` is not satisfied
              Rc<T>
              String
              Vec<T>
-             parity_scale_codec::Ref<'a, T, U>
-   = note: required for `NonCodec` to implement `Encode`
+           and 2 others
+   = note: required because of the requirements on the impl of `Encode` for `NonCodec`
 note: required by a bound in `DispatchOutput`
   --> src/codegen/dispatch/type_check.rs
    |
@@ -24,17 +24,22 @@ note: required by a bound in `DispatchOutput`
 error[E0599]: the method `fire` exists for struct `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodec>>>`, but its trait bounds were not satisfied
    --> tests/ui/trait_def/fail/message_output_non_codec.rs:7:5
     |
-3   |   pub struct NonCodec;
-    |   ------------------- doesn't satisfy `NonCodec: parity_scale_codec::Decode`
+3   | pub struct NonCodec;
+    | -------------------- doesn't satisfy `NonCodec: parity_scale_codec::Decode`
 ...
-7   | /     #[ink(message)]
-8   | |     fn message(&self) -> NonCodec;
-    | |__________________________________^ method cannot be called on `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodec>>>` due to unsatisfied trait bounds
+7   |     #[ink(message)]
+    |     ^ method cannot be called on `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodec>>>` due to unsatisfied trait bounds
     |
     = note: the following trait bounds were not satisfied:
             `NonCodec: parity_scale_codec::Decode`
 note: the following trait must be implemented
    --> $CARGO/parity-scale-codec-3.1.5/src/codec.rs
     |
-    | pub trait Decode: Sized {
-    | ^^^^^^^^^^^^^^^^^^^^^^^
+    | / pub trait Decode: Sized {
+    | |     // !INTERNAL USE ONLY!
+    | |     // This const helps SCALE to optimize the encoding/decoding by doing fake specialization.
+    | |     #[doc(hidden)]
+...   |
+    | |     }
+    | | }
+    | |_^

--- a/crates/lang/tests/ui/trait_def/fail/message_selector_invalid_1.stderr
+++ b/crates/lang/tests/ui/trait_def/fail/message_selector_invalid_1.stderr
@@ -2,4 +2,4 @@ error: expected 4-digit hexcode for `selector` argument, e.g. #[ink(selector = 0
  --> tests/ui/trait_def/fail/message_selector_invalid_1.rs:5:20
   |
 5 |     #[ink(message, selector = true)]
-  |                    ^^^^^^^^^^^^^^^
+  |                    ^^^^^^^^

--- a/crates/lang/tests/unique_topics.rs
+++ b/crates/lang/tests/unique_topics.rs
@@ -13,12 +13,6 @@
 // limitations under the License.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-// TODO `cargo clippy --verbose --all-targets --all-features` for this crate
-// fails on `stable`, but succeeds on `nightly`. I can't find the unused lifetime
-// and assume it's a bug in `stable` (there are some recently closed issues for
-// `clippy` that match). Remove the following line again as soon as `clippy` on
-// stable would succeed again
-#![allow(clippy::extra_unused_lifetimes)]
 
 use ink_lang as ink;
 


### PR DESCRIPTION
This is needed for https://github.com/paritytech/ink/issues/1234.

The reason is that going forward `cargo-contract` will require stable and the E2E tests use it for building the contract. If the CI runs nightly clippy on our example contracts and later builds them in stable it runs into:

```
error[E0514]: found crate `core` compiled by an incompatible version of rustc
```

I'm aware of the discussion that happened in https://github.com/paritytech/scripts/pull/453, namely @HCastano was bringing this up:

>I've thought about this a bit and I'm not sure we want to do this, since contributors to ink! will have to use `RUSTC_BOOTSTRAP=1` locally to check that Clippy passes. I'd prefer if they were told to use nightly instead.

I agree, it's a bit unfortunate, but working around the above compiler error would require significant work to our CI setup and how it uses `CARGO_TARGET_DIR`.
