### PR TITLE
CI: Remove `codecov` stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -290,50 +290,6 @@ docs:
     - chown -R nonroot:nonroot ./crate-docs
 
 
-codecov:
-  stage:                           workspace
-  <<:                              *docker-env
-  <<:                              *test-refs
-  needs:
-    - job:                         check-std
-      artifacts:                   false
-  variables:
-    # For codecov it's sufficient to run the fuzz tests only once.
-    QUICKCHECK_TESTS:              1
-    INK_COVERAGE_REPORTING:        "true"
-    CARGO_INCREMENTAL:             0
-    # Variables partly came from https://github.com/mozilla/grcov/blob/master/README.md
-    RUSTFLAGS:                     "-Zprofile -Zmir-opt-level=0 -Ccodegen-units=1
-                                    -Clink-dead-code -Copt-level=0 -Coverflow-checks=off"
-    # The `cargo-taurpalin` coverage reporting tool seems to have better code instrumentation and thus
-    # produces better results for Rust codebases in general. However, unlike `grcov` it requires
-    # running docker with `--security-opt seccomp=unconfined` which is why we use `grcov` instead.
-  before_script:
-    - *rust-info-script
-    # RUSTFLAGS are the cause target cache can't be used here
-    # FIXME: cust-covfix doesn't support the external target dir
-    # https://github.com/Kogia-sima/rust-covfix/issues/7
-    - unset "CARGO_TARGET_DIR"
-    - cargo clean
-    # make sure there's no stale coverage artifacts
-    - find . -name "*.profraw" -type f -delete
-    - find . -name "*.gcda" -type f -delete
-  script:
-    # RUSTFLAGS are the cause target cache can't be used here
-    - cargo build --verbose --all-features --workspace
-    - cargo test --verbose --all-features --no-fail-fast --workspace
-    # coverage with branches
-    - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm --branch
-        --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
-    - rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
-    - codecov --token "$CODECOV_P_TOKEN" --file lcov-w-branch-fixed.info --nonZero
-    # lines coverage
-    - grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm
-        --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info
-    - rust-covfix lcov-lines.info --output lcov-lines-fixed.info
-    - codecov --token "$CODECOV_TOKEN" --file lcov-lines-fixed.info --nonZero
-
-
 #### stage:                        examples
 
 examples-test:

--- a/README.md
+++ b/README.md
@@ -4,14 +4,10 @@
     Parity's ink! for writing smart contracts
 </h1>
 
-[![linux][a1]][a2] [![codecov][c1]][c2] [![coveralls][d1]][d2] [![loc][e1]][e2] [![stack-exchange][s1]][s2]
+[![linux][a1]][a2] [![loc][e1]][e2] [![stack-exchange][s1]][s2]
 
 [a1]: https://gitlab.parity.io/parity/ink/badges/master/pipeline.svg
 [a2]: https://gitlab.parity.io/parity/ink/pipelines?ref=master
-[c1]: https://codecov.io/gh/paritytech/ink/branch/master/graph/badge.svg
-[c2]: https://codecov.io/gh/paritytech/ink/branch/master
-[d1]: https://coveralls.io/repos/github/paritytech/ink/badge.svg?branch=master
-[d2]: https://coveralls.io/github/paritytech/ink?branch=master
 [e1]: https://tokei.rs/b1/github/paritytech/ink?category=code
 [e2]: https://github.com/Aaronepower/tokei#badges
 [f1]: https://img.shields.io/badge/click-blue.svg
@@ -162,7 +158,7 @@ mod flipper {
     #[cfg(test)]
     mod tests {
         use super::*;
-        
+
         #[ink::test]
         fn it_works() {
             let mut flipper = Flipper::new(false);


### PR DESCRIPTION
We've migrated ink! to Rust `stable`, the current `codecov` setup runs only in `nightly` (due to `-Z` `RUSTFLAGS`). Our test fixtures have different output for `stable` though, hence `codecov` fails.

It's unfortunate. I've created this follow-up ticket to bring it back: https://github.com/paritytech/ci_cd/issues/611.