### PR TITLE
Remove random function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove random function from ink!.
+
 ## Version 4.0.0-alpha.3
 
 ### Breaking Changes

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -23,8 +23,6 @@ sha2 = { version = "0.10" }
 sha3 = { version = "0.10" }
 blake2 = { version = "0.10" }
 
-rand = { version = "0.8" }
-
 # ECDSA for the off-chain environment.
 secp256k1 = { version = "0.24", features = ["recovery", "global-context"], optional = true }
 

--- a/crates/engine/src/exec_context.rs
+++ b/crates/engine/src/exec_context.rs
@@ -17,9 +17,7 @@ use super::types::{
     Balance,
     BlockNumber,
     BlockTimestamp,
-    Hash,
 };
-use rand::Rng;
 
 /// The context of a contract execution.
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
@@ -44,21 +42,16 @@ pub struct ExecContext {
     pub block_number: BlockNumber,
     /// The current block timestamp.
     pub block_timestamp: BlockTimestamp,
-    /// The randomization entropy for a block.
-    pub entropy: Hash,
 }
 
 impl Default for ExecContext {
     fn default() -> Self {
-        let mut entropy: [u8; 32] = Default::default();
-        rand::thread_rng().fill(entropy.as_mut());
         Self {
             caller: None,
             callee: None,
             value_transferred: 0,
             block_number: 0,
             block_timestamp: 0,
-            entropy,
         }
     }
 }
@@ -101,10 +94,8 @@ mod tests {
         assert_eq!(exec_cont.callee(), vec![13]);
 
         exec_cont.reset();
-        exec_cont.entropy = Default::default();
 
-        let mut new_exec_cont = ExecContext::new();
-        new_exec_cont.entropy = Default::default();
+        let new_exec_cont = ExecContext::new();
         assert_eq!(exec_cont, new_exec_cont);
     }
 }

--- a/crates/engine/src/ext.rs
+++ b/crates/engine/src/ext.rs
@@ -31,10 +31,6 @@ use crate::{
         BlockTimestamp,
     },
 };
-use rand::{
-    Rng,
-    SeedableRng,
-};
 use scale::Encode;
 use std::panic::panic_any;
 
@@ -429,34 +425,6 @@ impl Engine {
         let fee = self.chain_spec.gas_price.saturating_mul(gas.into());
         let fee: Vec<u8> = scale::Encode::encode(&fee);
         set_output(output, &fee[..])
-    }
-
-    /// Returns a randomized hash.
-    ///
-    /// # Note
-    ///
-    /// - This is the off-chain environment implementation of `random`.
-    ///   It provides the same behavior in that it will likely yield the
-    ///   same hash for the same subjects within the same block (or
-    ///   execution context).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    ///    let engine = ink_engine::ext::Engine::default();
-    ///    let subject = [0u8; 32];
-    ///    let mut output = [0u8; 32];
-    ///    engine.random(&subject, &mut output.as_mut_slice());
-    /// ```
-    pub fn random(&self, subject: &[u8], output: &mut &mut [u8]) {
-        let seed = (self.exec_context.entropy, subject).encode();
-        let mut digest = [0u8; 32];
-        Engine::hash_blake2_256(&seed, &mut digest);
-
-        let mut rng = rand::rngs::StdRng::from_seed(digest);
-        let mut rng_bytes: [u8; 32] = Default::default();
-        rng.fill(&mut rng_bytes);
-        set_output(output, &rng_bytes[..])
     }
 
     /// Calls the chain extension method registered at `func_id` with `input`.

--- a/crates/engine/src/types.rs
+++ b/crates/engine/src/types.rs
@@ -17,9 +17,6 @@
 
 use derive_more::From;
 
-/// Same type as the `DefaultEnvironment::Hash` type.
-pub type Hash = [u8; 32];
-
 /// Same type as the `DefaultEnvironment::BlockNumber` type.
 pub type BlockNumber = u32;
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -47,7 +47,6 @@ secp256k1 = { version = "0.24", features = ["recovery", "global-context"], optio
 #
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside the off-chain environment!
-rand = { version = "0.8", default-features = false, features = ["alloc"], optional = true }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 [features]
@@ -62,8 +61,6 @@ std = [
     "scale/std",
     "scale-info/std",
     "secp256k1",
-    "rand/std",
-    "rand/std_rng",
     "num-traits/std",
     # Enables hashing crates for off-chain environment.
     "sha2",

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -405,34 +405,6 @@ where
     })
 }
 
-/// Returns a random hash seed and the block number since which it was determinable
-/// by chain observers.
-///
-/// # Note
-///
-/// - The subject buffer can be used to further randomize the hash.
-/// - Within the same execution returns the same random hash for the same subject.
-///
-/// # Errors
-///
-/// If the returned value cannot be properly decoded.
-///
-/// # Important
-///
-/// The returned seed should only be used to distinguish commitments made before
-/// the returned block number. If the block number is too early (i.e. commitments were
-/// made afterwards), then ensure no further commitments may be made and repeatedly
-/// call this on later blocks until the block number returned is later than the latest
-/// commitment.
-pub fn random<E>(subject: &[u8]) -> Result<(E::Hash, E::BlockNumber)>
-where
-    E: Environment,
-{
-    <EnvInstance as OnInstance>::on_instance(|instance| {
-        TypedEnvBackend::random::<E>(instance, subject)
-    })
-}
-
 /// Appends the given message to the debug message buffer.
 pub fn debug_message(message: &str) {
     <EnvInstance as OnInstance>::on_instance(|instance| {

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -450,15 +450,6 @@ pub trait TypedEnvBackend: EnvBackend {
     where
         E: Environment;
 
-    /// Returns a random hash seed.
-    ///
-    /// # Note
-    ///
-    /// For more details visit: [`random`][`crate::random`]
-    fn random<E>(&mut self, subject: &[u8]) -> Result<(E::Hash, E::BlockNumber)>
-    where
-        E: Environment;
-
     /// Checks whether a specified account belongs to a contract.
     ///
     /// # Note

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -495,15 +495,6 @@ impl TypedEnvBackend for EnvInstance {
         })
     }
 
-    fn random<E>(&mut self, subject: &[u8]) -> Result<(E::Hash, E::BlockNumber)>
-    where
-        E: Environment,
-    {
-        let mut output: [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
-        self.engine.random(subject, &mut &mut output[..]);
-        scale::Decode::decode(&mut &output[..]).map_err(Into::into)
-    }
-
     fn is_contract<E>(&mut self, _account: &E::AccountId) -> bool
     where
         E: Environment,

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -98,18 +98,6 @@ where
     })
 }
 
