### PR TITLE
Update release checklist

### DIFF
--- a/RELEASES_CHECKLIST.md
+++ b/RELEASES_CHECKLIST.md
@@ -35,6 +35,10 @@ We'll be using [`cargo-release`](https://github.com/crate-ci/cargo-release) to r
 steps though, and we hope to make this more streamlined in the future.
 
 1. Create a new feature branch off `master`.
+1. Bump the version in all TOML files to the new version.
+    ```
+    find . -type f -name *.toml -exec sed -i -e 's/$OLD_VERSION/$NEW_VERSION/g' {} \;
+    ```
 1. Make sure you've moved the changes in the `CHANGELOG.md` from `[Unreleased]` into a new
    section for the release.
 1. Check that all notable PRs since the last release are now in the new release section,
@@ -45,13 +49,18 @@ steps though, and we hope to make this more streamlined in the future.
 1. Open a release PR
     - Wait for approvals from Core team members.
     - Ensure the entire CI pipeline is green.
-1. Do a dry run with `cargo release [new_version] -v --no-tag --no-push --dependent-version upgrade`
-    - `[new_version]` should be the the . 
-      - 
+1. Do a dry run with `cargo release [new_version] -v --no-tag --no-push`
+    - `[new_version]` should be the **exact** SemVer compatible version you are attempting to release e.g. 
+      `4.0.0-alpha.3`
+      - It is possible to supply a SemVer level here e.g. `major`, `minor`, `patch` or `<pre-release-name>`, however
+        this will automatically bump and commit the changes to the `Cargo.toml` manifests. We have already done that in
+        an earlier step so it is not necessary.
     - We don't want `cargo-release` to create any releases or push any code, we'll do
        that manually once we've actually published to `crates.io`.
 1. If there are no errors, merge the release PR into `master`.
-1. Publish with `export PUBLISH_GRACE_SLEEP=5 && cargo release [level] -v --no-tag --no-push --execute`
+1. Publish with `export PUBLISH_GRACE_SLEEP=5 && cargo release [new_version] -v --no-tag --no-push --execute`
+    - Ensure the same `[new_version]` as the dry run, which should be the **exact** SemVer compatible version you are 
+      attempting to release e.g. `4.0.0-alpha.3`.
     - We add the grace period since crates depend on one another.
     - We add the `--execute` flag to _actually_ publish things to crates.io.
 1. Replace `vX.X.X` with the new version in the following command and then execute it:

--- a/RELEASES_CHECKLIST.md
+++ b/RELEASES_CHECKLIST.md
@@ -36,9 +36,10 @@ ink!. There are still a few manual steps though, and we hope to make this more s
 in the future.
 
 1. Create a new feature branch off `master`.
