### PR TITLE
Release `v3.4.0`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,15 @@
 # [Unreleased]
 
+# Version 3.4
+
+We keep ink! v3 updated with nice features and fixes from the `master` branch.
+
+This release:
+
+- Inroduces the `ink_env::pay_with_call!` helper macro for the emulation of invoking payble messages in off-chain tests.
+  As response to ink! developers request on our [SE](https://substrate.stackexchange.com/a/4793/472).
+- Fixes contracts compilation error with the latest Rust +nightly [#1417](https://github.com/paritytech/ink/issues/1417) (thanks [@xgreenx](https://github.com/xgreenx)).
+
 # Version 3.3.1
 
 At the moment teams which use both Substrate and ink! in the same codebase are

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,10 +7,10 @@ We keep ink! v3 updated with nice features and fixes from the `master` branch.
 This release:
 
 - Introduces the `ink_env::pay_with_call!` helper macro for the emulation of invoking payble messages in off-chain tests.
-  As response to ink! developers request on our [SE](https://substrate.stackexchange.com/a/4793/472).
-- Fixes contracts compilation error with the latest Rust +nightly [#1417](https://github.com/paritytech/ink/issues/1417) (thanks [@xgreenx](https://github.com/xgreenx)).
+  As response to ink! developers request on the [ Substrate StackExchange](https://substrate.stackexchange.com/a/4793/472).
+- Fixes contracts compilation error with the latest Rust `+nightly`  ‒ [#1417](https://github.com/paritytech/ink/issues/1417) (thanks [@xgreenx](https://github.com/xgreenx)).
 
-See the back portation PR[#1439](https://github.com/paritytech/ink/pull/1439) for details.
+See the back portation PR [#1439](https://github.com/paritytech/ink/pull/1439) for details.
 
 # Version 3.3.1
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # [Unreleased]
 
-# Version 3.4
+# Version 3.4.0
 
 We keep ink! v3 updated with nice features and fixes from the `master` branch.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,9 +6,11 @@ We keep ink! v3 updated with nice features and fixes from the `master` branch.
 
 This release:
 
-- Inroduces the `ink_env::pay_with_call!` helper macro for the emulation of invoking payble messages in off-chain tests.
+- Introduces the `ink_env::pay_with_call!` helper macro for the emulation of invoking payble messages in off-chain tests.
   As response to ink! developers request on our [SE](https://substrate.stackexchange.com/a/4793/472).
 - Fixes contracts compilation error with the latest Rust +nightly [#1417](https://github.com/paritytech/ink/issues/1417) (thanks [@xgreenx](https://github.com/xgreenx)).
+
+See the back portation PR[#1439](https://github.com/paritytech/ink/pull/1439) for details.
 
 # Version 3.3.1
 

--- a/RELEASES_CHECKLIST.md
+++ b/RELEASES_CHECKLIST.md
@@ -5,7 +5,7 @@ mono-repository in lockstep.
 It does not matter if it's a `PATCH`, `MINOR`, `MAJOR` release.
 
 Reasons for doing it this way:
-* Keeps our [`RELEASES.md`](https://github.com/paritytech/ink/blob/master/RELEASES.md)
+* Keeps our [`RELEASES.md`](https://github.com/paritytech/ink/blob/v3.x.x/RELEASES.md)
   simple and easy to grasp.<br>
   We can still bundle all changes there together and don't have to go to a
   more fine-grained crate level.
@@ -31,7 +31,15 @@ crates.io.
 
 ## Checklist
 
-1. Create a new feature branch of `master`.
+We'll be using [`cargo-release`](https://github.com/crate-ci/cargo-release) to release 
+ink!. There are still a few manual steps though, and we hope to make this more streamlined 
+in the future.
+
+1. Create a new feature branch off `v3.x.x`.
+1. Copy the release notes that appear in the [`RELEASES.md`](https://github.com/paritytech/ink/blob/v3.x.x/RELEASES.md) 
+   into the PR description.
+   - This will cause the individual PRs to be linked to the release in which they are 
+     included.
 1. Bump the version in all TOML files to the new version.
     ```
     find . -type f -name *.toml -exec sed -i -e 's/$OLD_VERSION/$NEW_VERSION/g' {} \;
@@ -40,29 +48,54 @@ crates.io.
    section for the release.
 1. Check that all notable PRs since the last release are now in the new release section,
    in case the `[Unreleased]` section was incomplete.<br>
-   Notable changes are changes that affect users in some way. This means that something
-   like a change to our CI pipeline is likely not notable and should not be included.
-1. Make sure you've merged the latest `master` into your branch.
+   - Notable changes are changes that affect users in some way. This means that something
+     like a change to our CI pipeline is likely not notable and should not be included.
+1. Make sure you've merged the latest `v3.x.x` into your branch.
 1. Open a release PR
-    1. Wait for approvals from Core team members
-    1. Ensure the entire CI pipeline is green
-1. Execute `cargo unleash em-dragons --dry-run` in the ink! repository.
-1. If successful, execute `cargo unleash em-dragons`.<br>
-   In some versions of `cargo-unleash` there is a bug during publishing.
-   If this is the case you need to do it manually, by executing `cargo publish --allow-dirty`
-   for the individual crates. The `--allow-dirty` is necessary because `cargo-unleash`
-   will have removed all `[dev-dependencies]`.
-1. Merge the PR into `master` if everything went fine.
-   We do this _after_ publishing since the publishing step can fail and we want to ensure
-   that what gets merged into `master` is what actually got published.
+    - Wait for approvals from Core team members.
+    - Ensure the entire CI pipeline is green.
+1. Do a dry run with `cargo release [new_version] -v --no-tag --no-push`
+    - `[new_version]` should be the **exact** SemVer compatible version you are attempting 
+      to release e.g. `4.0.0-alpha.3`
+      - It is possible to supply a SemVer level here e.g. `major`, `minor`, `patch` or 
+        `<pre-release-name>`, however this will automatically bump and commit the changes 
+        to the `Cargo.toml` manifests. We have already done that in an earlier step so it 
+        is not necessary.
+    - We don't want `cargo-release` to create any releases or push any code, we'll do
+      that manually once we've actually published to `crates.io`.
+1. Check the output of the dry run:
+   - Does not show any automatic bumping of crate versions.
+   - Runs without error.
+1. Following a successful dry run, we can now publish to crates.io.
+   - This will be done from the release branch itself.
+   - This is because it is possible for the dry run to succeed but for the actual publish 
+     to fail and require some changes. So before running the next step:
+     - Ensure there have been no new commits to `v3.x.x` which are not included in this 
+       branch.
+     - Notify core team members in the Element channel that no PRs should be merged to 
+       `v3.x.x` during the release.
+     - The above are to ensure that the bundled code pushed to crates.io is the same as 
+       the tagged release on GitHub.
+1. Publish with `export PUBLISH_GRACE_SLEEP=5 && cargo release [new_version] -v --no-tag --no-push --execute`
+    - Ensure the same `[new_version]` as the dry run, which should be the **exact** SemVer 
+      compatible version you are attempting to release e.g. `4.0.0-alpha.3`.
+    - We add the grace period since crates depend on one another.
+    - We add the `--execute` flag to _actually_ publish things to crates.io.
+1. Following a successful release from the release PR branch, now the PR can be merged 
+   into `v3.x.x`
+    - Once merged, notify core team members in the Element channel that PRs can be merged 
+      again into `v3.x.x`
 1. Replace `vX.X.X` with the new version in the following command and then execute it:
     ```
-    git checkout master && git pull && git tag vX.X.X && git push origin vX.X.X
+    git tag -s vX.X.X && git push origin vX.X.X
     ```
+    - Ensure your tag is signed with an offline GPG key!
+    - Alternatively, the `Create release` GitHub UI below allows creating this tag when 
+      creating the release.
 1. Create a GitHub release for this tag. In the [tag overview](https://github.com/paritytech/ink/tags)
-   you'll see your new tag appear. Click the `…` on the right of the tag and then `Create release`.
-1. Paste the release notes that appear in the [`RELEASES.md`](https://github.com/paritytech/ink/blob/master/RELEASES.md)
+   you'll see your new tag appear. Click the `…` on the right of the tag and then 
+   `Create release`.
+1. Paste the release notes that appear in the [`RELEASES.md`](https://github.com/paritytech/ink/blob/v3.x.x/RELEASES.md)
    there. The title of the release should be `vX.X.X`.
 1. Post an announcement to those Element channels:
     * [Smart Contracts & Parity ink!](https://matrix.to/#/#ink:matrix.parity.io)
-    * [ink! Announcements](https://matrix.to/#/#ink-announcements:matrix.parity.io)

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_allocator"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_engine"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Michael Müller <michi@parity.io>"]
 edition = "2021"
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_env"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,10 +15,10 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "3.3.1", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_allocator = { version = "3.3.1", path = "../allocator/", default-features = false }
-ink_primitives = { version = "3.3.1", path = "../primitives/", default-features = false }
-ink_prelude = { version = "3.3.1", path = "../prelude/", default-features = false }
+ink_metadata = { version = "3.4.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_allocator = { version = "3.4.0", path = "../allocator/", default-features = false }
+ink_primitives = { version = "3.4.0", path = "../primitives/", default-features = false }
+ink_prelude = { version = "3.4.0", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -32,7 +32,7 @@ static_assertions = "1.1"
 rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ink_engine = { version = "3.3.1", path = "../engine/", optional = true }
+ink_engine = { version = "3.4.0", path = "../engine/", optional = true }
 
 # Hashes for the off-chain environment.
 sha2 = { version = "0.10", optional = true }

--- a/crates/eth_compatibility/Cargo.toml
+++ b/crates/eth_compatibility/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_eth_compatibility"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_env = { version = "3.3.1", path = "../env", default-features = false }
+ink_env = { version = "3.4.0", path = "../env", default-features = false }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # We do not include `libsecp256k1` on Windows, since it's incompatible.

--- a/crates/lang/Cargo.toml
+++ b/crates/lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,19 +15,19 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "3.3.1", path = "../env", default-features = false }
-ink_storage = { version = "3.3.1", path = "../storage", default-features = false }
-ink_primitives = { version = "3.3.1", path = "../primitives", default-features = false }
-ink_metadata = { version = "3.3.1", path = "../metadata", default-features = false, optional = true }
-ink_prelude = { version = "3.3.1", path = "../prelude", default-features = false }
-ink_lang_macro = { version = "3.3.1", path = "macro", default-features = false }
+ink_env = { version = "3.4.0", path = "../env", default-features = false }
+ink_storage = { version = "3.4.0", path = "../storage", default-features = false }
+ink_primitives = { version = "3.4.0", path = "../primitives", default-features = false }
+ink_metadata = { version = "3.4.0", path = "../metadata", default-features = false, optional = true }
+ink_prelude = { version = "3.4.0", path = "../prelude", default-features = false }
+ink_lang_macro = { version = "3.4.0", path = "macro", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 
 [dev-dependencies]
-ink_lang_ir = { version = "3.3.1", path = "ir" }
-ink_metadata = { version = "3.3.1", default-features = false, path = "../metadata" }
+ink_lang_ir = { version = "3.4.0", path = "ir" }
+ink_metadata = { version = "3.4.0", default-features = false, path = "../metadata" }
 
 trybuild = { version = "1.0.60", features = ["diff"] }
 # Required for the doctest of `env_access::EnvAccess::instantiate_contract`

--- a/crates/lang/codegen/Cargo.toml
+++ b/crates/lang/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_codegen"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -18,7 +18,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 name = "ink_lang_codegen"
 
 [dependencies]
-ir = { version = "3.3.1", package = "ink_lang_ir", path = "../ir", default-features = false }
+ir = { version = "3.4.0", package = "ink_lang_ir", path = "../ir", default-features = false }
 quote = "1"
 syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = "1.0"

--- a/crates/lang/ir/Cargo.toml
+++ b/crates/lang/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_ir"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/lang/macro/Cargo.toml
+++ b/crates/lang/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_lang_macro"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,19 +15,19 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_lang_ir = { version = "3.3.1", path = "../ir", default-features = false }
-ink_lang_codegen = { version = "3.3.1", path = "../codegen", default-features = false }
-ink_primitives = { version = "3.3.1", path = "../../primitives/", default-features = false }
+ink_lang_ir = { version = "3.4.0", path = "../ir", default-features = false }
+ink_lang_codegen = { version = "3.4.0", path = "../codegen", default-features = false }
+ink_primitives = { version = "3.4.0", path = "../../primitives/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 syn = "1"
 proc-macro2 = "1"
 
 [dev-dependencies]
-ink_metadata = { version = "3.3.1", path = "../../metadata/" }
-ink_env = { version = "3.3.1", path = "../../env/" }
-ink_storage = { version = "3.3.1", path = "../../storage/" }
-ink_lang = { version = "3.3.1", path = ".." }
+ink_metadata = { version = "3.4.0", path = "../../metadata/" }
+ink_env = { version = "3.4.0", path = "../../env/" }
+ink_storage = { version = "3.4.0", path = "../../storage/" }
+ink_lang = { version = "3.4.0", path = ".." }
 scale-info = { version = "2", default-features = false, features = ["derive"] }
 
 [lib]

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_metadata"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,8 +15,8 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "3.3.1", path = "../prelude/", default-features = false }
-ink_primitives = { version = "3.3.1", path = "../primitives/", default-features = false }
+ink_prelude = { version = "3.4.0", path = "../prelude/", default-features = false }
+ink_primitives = { version = "3.4.0", path = "../primitives/", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.3.1"

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_prelude"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_primitives"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "3.3.1", path = "../prelude/", default-features = false }
+ink_prelude = { version = "3.4.0", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "3.3.1", path = "../env/", default-features = false }
-ink_metadata = { version = "3.3.1", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "3.3.1", path = "../primitives/", default-features = false }
-ink_storage_derive = { version = "3.3.1", path = "derive", default-features = false }
-ink_prelude = { version = "3.3.1", path = "../prelude/", default-features = false }
+ink_env = { version = "3.4.0", path = "../env/", default-features = false }
+ink_metadata = { version = "3.4.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "3.4.0", path = "../primitives/", default-features = false }
+ink_storage_derive = { version = "3.4.0", path = "derive", default-features = false }
+ink_prelude = { version = "3.4.0", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -33,7 +33,7 @@ quickcheck_macros = "1.0"
 itertools = "0.10"
 paste = "1.0"
 
-ink_lang = { version = "3.3.1", path = "../lang/", default-features = false }
+ink_lang = { version = "3.4.0", path = "../lang/", default-features = false }
 
 [features]
 default = ["std"]

--- a/crates/storage/derive/Cargo.toml
+++ b/crates/storage/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage_derive"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -25,8 +25,8 @@ synstructure = "0.12.4"
 
 [dev-dependencies]
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
-ink_env = { version = "3.3.1", path = "../../env" }
-ink_primitives = { version = "3.3.1", path = "../../primitives" }
-ink_metadata = { version = "3.3.1", path = "../../metadata" }
-ink_prelude = { version = "3.3.1", path = "../../prelude/" }
-ink_storage = { version = "3.3.1", path = ".." }
+ink_env = { version = "3.4.0", path = "../../env" }
+ink_primitives = { version = "3.4.0", path = "../../primitives" }
+ink_metadata = { version = "3.4.0", path = "../../metadata" }
+ink_prelude = { version = "3.4.0", path = "../../prelude/" }
+ink_storage = { version = "3.4.0", path = ".." }

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_terminate"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_transfer"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegator"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulator"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adder"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subber"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc1155"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc20"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc721"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_extension"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_erc20"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_flipper"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/Cargo.toml
+++ b/examples/trait-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/traits/Cargo.toml
+++ b/examples/trait-incrementer/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traits"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/delegate-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/delegate-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegate_calls"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
+++ b/examples/upgradeable-contracts/delegate-calls/upgradeable-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upgradeable_flipper"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/forward-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/forward-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forward_calls"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "3.3.1"
+version = "3.4.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated-incrementer"
-version = "3.3.1"
+version = "3.4.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false


### PR DESCRIPTION
We keep ink! v3 updated with nice features and fixes from the `master` branch.

This release:

- Introduces the `ink_env::pay_with_call!` helper macro for the emulation of invoking payble messages in off-chain tests.
  As response to ink! developers request on our [SE](https://substrate.stackexchange.com/a/4793/472).
- Fixes contracts compilation error with the latest Rust +nightly [#1417](https://github.com/paritytech/ink/issues/1417) (thanks [@xgreenx](https://github.com/xgreenx)).

See the back portation PR[#1439](https://github.com/paritytech/ink/pull/1439) for details.