### PR TITLE
Remove node log testing from E2E framework

### DIFF
--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -73,7 +73,6 @@ impl InkE2ETest {
         };
 
         let ws_url = &self.test.config.ws_url();
-        let node_log = &self.test.config.node_log();
 
         let mut additional_contracts: Vec<String> =
             self.test.config.additional_contracts();
@@ -144,7 +143,7 @@ impl InkE2ETest {
                     let mut client = ::ink_e2e::Client::<
                         ::ink_e2e::PolkadotConfig,
                         ink::env::DefaultEnvironment
-                    >::new(&#ws_url, &#node_log).await;
+                    >::new(&#ws_url).await;
 
                     let __ret = {
                         #block

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -24,8 +24,6 @@ use ink_ir::{
 /// The End-to-End test configuration.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct E2EConfig {
-    /// The path where the node writes its log.
-    node_log: Option<syn::LitStr>,
     /// The WebSocket URL where to connect with the node.
     ws_url: Option<syn::LitStr>,
     /// The set of attributes that can be passed to call builder in the codegen.
@@ -38,25 +36,12 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
     type Error = syn::Error;
 
     fn try_from(args: ast::AttributeArgs) -> Result<Self, Self::Error> {
-        let mut node_log: Option<(syn::LitStr, ast::MetaNameValue)> = None;
         let mut ws_url: Option<(syn::LitStr, ast::MetaNameValue)> = None;
         let mut whitelisted_attributes = WhitelistedAttributes::default();
         let mut additional_contracts: Option<(syn::LitStr, ast::MetaNameValue)> = None;
 
         for arg in args.into_iter() {
-            if arg.name.is_ident("node_log") {
-                if let Some((_, ast)) = node_log {
-                    return Err(duplicate_config_err(ast, arg, "node_log", "e2e test"))
-                }
-                if let ast::PathOrLit::Lit(syn::Lit::Str(lit_str)) = &arg.value {
-                    node_log = Some((lit_str.clone(), arg))
-                } else {
-                    return Err(format_err_spanned!(
-                        arg,
-                        "expected a path for `node_log` ink! e2e test configuration argument",
-                    ))
-                }
-            } else if arg.name.is_ident("ws_url") {
+            if arg.name.is_ident("ws_url") {
                 if let Some((_, ast)) = ws_url {
                     return Err(duplicate_config_err(ast, arg, "ws_url", "e2e test"))
                 }
@@ -98,7 +83,6 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
             .map(|(value, _)| value.value().split(" ").map(String::from).collect())
             .unwrap_or_else(|| Vec::new());
         Ok(E2EConfig {
-            node_log: node_log.map(|(value, _)| value),
             ws_url: ws_url.map(|(value, _)| value),
             additional_contracts,
             whitelisted_attributes,
@@ -107,14 +91,6 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
 }
 
 impl E2EConfig {
-    /// Returns the path to the node log if specified.
-    /// Otherwise returns the default path `/tmp/contracts-node.log`.
-    pub fn node_log(&self) -> syn::LitStr {
-        let default_node_log =
-            syn::LitStr::new("/tmp/contracts-node.log", proc_macro2::Span::call_site());
-        self.node_log.clone().unwrap_or(default_node_log)
-    }
-
     /// Returns the WebSocket URL where to connect to the RPC endpoint
     /// of the node, if specified. Otherwise returns the default URL
     /// `ws://localhost:9944`.
@@ -199,7 +175,6 @@ mod tests {
                 keep_attr = "foo, bar"
             },
             Ok(E2EConfig {
-                node_log: None,
                 ws_url: None,
                 whitelisted_attributes: attrs,
                 additional_contracts: Vec::new(),

--- a/crates/e2e/macro/src/lib.rs
+++ b/crates/e2e/macro/src/lib.rs
@@ -63,25 +63,6 @@ use syn::Result;
 ///
 ///     **Default value:** `"ws://localhost:9944"`.
 ///
-/// - `node_log: String`
-///
-///     The `node_log` denotes the path under which to find the node's log.
-///
-///     **Usage Example:**
-///     ```no_compile
-///     # // TODO(#xxx) Remove the `no_compile`.
-///     type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
-///     #[ink::e2e_test(ws_url = "ws://localhost:9944")]
-///     async fn e2e_contract_must_transfer_value_to_sender(
-///         mut client: ::ink_e2e::Client<C, E>,
-///     ) -> E2EResult<()> {
-///         assert!(client.node_log_contains("requested value: 100000000000000\n"));
-///         Ok(())
-///     }
-///     ```
-///
-///     **Default value:** `"/tmp/contracts-node.log"`.
-///
 /// # Example
 ///
 /// ```no_compile

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -256,7 +256,6 @@ where
     E: Environment,
 {
     api: ContractsApi<C, E>,
-    node_log: String,
 }
 
 impl<C, E> Client<C, E>
@@ -278,7 +277,7 @@ where
     InstantiateWithCode<E::Balance>: scale::Encode,
 {
     /// Creates a new [`Client`] instance.
-    pub async fn new(url: &str, node_log: &str) -> Self {
+    pub async fn new(url: &str) -> Self {
         let client = subxt::OnlineClient::from_url(url)
             .await
             .unwrap_or_else(|err| {
@@ -290,7 +289,6 @@ where
 
         Self {
             api: ContractsApi::new(client, url).await,
-            node_log: node_log.to_string(),
         }
     }
 
@@ -641,25 +639,6 @@ where
             account_id, alice_pre
         ));
         Ok(alice_pre.data.free)
-    }
-
-    /// Returns true if the `substrate-contracts-node` log under
-    /// `/tmp/contracts-node.log` contains `msg`.
-    /// TODO(#1423) Matches on any log entry currently, even if done
-    /// by a different test.
-    pub fn node_log_contains(&self, msg: &str) -> bool {
-        let output = std::process::Command::new("grep")
-            .arg("-q")
-            .arg(msg)
-            .arg(&self.node_log)
-            .spawn()
-            .map_err(|err| {
-                format!("ERROR while executing `grep` with {:?}: {:?}", msg, err)
-            })
-            .expect("failed to execute process")
-            .wait_with_output()
-            .expect("failed to receive output");
-        output.status.success()
     }
 
     /// Fetches the next system account index for `signer.account_id()`

--- a/examples/contract-transfer/lib.rs
+++ b/examples/contract-transfer/lib.rs
@@ -240,7 +240,7 @@ pub mod give_me {
 
             // when
             let transfer = contract_transfer::messages::give_me(120);
-            let _ = client
+            let call_res = client
                 .call(
                     &mut ink_e2e::eve(),
                     contract_acc_id.clone(),
@@ -252,6 +252,11 @@ pub mod give_me {
                 .expect("call failed");
 
             // then
+            let contains_debug_println =
+                String::from_utf8_lossy(&call_res.dry_run.debug_message)
+                    .contains("requested value: 120\n");
+            assert!(contains_debug_println);
+
             let balance_after: Balance = client
                 .balance(contract_acc_id)
                 .await

--- a/examples/contract-transfer/lib.rs
+++ b/examples/contract-transfer/lib.rs
@@ -257,7 +257,6 @@ pub mod give_me {
                 .await
                 .expect("getting balance failed");
             assert_eq!(balance_before - balance_after, 120);
-            assert!(client.node_log_contains("requested value: 100000000000000\n"));
 
             Ok(())
         }


### PR DESCRIPTION
Removing the `node_log_contains` command for the reasons outlined in https://github.com/paritytech/ink/issues/1423.