-1. Copy the release notes that appear in the [`CHANGELOG.md`](https://github.com/paritytech/ink/blob/master/CHANGELOG.md)
-   into the PR description. This will cause the individual PRs to be linked to the release 
-   in which they are included.
+1. Copy the release notes that appear in the [`CHANGELOG.md`](https://githubcom/paritytech/ink/blob/master/CHANGELOG.md)
+   into the PR description. 
+   - This will cause the individual PRs to be linked to the release in which they are 
+     included.
 1. Bump the version in all TOML files to the new version.
     ```
     find . -type f -name *.toml -exec sed -i -e 's/$OLD_VERSION/$NEW_VERSION/g' {} \;
@@ -65,15 +66,16 @@ in the future.
 1. Check the output of the dry run:
    - Does not show any automatic bumping of crate versions.
    - Runs without error.
-1. Following a successful dry run, we can now publish to crates.io. This will be done from 
-   the release branch, since it is possible for the dry run to succeed but for the actual 
-   publish to fail, which would require some changes. So before running the next step:
-   - Ensure there have been no new commits to `master` which are not included in this 
-     branch.
-   - Notify core team members in the Element channel that no PRs should be merged to 
-     `master` during the release.
-   - The above are to ensure that the bundled code pushed to crates.io is the same as the 
-     tagged release on GitHub.
+1. Following a successful dry run, we can now publish to crates.io. 
+   - This will be done from the release branch itself.
+   - This is because it is possible for the dry run to succeed but for the actual publish 
+     to fail and require some changes. So before running the next step:
+     - Ensure there have been no new commits to `master` which are not included in this 
+       branch.
+     - Notify core team members in the Element channel that no PRs should be merged to 
+       `master` during the release.
+     - The above are to ensure that the bundled code pushed to crates.io is the same as 
+       the tagged release on GitHub.
 1. Publish with `export PUBLISH_GRACE_SLEEP=5 && cargo release [new_version] -v --no-tag --no-push --execute`
     - Ensure the same `[new_version]` as the dry run, which should be the **exact** SemVer 
       compatible version you are attempting to release e.g. `4.0.0-alpha.3`.

--- a/RELEASES_CHECKLIST.md
+++ b/RELEASES_CHECKLIST.md
@@ -35,10 +35,6 @@ We'll be using [`cargo-release`](https://github.com/crate-ci/cargo-release) to r
 steps though, and we hope to make this more streamlined in the future.
 
 1. Create a new feature branch off `master`.
-1. Bump the version in all TOML files to the new version.
-    ```
-    find . -type f -name *.toml -exec sed -i -e 's/$OLD_VERSION/$NEW_VERSION/g' {} \;
-    ```
 1. Make sure you've moved the changes in the `CHANGELOG.md` from `[Unreleased]` into a new
    section for the release.
 1. Check that all notable PRs since the last release are now in the new release section,
@@ -49,8 +45,9 @@ steps though, and we hope to make this more streamlined in the future.
 1. Open a release PR
     - Wait for approvals from Core team members.
     - Ensure the entire CI pipeline is green.
-1. Do a dry run with `cargo release [level] -v --no-tag --no-push`
-    - `[level]` will depend on what you're releasing.
+1. Do a dry run with `cargo release [new_version] -v --no-tag --no-push --dependent-version upgrade`
+    - `[new_version]` should be the the . 
+      - 
     - We don't want `cargo-release` to create any releases or push any code, we'll do
        that manually once we've actually published to `crates.io`.
 1. If there are no errors, merge the release PR into `master`.

--- a/RELEASES_CHECKLIST.md
+++ b/RELEASES_CHECKLIST.md
@@ -35,6 +35,8 @@ We'll be using [`cargo-release`](https://github.com/crate-ci/cargo-release) to r
 steps though, and we hope to make this more streamlined in the future.
 
 1. Create a new feature branch off `master`.
+2. Copy the release notes that appear in the [`CHANGELOG.md`](https://github.com/paritytech/ink/blob/master/CHANGELOG.md)
+   into the PR description. This will cause the individual PRs to be linked to the release in which they are included.
 1. Bump the version in all TOML files to the new version.
     ```
     find . -type f -name *.toml -exec sed -i -e 's/$OLD_VERSION/$NEW_VERSION/g' {} \;
@@ -57,17 +59,28 @@ steps though, and we hope to make this more streamlined in the future.
         an earlier step so it is not necessary.
     - We don't want `cargo-release` to create any releases or push any code, we'll do
        that manually once we've actually published to `crates.io`.
-1. If there are no errors, merge the release PR into `master`.
+1. Check the output of the dry run:
+   - Does not show any automatic bumping of crate versions.
+   - Runs without error.
+1. Following a successful dry run, we can now publish to crates.io. This will be done from the release branch, since it
+   is possible for the dry run to succeed but for the actual publish to fail, which would require some changes. So 
+   before running the next step:
+   - Ensure there have been no new commits to `master` which are not included in this branch.
+   - Notify core team members in the Element channel that no PRs should be merged to `master` during the release.
+   - The above are to ensure that the bundled code pushed to crates.io is the same as the tagged release on GitHub.
 1. Publish with `export PUBLISH_GRACE_SLEEP=5 && cargo release [new_version] -v --no-tag --no-push --execute`
     - Ensure the same `[new_version]` as the dry run, which should be the **exact** SemVer compatible version you are 
       attempting to release e.g. `4.0.0-alpha.3`.
     - We add the grace period since crates depend on one another.
     - We add the `--execute` flag to _actually_ publish things to crates.io.
+1. Following a successful release from the release PR branch, now the PR can be merged into `master`
+    - Once merged, notify core team members in the Element channel that PRs can be merged again into `master`
 1. Replace `vX.X.X` with the new version in the following command and then execute it:
     ```
     git tag -s vX.X.X && git push origin vX.X.X
     ```
     - Ensure your tag is signed with an offline GPG key!
+    - Alternatively, the `Create release` GitHub UI below allows creating this tag when creating the release.
 1. Create a GitHub release for this tag. In the [tag overview](https://github.com/paritytech/ink/tags)
    you'll see your new tag appear. Click the `…` on the right of the tag and then `Create release`.
 1. Paste the release notes that appear in the [`CHANGELOG.md`](https://github.com/paritytech/ink/blob/master/CHANGELOG.md)

--- a/RELEASES_CHECKLIST.md
+++ b/RELEASES_CHECKLIST.md
@@ -35,7 +35,7 @@ We'll be using [`cargo-release`](https://github.com/crate-ci/cargo-release) to r
 steps though, and we hope to make this more streamlined in the future.
 
 1. Create a new feature branch off `master`.
-2. Copy the release notes that appear in the [`CHANGELOG.md`](https://github.com/paritytech/ink/blob/master/CHANGELOG.md)
+1. Copy the release notes that appear in the [`CHANGELOG.md`](https://github.com/paritytech/ink/blob/master/CHANGELOG.md)
    into the PR description. This will cause the individual PRs to be linked to the release in which they are included.
 1. Bump the version in all TOML files to the new version.
     ```

--- a/RELEASES_CHECKLIST.md
+++ b/RELEASES_CHECKLIST.md
@@ -31,12 +31,14 @@ crates.io.
 
 ## Checklist
 
-We'll be using [`cargo-release`](https://github.com/crate-ci/cargo-release) to release ink!. There are still a few manual
-steps though, and we hope to make this more streamlined in the future.
+We'll be using [`cargo-release`](https://github.com/crate-ci/cargo-release) to release 
+ink!. There are still a few manual steps though, and we hope to make this more streamlined 
+in the future.
 
 1. Create a new feature branch off `master`.
 1. Copy the release notes that appear in the [`CHANGELOG.md`](https://github.com/paritytech/ink/blob/master/CHANGELOG.md)
-   into the PR description. This will cause the individual PRs to be linked to the release in which they are included.
+   into the PR description. This will cause the individual PRs to be linked to the release 
+   in which they are included.
 1. Bump the version in all TOML files to the new version.
     ```
     find . -type f -name *.toml -exec sed -i -e 's/$OLD_VERSION/$NEW_VERSION/g' {} \;
@@ -52,37 +54,45 @@ steps though, and we hope to make this more streamlined in the future.
     - Wait for approvals from Core team members.
     - Ensure the entire CI pipeline is green.
 1. Do a dry run with `cargo release [new_version] -v --no-tag --no-push`
-    - `[new_version]` should be the **exact** SemVer compatible version you are attempting to release e.g. 
-      `4.0.0-alpha.3`
-      - It is possible to supply a SemVer level here e.g. `major`, `minor`, `patch` or `<pre-release-name>`, however
-        this will automatically bump and commit the changes to the `Cargo.toml` manifests. We have already done that in
-        an earlier step so it is not necessary.
+    - `[new_version]` should be the **exact** SemVer compatible version you are attempting 
+      to release e.g. `4.0.0-alpha.3`
+      - It is possible to supply a SemVer level here e.g. `major`, `minor`, `patch` or 
+        `<pre-release-name>`, however this will automatically bump and commit the changes 
+        to the `Cargo.toml` manifests. We have already done that in an earlier step so it 
+        is not necessary.
     - We don't want `cargo-release` to create any releases or push any code, we'll do
-       that manually once we've actually published to `crates.io`.
+      that manually once we've actually published to `crates.io`.
 1. Check the output of the dry run:
    - Does not show any automatic bumping of crate versions.
    - Runs without error.
-1. Following a successful dry run, we can now publish to crates.io. This will be done from the release branch, since it
-   is possible for the dry run to succeed but for the actual publish to fail, which would require some changes. So 
-   before running the next step:
-   - Ensure there have been no new commits to `master` which are not included in this branch.
-   - Notify core team members in the Element channel that no PRs should be merged to `master` during the release.
-   - The above are to ensure that the bundled code pushed to crates.io is the same as the tagged release on GitHub.
+1. Following a successful dry run, we can now publish to crates.io. This will be done from 
+   the release branch, since it is possible for the dry run to succeed but for the actual 
+   publish to fail, which would require some changes. So before running the next step:
+   - Ensure there have been no new commits to `master` which are not included in this 
+     branch.
+   - Notify core team members in the Element channel that no PRs should be merged to 
+     `master` during the release.
+   - The above are to ensure that the bundled code pushed to crates.io is the same as the 
+     tagged release on GitHub.
 1. Publish with `export PUBLISH_GRACE_SLEEP=5 && cargo release [new_version] -v --no-tag --no-push --execute`
-    - Ensure the same `[new_version]` as the dry run, which should be the **exact** SemVer compatible version you are 
-      attempting to release e.g. `4.0.0-alpha.3`.
+    - Ensure the same `[new_version]` as the dry run, which should be the **exact** SemVer 
+      compatible version you are attempting to release e.g. `4.0.0-alpha.3`.
     - We add the grace period since crates depend on one another.
     - We add the `--execute` flag to _actually_ publish things to crates.io.
-1. Following a successful release from the release PR branch, now the PR can be merged into `master`
-    - Once merged, notify core team members in the Element channel that PRs can be merged again into `master`
+1. Following a successful release from the release PR branch, now the PR can be merged 
+   into `master`
+    - Once merged, notify core team members in the Element channel that PRs can be merged 
+      again into `master`
 1. Replace `vX.X.X` with the new version in the following command and then execute it:
     ```
     git tag -s vX.X.X && git push origin vX.X.X
     ```
     - Ensure your tag is signed with an offline GPG key!
-    - Alternatively, the `Create release` GitHub UI below allows creating this tag when creating the release.
+    - Alternatively, the `Create release` GitHub UI below allows creating this tag when 
+      creating the release.
 1. Create a GitHub release for this tag. In the [tag overview](https://github.com/paritytech/ink/tags)
-   you'll see your new tag appear. Click the `…` on the right of the tag and then `Create release`.
+   you'll see your new tag appear. Click the `…` on the right of the tag and then 
+   `Create release`.
 1. Paste the release notes that appear in the [`CHANGELOG.md`](https://github.com/paritytech/ink/blob/master/CHANGELOG.md)
    there. The title of the release should be `vX.X.X`.
 1. Post an announcement to those Element channels:


### PR DESCRIPTION
First, a post-mortem of how I messed up the `4.0.0-alpha.2` release:

1. Following the existing release checklist, I bumped the versions to `alpha.2`
2. For the value of `[level]` running `cargo release`, I used the value `alpha`, following the docs of `cargo release --help` which suggests to use the pre release label. Our checklist was not clear as to what this value should be.
3. The effect of this was that it caused the `cargo release` tool to bump all the versions of the crates *again* to `alpha.3`, but crucially not updating the inter-workspace crate dependency versions. 
4. Had I checked the output of the dry run correctly I would have seen these proposed version bumps, but there was a lot of output so all I was looking for was the "Success" at the bottom as documented and didn't scroll up to see those bumps.
5. Then I ran the release for real, it performed the bumps to `alpha.3`, successfully published the "leaf" crates but then the dependent crates failed to publish because they still had `alpha.2` versions which were never published. Note that this is a case where the dry run succeeded but the publish itself failed.
6. To fix this I did an immediate new `alpha.3` release with the remaining crates.

This PR updates the release process to try and avoid this mistake, instructing the user to provide the **exact** version to be deployed. Note that it would be possible to use the publish process to bump inter workspace dependencies with `--dependent-version upgrade`, though this does not work as thoroughly as the existing step to simply find/replace versions.

Another important change is that instead of first merging to `master` and then releasing, we should first release from the PR branch and then merge. This is because it is possible (as above) for the dry run to succeed but the actual publish to fail and require changes. This requires "locking" the master branch so no commits happen while the release is happening, which I think is feasible in this project with only a handful of devs and not that often commits. However dependabot might be an issue... This is just to ensure that the code bundled to `crates.io` is the same as the code at the git release tag, so if there is a race condition then a special cherry-picked branch could be created and the release tag made from there.