### PR TITLE
Add ink! logo to our crate docs

### DIFF
--- a/crates/allocator/src/lib.rs
+++ b/crates/allocator/src/lib.rs
@@ -18,6 +18,8 @@
 //! It never frees memory, having this logic in place would increase the size footprint
 //! of each contract.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc_error_handler))]
 

--- a/crates/e2e/macro/src/lib.rs
+++ b/crates/e2e/macro/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 mod codegen;
 mod config;
 mod ir;

--- a/crates/e2e/macro/src/lib.rs
+++ b/crates/e2e/macro/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// extern crate proc_macro;
-
 mod codegen;
 mod config;
 mod ir;

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -14,6 +14,8 @@
 
 //! Module for the logic behind ink!'s End-to-End testing framework.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 mod client;
 mod default_accounts;
 mod xts;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 pub mod ext;
 pub mod test_api;
 

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -20,6 +20,8 @@
 //! FFI to interface with FRAME contracts and a primitive blockchain
 //! emulator for simple off-chain testing.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,

--- a/crates/ink/codegen/src/lib.rs
+++ b/crates/ink/codegen/src/lib.rs
@@ -29,6 +29,8 @@
 //! [`cargo-expand`](https://github.com/dtolnay/cargo-expand)
 //! and executing `cargo expand --manifest-path ./examples/flipper/Cargo.toml` in this repository.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 mod enforced_error;
 mod generator;
 mod traits;

--- a/crates/ink/ir/src/lib.rs
+++ b/crates/ink/ir/src/lib.rs
@@ -27,6 +27,8 @@
 //! Therefore all ink! definition are found and accessed using the
 //! [`ItemMod`](`crate::ir::ItemMod`) data structure.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 #[macro_use]
 mod error;
 

--- a/crates/ink/macro/src/lib.rs
+++ b/crates/ink/macro/src/lib.rs
@@ -813,7 +813,6 @@ pub fn storage_item(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```
-/// 
 /// #[cfg(test)]
 /// mod tests {
 ///     // Conventional unit test that works with assertions.
@@ -944,7 +943,6 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Every chain extension defines exactly one `ErrorCode` using the following syntax:
 ///
 /// ```
-/// 
 /// #[ink::chain_extension]
 /// pub trait MyChainExtension {
 ///     type ErrorCode = MyErrorCode;
@@ -966,7 +964,6 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// from and to the runtime storage using access privileges:
 ///
 /// ```
-/// 
 /// /// Custom chain extension to read to and write from the runtime.
 /// #[ink::chain_extension]
 /// pub trait RuntimeReadWrite {

--- a/crates/ink/macro/src/lib.rs
+++ b/crates/ink/macro/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 extern crate proc_macro;
 
 mod blake2b;

--- a/crates/ink/src/lib.rs
+++ b/crates/ink/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]

--- a/crates/prelude/src/lib.rs
+++ b/crates/prelude/src/lib.rs
@@ -20,6 +20,8 @@
 //!
 //! The `ink_prelude` crate guarantees a stable interface between `std` and `no_std` mode.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -21,6 +21,8 @@
 //! By introducing `ink_primitives` we have a way to share utility components between `ink_env` or `ink_storage` and
 //! other parts of the framework, like `ink`.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod key;

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -20,6 +20,8 @@
 //! FFI to interface with FRAME contracts and a primitive blockchain
 //! emulator for simple off-chain testing.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     missing_docs,

--- a/crates/storage/traits/src/lib.rs
+++ b/crates/storage/traits/src/lib.rs
@@ -25,6 +25,8 @@
 //! If at least one of the type's fields occupies its own separate storage cell, it is a
 //! non-[`Packed`] type because it occupies more than one storage cell.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod impls;

--- a/linting/src/lib.rs
+++ b/linting/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
+#![doc(html_logo_url = "https://use.ink/img/crate-docs/logo.png", html_favicon_url = "https://use.ink/crate-docs/favicon.png")]
+
 #![feature(rustc_private)]
 
 dylint_linting::dylint_library!();


### PR DESCRIPTION
Currently it's necessary to have the image assets hosted somewhere. It's not possible to reference a local image. This enables us to switch out the assets though if we ever decide on something else.