### PR TITLE
Release `v4.0.0-alpha.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Version 4.0.0-alpha.2
+## Version 4.0.0-alpha.3
 
 ### Breaking Changes
 
@@ -48,6 +48,10 @@ through a feature flag. `wee-alloc` is no longer maintained and we removed suppo
 
 ### Removed
 - Remove `wee-alloc` ‒ [#1403](https://github.com/paritytech/ink/pull/1403)
+
+## Version 4.0.0-alpha.2
+
+**This version was skipped due to an error in the release process**
 
 ## Version 4.0.0-alpha.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ through a feature flag. `wee-alloc` is no longer maintained and we removed suppo
 
 ## Version 4.0.0-alpha.2
 
-**This version was skipped due to an error in the release process**
+**This version was skipped due to a human error in the release process**
 
 ## Version 4.0.0-alpha.1
 

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_allocator"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_primitives = { version = "4.0.0-alpha.2", path = "../../crates/primitives", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.3", path = "../../crates/primitives", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_engine"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Michael Müller <michi@parity.io>"]
 edition = "2021"
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "4.0.0-alpha.2", path = "../metadata", default-features = false, features = ["derive"], optional = true }
-ink_allocator = { version = "4.0.0-alpha.2", path = "../allocator", default-features = false }
-ink_storage_traits = { version = "4.0.0-alpha.2", path = "../storage/traits", default-features = false }
-ink_prelude = { version = "4.0.0-alpha.2", path = "../prelude", default-features = false }
-ink_primitives = { version = "4.0.0-alpha.2", path = "../primitives", default-features = false }
+ink_metadata = { version = "4.0.0-alpha.3", path = "../metadata", default-features = false, features = ["derive"], optional = true }
+ink_allocator = { version = "4.0.0-alpha.3", path = "../allocator", default-features = false }
+ink_storage_traits = { version = "4.0.0-alpha.3", path = "../storage/traits", default-features = false }
+ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.3", path = "../primitives", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -33,7 +33,7 @@ static_assertions = "1.1"
 rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ink_engine = { version = "4.0.0-alpha.2", path = "../engine/", optional = true }
+ink_engine = { version = "4.0.0-alpha.3", path = "../engine/", optional = true }
 
 # Hashes for the off-chain environment.
 sha2 = { version = "0.10", optional = true }

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_env"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -15,12 +15,12 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.0.0-alpha.2", path = "../env", default-features = false }
-ink_storage = { version = "4.0.0-alpha.2", path = "../storage", default-features = false }
-ink_primitives = { version = "4.0.0-alpha.2", path = "../primitives", default-features = false }
-ink_metadata = { version = "4.0.0-alpha.2", path = "../metadata", default-features = false, optional = true }
-ink_prelude = { version = "4.0.0-alpha.2", path = "../prelude", default-features = false }
-ink_macro = { version = "4.0.0-alpha.2", path = "macro", default-features = false }
+ink_env = { version = "4.0.0-alpha.3", path = "../env", default-features = false }
+ink_storage = { version = "4.0.0-alpha.3", path = "../storage", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.3", path = "../primitives", default-features = false }
+ink_metadata = { version = "4.0.0-alpha.3", path = "../metadata", default-features = false, optional = true }
+ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude", default-features = false }
+ink_macro = { version = "4.0.0-alpha.3", path = "macro", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_codegen"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -18,8 +18,8 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 name = "ink_codegen"
 
 [dependencies]
-ink_primitives = { version = "4.0.0-alpha.2", path = "../../primitives" }
-ir = { version = "4.0.0-alpha.2", package = "ink_ir", path = "../ir", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.3", path = "../../primitives" }
+ir = { version = "4.0.0-alpha.3", package = "ink_ir", path = "../ir", default-features = false }
 quote = "1"
 syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = "1.0"

--- a/crates/ink/ir/Cargo.toml
+++ b/crates/ink/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_ir"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -15,9 +15,9 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_ir = { version = "4.0.0-alpha.2", path = "../ir", default-features = false }
-ink_codegen = { version = "4.0.0-alpha.2", path = "../codegen", default-features = false }
-ink_primitives = { version = "4.0.0-alpha.2", path = "../../primitives/", default-features = false }
+ink_ir = { version = "4.0.0-alpha.3", path = "../ir", default-features = false }
+ink_codegen = { version = "4.0.0-alpha.3", path = "../codegen", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.3", path = "../../primitives/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 syn = "1"

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_macro"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "4.0.0-alpha.2", path = "../prelude/", default-features = false }
-ink_primitives = { version = "4.0.0-alpha.2", path = "../primitives/", default-features = false }
+ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude/", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.3", path = "../primitives/", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.4.0"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_metadata"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_prelude"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -16,7 +16,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-ink_prelude = { version = "4.0.0-alpha.2", path = "../prelude/", default-features = false }
+ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", features = ["const_xxh32"] }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_primitives"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.0.0-alpha.2", path = "../env/", default-features = false }
-ink_metadata = { version = "4.0.0-alpha.2", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.0.0-alpha.2", path = "../primitives/", default-features = false }
-ink_storage_traits = { version = "4.0.0-alpha.2", path = "traits", default-features = false }
-ink_prelude = { version = "4.0.0-alpha.2", path = "../prelude/", default-features = false }
+ink_env = { version = "4.0.0-alpha.3", path = "../env/", default-features = false }
+ink_metadata = { version = "4.0.0-alpha.3", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "4.0.0-alpha.3", path = "../primitives/", default-features = false }
+ink_storage_traits = { version = "4.0.0-alpha.3", path = "traits", default-features = false }
+ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage_traits"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -24,7 +24,6 @@ syn = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 paste = "1.0"
-ink_env = { version = "4.0.0-alpha.3", path = "../../env" }
 
 [features]
 default = ["std"]

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -15,16 +15,16 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "4.0.0-alpha.2", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.0.0-alpha.2", path = "../../primitives", default-features = false }
-ink_prelude = { version = "4.0.0-alpha.2", path = "../../prelude", default-features = false }
+ink_metadata = { version = "4.0.0-alpha.3", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "4.0.0-alpha.3", path = "../../primitives", default-features = false }
+ink_prelude = { version = "4.0.0-alpha.3", path = "../../prelude", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 syn = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 paste = "1.0"
-ink_env = { version = "4.0.0-alpha.2", path = "../../env" }
+ink_env = { version = "4.0.0-alpha.3", path = "../../env" }
 
 [features]
 default = ["std"]

--- a/crates/storage/traits/src/impls/mod.rs
+++ b/crates/storage/traits/src/impls/mod.rs
@@ -119,14 +119,10 @@ mod tests {
                 #[test]
                 #[allow(non_snake_case)]
                 fn [<$ty _storage_hint_works>] () {
-                    ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
-                        assert_eq!(
-                            ::core::any::TypeId::of::<$ty>(),
-                            ::core::any::TypeId::of::<<$ty as $crate::StorableHint<$crate::ManualKey<123>>>::Type>()
-                        );
-                        Ok(())
-                    })
-                    .unwrap()
+                    assert_eq!(
+                        ::core::any::TypeId::of::<$ty>(),
+                        ::core::any::TypeId::of::<<$ty as $crate::StorableHint<$crate::ManualKey<123>>>::Type>()
+                    );
                 }
             }
         };

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_terminate"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_transfer"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegator"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulator"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adder"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subber"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc1155"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc20"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc721"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/mother/Cargo.toml
+++ b/examples/mother/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mother"
 description = "Mother of all contracts"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/payment-channel/Cargo.toml
+++ b/examples/payment-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payment_channel"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/psp22-extension/Cargo.toml
+++ b/examples/psp22-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_extension"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_extension"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_erc20"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_flipper"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/Cargo.toml
+++ b/examples/trait-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/traits/Cargo.toml
+++ b/examples/trait-incrementer/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traits"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/forward-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/forward-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forward_calls"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated-incrementer"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_linting"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false


### PR DESCRIPTION
When attempting to release `alpha.2`, the `cargo release` auto bumped the version to `alpha.3` (see commits in this PR) because I supplied simply `alpha` as the `level` instead of the specific version `v4.0.0 alpha.2`. The result was some crates were published as `v4.0.0-alpha.3`, with others not being published because the inter-crate dependency versions were not updated.

## Version 4.0.0-alpha.3

### Breaking Changes

#### New `ink` crate
The `ink_lang` crate has been replaced in [#1223](https://github.com/paritytech/ink/pull/1223) by a new top level `ink`
crate. All existing sub-crates are reexported and should be used via the new `ink` crate, so e.g. `ink::env` instead of
`ink_env`. Contract authors should now import the top level `ink` crate instead of the individual crates.

##### Migration
- In `Cargo.toml` Replace all individual `ink_*` crate dependencies with the `ink` crate.
- In the contract source:
  - Remove the commonly used `use ink_lang as ink` idiom.
  - Replace all usages of individual crates with reexports, e.g. `ink_env` ➜ `ink::env`.

#### Storage Rework
[#1331](https://github.com/paritytech/ink/pull/1331) changes the way `ink!` works with contract storage. Storage keys 
are generated at compile-time, and user facing abstractions which determine how contract data is laid out in storage
have changed.

##### Migration
- Initialize `Mapping` fields with `Mapping::default()` instead of  `ink_lang::utils::initialize_contract` in
constructors. See [`erc20`](./examples/erc20/lib.rs) and other examples which use a `Mapping`.
- Remove `SpreadAllocate`, `SpreadLayout` and `PackedLayout` implementations.

#### Removal of `wee-alloc` support
ink! uses a bump allocator by default, additionally we supported another allocator (`wee-alloc`)
through a feature flag. `wee-alloc` is no longer maintained and we removed support for it.

### Changed
- Introduce `ink` entrance crate ‒ [#1223](https://github.com/paritytech/ink/pull/1223)
- Use `XXH32` instead of `sha256` for calculating storage keys ‒ [#1393](https://github.com/paritytech/ink/pull/1393)

### Fixed
- Trim single whitespace prefix in the metadata `docs` field ‒ [#1385](https://github.com/paritytech/ink/pull/1385)
- Allow pay_with_call to take multiple arguments ‒ [#1401](https://github.com/paritytech/ink/pull/1401)

### Added
- Add `ink_env::pay_with_call!` helper macro for off-chain emulation of sending payments with contract message calls ‒ [#1379](https://github.com/paritytech/ink/pull/1379)

### Removed
- Remove `wee-alloc` ‒ [#1403](https://github.com/paritytech/ink/pull/1403)