### PR TITLE
Remove `--skip-linting` flag

### DIFF
--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -175,7 +175,6 @@ fn build_contract(manifest_path: &str) -> String {
             "+stable",
             "contract",
             "build",
-            "--skip-linting",
             "--output-json",
             &format!("--manifest-path={}", manifest_path),
         ])


### PR DESCRIPTION
Fixes CI pipeline by removing `--skip-linting` flag that was replaced with optional lint flag `--lint` in https://github.com/paritytech/cargo-contract/pull/799 