-/// Set the entropy hash of the current block.
-///
-/// # Note
-///
-/// This allows to control what [`random`][`crate::random`] returns.
-pub fn set_block_entropy<T>(_entropy: T::Hash) -> Result<()>
-where
-    T: Environment,
-{
-    unimplemented!("off-chain environment does not yet support `set_block_entropy`");
-}
-
 /// Returns the contents of the past performed environmental debug messages in order.
 pub fn recorded_debug_messages() -> RecordedDebugMessages {
     <EnvInstance as OnInstance>::on_instance(|instance| {

--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -347,13 +347,6 @@ mod sys {
 
         pub fn seal_terminate(beneficiary_ptr: Ptr32<[u8]>) -> !;
 
-        pub fn seal_random(
-            subject_ptr: Ptr32<[u8]>,
-            subject_len: u32,
-            output_ptr: Ptr32Mut<[u8]>,
-            output_len_ptr: Ptr32Mut<u32>,
-        );
-
         pub fn seal_call(
             flags: u32,
             callee_ptr: Ptr32<[u8]>,
@@ -667,22 +660,6 @@ pub fn weight_to_fee(gas: u64, output: &mut &mut [u8]) {
         unsafe {
             sys::seal_weight_to_fee(
                 gas,
-                Ptr32Mut::from_slice(output),
-                Ptr32Mut::from_ref(&mut output_len),
-            )
-        };
-    }
-    extract_from_slice(output, output_len as usize);
-}
-
-#[inline(always)]
-pub fn random(subject: &[u8], output: &mut &mut [u8]) {
-    let mut output_len = output.len() as u32;
-    {
-        unsafe {
-            sys::seal_random(
-                Ptr32::from_slice(subject),
-                subject.len() as u32,
                 Ptr32Mut::from_slice(output),
                 Ptr32Mut::from_ref(&mut output_len),
             )

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -523,17 +523,6 @@ impl TypedEnvBackend for EnvInstance {
         <E::Balance as FromLittleEndian>::from_le_bytes(result)
     }
 
-    fn random<E>(&mut self, subject: &[u8]) -> Result<(E::Hash, E::BlockNumber)>
-    where
-        E: Environment,
-    {
-        let mut scope = self.scoped_buffer();
-        let enc_subject = scope.take_bytes(subject);
-        let output = &mut scope.take_rest();
-        ext::random(enc_subject, output);
-        scale::Decode::decode(&mut &output[..]).map_err(Into::into)
-    }
-
     fn is_contract<E>(&mut self, account_id: &E::AccountId) -> bool
     where
         E: Environment,

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -666,40 +666,6 @@ where
         ink_env::transfer::<E>(destination, value)
     }
 
-    /// Returns a random hash seed.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # #[ink::contract]
-    /// # pub mod my_contract {
-    /// #     #[ink(storage)]
-    /// #     pub struct MyContract { }
-    /// #
-    /// #     impl MyContract {
-    /// #         #[ink(constructor)]
-    /// #         pub fn new() -> Self {
-    /// #             Self {}
-    /// #         }
-    /// #
-    /// #[ink(message)]
-    /// pub fn random_bool(&self) -> bool {
-    ///     let additional_randomness = b"seed";
-    ///     let (hash, _block_number) = self.env().random(additional_randomness);
-    ///     hash.as_ref()[0] != 0
-    /// }
-    /// #
-    /// #     }
-    /// # }
-    /// ```
-    ///
-    /// # Note
-    ///
-    /// For more details visit: [`ink_env::random`]
-    pub fn random(self, subject: &[u8]) -> (E::Hash, E::BlockNumber) {
-        ink_env::random::<E>(subject).expect("couldn't decode randomized hash")
-    }
-
     /// Computes the hash of the given bytes using the cryptographic hash `H`.
     ///
     /// # Example

--- a/crates/ink/tests/ui/contract/pass/env-access.rs
+++ b/crates/ink/tests/ui/contract/pass/env-access.rs
@@ -13,7 +13,6 @@ mod contract {
             let _ = Self::env().caller();
             let _ = Self::env().gas_left();
             let _ = Self::env().minimum_balance();
-            let _ = Self::env().random(&[]);
             let _ = Self::env().transferred_value();
             let _ = Self::env().weight_to_fee(0);
             Self {}
@@ -28,7 +27,6 @@ mod contract {
             let _ = self.env().caller();
             let _ = self.env().gas_left();
             let _ = self.env().minimum_balance();
-            let _ = self.env().random(&[]);
             let _ = self.env().transferred_value();
             let _ = self.env().weight_to_fee(0);
         }


### PR DESCRIPTION
We need to remove away from on-chain randomness. We cannot rely on hosting chains to provide unpredictable randomness. Like on ethereum that should be provided by oracles or maybe a chain extension of a chain has a way to provide randomness. It should not be part of the core API.