### PR TITLE
Fix ink-waterfall CI for the `v3.x.x` branch (needs cargo-contract 1.5.0)

### DIFF
--- a/scripts/ci/trigger_pipeline.sh
+++ b/scripts/ci/trigger_pipeline.sh
@@ -18,7 +18,7 @@ echo "https://${CI_SERVER_HOST}/api/v4/projects/${DWNSTRM_ID}/trigger/pipeline"
 curl --silent \
     -X POST \
     -F "token=${CI_JOB_TOKEN}" \
-    -F "ref=master" \
+    -F "ref=37" \
     -F "variables[TRGR_PROJECT]=${TRGR_PROJECT}" \
     -F "variables[TRGR_REF]=${TRGR_REF}" \
     "https://${CI_SERVER_HOST}/api/v4/projects/${DWNSTRM_ID}/trigger/pipeline" | \


### PR DESCRIPTION
Currently ink-waterfall CI fails on the v3.x.x branch because it uses ink-waterfall-ci latest image with new cargo-contract v2, which is incompatible with ink v3. 

By this PR, we make the script to trigger pipeline for the ink-waterfall [branch which uses proper ci image](https://github.com/paritytech/ink-waterfall/blob/v3.x.x/.gitlab-ci.yml#L18).