### PR TITLE
replaces .expect() with .unwrap_or_else()

### DIFF
--- a/crates/engine/src/database.rs
+++ b/crates/engine/src/database.rs
@@ -114,8 +114,9 @@ impl Database {
     pub fn get_balance(&self, account_id: &[u8]) -> Option<Balance> {
         let hashed_key = balance_of_key(account_id);
         self.get(&hashed_key).map(|encoded_balance| {
-            scale::Decode::decode(&mut &encoded_balance[..])
-                .expect("unable to decode balance from database")
+            scale::Decode::decode(&mut &encoded_balance[..]).unwrap_or_else(|err| {
+                panic!("unable to decode balance from database. Reason: {}", err)
+            })
         })
     }
 

--- a/crates/env/src/chain_extension.rs
+++ b/crates/env/src/chain_extension.rs
@@ -382,7 +382,7 @@ where
                 ErrorCode::from_status_code,
                 |mut output| {
                     let decoded = <O as scale::Decode>::decode(&mut output)
-                        .expect("encountered error while decoding chain extension method call return value");
+                        .unwrap_or_else(|err| panic!("encountered error while decoding chain extension method call return value: {}", err));
                     Ok(decoded)
                 },
             )
@@ -431,10 +431,10 @@ where
                 |_status_code| Ok(()),
                 |mut output| {
                     let decoded = <O as scale::Decode>::decode(&mut output)
-                        .expect("encountered error while decoding chain extension method call return value");
+                        .unwrap_or_else(|err| panic!("encountered error while decoding chain extension method call return value: {}", err));
                     Ok(decoded)
                 },
-            ).expect("assume the chain extension method never fails")
+            ).unwrap_or_else(|err| panic!("assume the chain extension method never fails, but there's a first time for anything{:?}", err))
         })
     }
 }

--- a/crates/env/src/engine/e2e/client.rs
+++ b/crates/env/src/engine/e2e/client.rs
@@ -316,7 +316,7 @@ where
 
         let salt = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .expect("unable to get unix time")
+            .unwrap_or_else(|err| panic!("unable to get unix time. Reason: {}", err))
             .as_millis()
             .as_u128()
             .to_le_bytes()
@@ -520,9 +520,9 @@ where
             .map_err(|err| {
                 format!("ERROR while executing `grep` with {:?}: {:?}", msg, err)
             })
-            .expect("failed to execute process")
+            .unwrap_or_else(|err| panic!("failed to execute process. Reason: {}", err))
             .wait_with_output()
-            .expect("failed to receive output");
+            .unwrap_or_else(|err| panic!("failed to receive output. Reason: {}", err));
         output.status.success()
     }
 }

--- a/crates/env/src/engine/e2e/xts.rs
+++ b/crates/env/src/engine/e2e/xts.rs
@@ -145,8 +145,8 @@ where
             WsClientBuilder::default()
                 .build(&url)
                 .await
-                .unwrap_or_else(|err| {
-                    panic!("error on ws request: {:?}", err);
+                .unwrap_or_else(|error| {
+                    panic!("error on ws request: {:?}", error);
                 });
 
         Self {
@@ -182,10 +182,11 @@ where
             .ws_client
             .request("state_call", params)
             .await
-            .unwrap_or_else(|err| {
-                panic!("error on ws request `contracts_instantiate`: {:?}", err);
+            .unwrap_or_else(|error| {
+                panic!("error on ws request `contracts_instantiate`: {:?}", error);
             });
-        scale::Decode::decode(&mut bytes.as_ref()).expect("decoding failed")
+        scale::Decode::decode(&mut bytes.as_ref())
+            .unwrap_or_else(|err| panic!("decoding failed. Reason: {}", err))
     }
 
     /// Submits an extrinsic to instantiate a contract with the given code.
@@ -229,10 +230,10 @@ where
                 ));
                 tx_progress
             })
-            .unwrap_or_else(|err| {
+            .unwrap_or_else(|error| {
                 panic!(
                     "error on call `sign_and_submit_then_watch_default`: {:?}",
-                    err
+                    error
                 );
             })
             .wait_for_in_block()
@@ -272,7 +273,8 @@ where
             .unwrap_or_else(|err| {
                 panic!("error on ws request `contracts_call`: {:?}", err);
             });
-        scale::Decode::decode(&mut bytes.as_ref()).expect("decoding failed")
+        scale::Decode::decode(&mut bytes.as_ref())
+            .unwrap_or_else(|err| panic!("decoding failed. Reason: {}", err))
     }
 
     /// Submits an extrinsic to call a contract with the given parameters.

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -170,7 +170,8 @@ where
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         let callee = instance.engine.get_callee();
-        scale::Decode::decode(&mut &callee[..]).expect("encoding failed")
+        scale::Decode::decode(&mut &callee[..])
+            .unwrap_or_else(|err| panic!("encoding failed. Reason: {}", err))
     })
 }
 
@@ -388,10 +389,11 @@ pub fn assert_contract_termination<T, F>(
         .downcast_ref::<Vec<u8>>()
         .expect("panic object can not be cast");
     let (value_transferred, encoded_beneficiary): (T::Balance, Vec<u8>) =
-        scale::Decode::decode(&mut &encoded_input[..]).expect("input can not be decoded");
+        scale::Decode::decode(&mut &encoded_input[..])
+            .unwrap_or_else(|err| panic!("input can not be decoded. Reason: {}", err));
     let beneficiary =
         <T::AccountId as scale::Decode>::decode(&mut &encoded_beneficiary[..])
-            .expect("input can not be decoded");
+            .unwrap_or_else(|err| panic!("input can not be decoded. Reason: {}", err));
     assert_eq!(value_transferred, expected_value_transferred_to_beneficiary);
     assert_eq!(beneficiary, expected_beneficiary);
 }

--- a/crates/ink/codegen/src/generator/ink_e2e_test.rs
+++ b/crates/ink/codegen/src/generator/ink_e2e_test.rs
@@ -117,7 +117,7 @@ impl GenerateCode for InkE2ETest<'_> {
 
                 let json = String::from_utf8_lossy(&output.stdout);
                 let metadata: serde_json::Value =
-                    serde_json::from_str(&json).expect("cannot convert json to utf8");
+                    serde_json::from_str(&json).unwrap_or_else(|err| panic!("cannot convert json to utf8. Reason: {}", err));
                 let mut dest_metadata =
                     metadata["metadata_result"]["dest_bundle"].to_string();
                 dest_metadata = dest_metadata.trim_matches('"').to_string();

--- a/crates/ink/codegen/src/generator/storage_item.rs
+++ b/crates/ink/codegen/src/generator/storage_item.rs
@@ -234,7 +234,12 @@ fn convert_into_storage_field(
         variant_name.as_str(),
         field_name.as_str(),
     )
-    .expect("unable to compute the storage key for the field");
+    .unwrap_or_else(|err| {
+        panic!(
+            "unable to compute the storage key for the field. Reason: {:?}",
+            err
+        )
+    });
 
     let mut new_field = field.clone();
     let ty = field.ty.clone().to_token_stream();

--- a/crates/ink/ir/src/ir/chain_extension.rs
+++ b/crates/ink/ir/src/ir/chain_extension.rs
@@ -37,7 +37,7 @@ impl ChainExtension {
     /// Returns the Rust attributes of the ink! chain extension.
     pub fn attrs(&self) -> Vec<syn::Attribute> {
         let (_, attrs) = ir::partition_attributes(self.item.attrs.iter().cloned())
-            .expect("encountered unexpected invalid attributes for ink! chain extension");
+            .unwrap_or_else(|err| panic!("encountered unexpected invalid attributes for ink! chain extension: {}", err));
         attrs
     }
 
@@ -278,7 +278,7 @@ impl ChainExtension {
                 item_type.ident,
                 "chain extensions expect an associated type with name `ErrorCode` but found {}",
                 item_type.ident,
-            ))
+            ));
         }
         if !item_type.generics.params.is_empty() {
             return Err(format_err_spanned!(
@@ -412,7 +412,7 @@ impl ChainExtension {
             return Err(format_err_spanned!(
                 default_impl,
                 "ink! chain extension methods with default implementations are not supported"
-            ))
+            ));
         }
         if let Some(constness) = &method.sig.constness {
             return Err(format_err_spanned!(

--- a/crates/ink/ir/src/ir/e2e_config.rs
+++ b/crates/ink/ir/src/ir/e2e_config.rs
@@ -53,7 +53,7 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
                     return Err(format_err_spanned!(
                         arg,
                         "expected a path for `node_log` ink! e2e test configuration argument",
-                    ))
+                    ));
                 }
             } else if arg.name.is_ident("ws_url") {
                 if let Some((_, ast)) = ws_url {
@@ -65,7 +65,7 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
                     return Err(format_err_spanned!(
                         arg,
                         "expected a string literal for `ws_url` ink! e2e test configuration argument",
-                    ))
+                    ));
                 }
             } else if arg.name.is_ident("skip_build") {
                 if let Some((_, ast)) = skip_build {
@@ -77,7 +77,7 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
                     return Err(format_err_spanned!(
                         arg,
                         "expected a bool literal for `skip_build` ink! e2e test configuration argument",
-                    ))
+                    ));
                 }
             } else if arg.name.is_ident("keep_attr") {
                 whitelisted_attributes.parse_arg_value(&arg)?;

--- a/crates/ink/ir/src/ir/item/event.rs
+++ b/crates/ink/ir/src/ir/item/event.rs
@@ -112,7 +112,7 @@ impl TryFrom<syn::ItemStruct> for Event {
                 return Err(format_err!(
                     field_span,
                     "first optional ink! attribute of an event field must be #[ink(topic)]",
-                ))
+                ));
             }
             for arg in normalized.args() {
                 if !matches!(arg.kind(), ir::AttributeArg::Topic) {
@@ -169,7 +169,9 @@ impl<'a> EventField<'a> {
     /// Returns all non-ink! attributes of the event field.
     pub fn attrs(self) -> Vec<syn::Attribute> {
         let (_, non_ink_attrs) = ir::partition_attributes(self.field.attrs.clone())
-            .expect("encountered invalid event field attributes");
+            .unwrap_or_else(|err| {
+                panic!("encountered invalid event field attributes: {}", err)
+            });
         non_ink_attrs
     }
 

--- a/crates/ink/ir/src/ir/item_impl/mod.rs
+++ b/crates/ink/ir/src/ir/item_impl/mod.rs
@@ -309,7 +309,7 @@ impl TryFrom<syn::ItemImpl> for ItemImpl {
             return Err(format_err!(
                 impl_block_span,
                 "namespace ink! property is not allowed on ink! trait implementation blocks",
-            ))
+            ));
         }
         Ok(Self {
             attrs: other_attrs,

--- a/crates/ink/ir/src/ir/item_mod.rs
+++ b/crates/ink/ir/src/ir/item_mod.rs
@@ -263,7 +263,7 @@ impl ItemMod {
                         .into_combine(format_err!(
                             overlap.span(),
                             "first ink! message with overlapping wildcard selector here",
-                        )))
+                        )));
                     }
                 }
             }
@@ -283,7 +283,7 @@ impl ItemMod {
                             .into_combine(format_err!(
                             overlap.span(),
                             "first ink! constructor with overlapping wildcard selector here",
-                        )))
+                        )));
                     }
                 }
             }

--- a/crates/ink/ir/src/ir/trait_def/item/mod.rs
+++ b/crates/ink/ir/src/ir/trait_def/item/mod.rs
@@ -349,7 +349,12 @@ impl InkItemTrait {
                 }
             },
         )
-        .expect("encountered unexpected invalid attributes on ink! trait definition");
+        .unwrap_or_else(|err| {
+            panic!(
+                "encountered unexpected invalid attributes on ink! trait definition: {}",
+                err
+            )
+        });
         let namespace = config.namespace();
         let ident = &item_trait.ident;
         let trait_prefix = TraitPrefix::new(ident, namespace);
@@ -380,7 +385,7 @@ impl InkItemTrait {
                 ).into_combine(format_err_spanned!(
                     duplicate_selector,
                     "first ink! trait constructor or message with same selector found here",
-                )))
+                )));
             }
             assert!(
                 duplicate_ident.is_none(),

--- a/crates/ink/macro/src/lib.rs
+++ b/crates/ink/macro/src/lib.rs
@@ -932,7 +932,7 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///             None,
 ///         )
 ///         .await
-///         .expect("instantiating contract failed")
+///         .unwrap_or_else(|err| panic!("instantiating contract failed. Reason: {:?}", err))
 ///         .account_id;
 ///
 ///         // when

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -859,7 +859,7 @@ impl TypeSpec {
         Self {
             ty: meta_type::<T>(),
             display_name: DisplayName::from_segments(segments)
-                .expect("display name is invalid"),
+                .unwrap_or_else(|err| panic!("display name is invalid: {:?}", err)),
         }
     }
 

--- a/examples/contract-transfer/lib.rs
+++ b/examples/contract-transfer/lib.rs
@@ -176,7 +176,7 @@ pub mod give_me {
             ink::env::test::get_account_balance::<ink::env::DefaultEnvironment>(
                 account_id,
             )
-            .expect("Cannot get account balance")
+            .unwrap_or_else(|err| panic!("Cannot get account balance: {}", err))
         }
     }
 
@@ -196,7 +196,7 @@ pub mod give_me {
             let contract_acc_id = client
                 .instantiate(&mut ink::env::e2e::alice(), constructor, 1000, None)
                 .await
-                .expect("instantiate failed")
+                .unwrap_or_else(|err| panic!("instantiate failed: {}", err))
                 .account_id;
 
             // when
@@ -233,12 +233,12 @@ pub mod give_me {
             let contract_acc_id = client
                 .instantiate(&mut ink::env::e2e::bob(), constructor, 1337, None)
                 .await
-                .expect("instantiate failed")
+                .unwrap_or_else(|err| panic!("instantiate failed: {}", err))
                 .account_id;
             let balance_before: Balance = client
                 .balance(contract_acc_id.clone())
                 .await
-                .expect("getting balance failed");
+                .unwrap_or_else(|err| panic!("getting balance failed: {}", err));
 
             // when
             let transfer = contract_transfer::messages::give_me(120);
@@ -251,13 +251,13 @@ pub mod give_me {
                     None,
                 )
                 .await
-                .expect("call failed");
+                .unwrap_or_else(|err| panic!("call failed: {}", err));
 
             // then
             let balance_after: Balance = client
                 .balance(contract_acc_id)
                 .await
-                .expect("getting balance failed");
+                .expectunwrap_or_else(|err| panic!("getting balance failed: {}", err));
             assert_eq!(balance_before - balance_after, 120);
             assert!(client.node_log_contains("requested value: 100000000000000\n"));
 

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -319,7 +319,7 @@ mod erc1155 {
             let mut sender_balance = self
                 .balances
                 .get(&(from, token_id))
-                .expect("Caller should have ensured that `from` holds `token_id`.");
+                .unwrap_or_else(|err| panic!("Caller should have ensured that `from` holds `token_id`. {}", err));
             sender_balance -= value;
             self.balances.insert(&(from, token_id), &sender_balance);
 

--- a/examples/erc20/lib.rs
+++ b/examples/erc20/lib.rs
@@ -228,7 +228,7 @@ mod erc20 {
             expected_value: Balance,
         ) {
             let decoded_event = <Event as scale::Decode>::decode(&mut &event.data[..])
-                .expect("encountered invalid contract event data buffer");
+                .unwrap_or_else(|err| panic!("encountered invalid contract event data buffer: {}", err));
             if let Event::Transfer(Transfer { from, to, value }) = decoded_event {
                 assert_eq!(from, expected_from, "encountered invalid Transfer.from");
                 assert_eq!(to, expected_to, "encountered invalid Transfer.to");

--- a/examples/erc721/lib.rs
+++ b/examples/erc721/lib.rs
@@ -344,7 +344,7 @@ mod erc721 {
             let caller = self.env().caller();
             let owner = self.owner_of(id);
             if !(owner == Some(caller)
-                || self.approved_for_all(owner.expect("Error with AccountId"), caller))
+                || self.approved_for_all(owner.unwrap_or_else(|err| panic!("Error with AccountId: {}", err)), caller))
             {
                 return Err(Error::NotAllowed)
             };
@@ -391,8 +391,8 @@ mod erc721 {
                 && (from == owner
                     || from == self.token_approvals.get(&id)
                     || self.approved_for_all(
-                        owner.expect("Error with AccountId"),
-                        from.expect("Error with AccountId"),
+                        owner.unwrap_or_else(|err| panic!("Error with AccountId: {}", err)),
+                        from.unwrap_or_else(|err| panic!("Error with AccountId: {}", err)),
                     ))
         }
 

--- a/examples/mother/lib.rs
+++ b/examples/mother/lib.rs
@@ -202,7 +202,7 @@ mod mother {
             );
             contract
                 .revert_or_trap(None)
-                .expect("Contract unexpected failure!");
+                .unwrap_or_else(|err| panic!("Contract unexpected failure! {}", err));
         }
 
         #[ink::test]

--- a/examples/payment-channel/lib.rs
+++ b/examples/payment-channel/lib.rs
@@ -267,7 +267,7 @@ mod payment_channel {
 
             let mut pub_key = [0; 33];
             ink::env::ecdsa_recover(&signature, &message, &mut pub_key)
-                .expect("recover failed");
+                .unwrap_or_else(|err| panic!("recover failed: {}", err));
             let mut signature_account_id = [0; 32];
             <ink::env::hash::Blake2x256 as ink::env::hash::CryptoHash>::hash(
                 &pub_key,
@@ -305,7 +305,7 @@ mod payment_channel {
 
         fn get_account_balance(account: AccountId) -> Balance {
             ink::env::test::get_account_balance::<ink::env::DefaultEnvironment>(account)
-                .expect("Cannot get account balance")
+                .unwrap_or_else(|err| panic!("Cannot get account balance: {}", err))
         }
 
         fn advance_block() {
@@ -315,7 +315,7 @@ mod payment_channel {
         fn get_current_time() -> Timestamp {
             let since_the_epoch = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .expect("Time went backwards");
+                .unwrap_or_else(|err| panic!("Time went backwards: {}", err));
             since_the_epoch.as_secs()
                 + since_the_epoch.subsec_nanos() as u64 / 1_000_000_000
         }
@@ -330,7 +330,7 @@ mod payment_channel {
             let pub_key = pair.public();
             let compressed_pub_key: [u8; 33] = pub_key.encode()[..]
                 .try_into()
-                .expect("slice with incorrect length");
+                .unwrap_or_else(|err| panic!("slice with incorrect length: {}", err));
             let mut account_id = [0; 32];
             <ink::env::hash::Blake2x256 as ink::env::hash::CryptoHash>::hash(
                 &compressed_pub_key,
@@ -465,7 +465,7 @@ mod payment_channel {
             let signature = sign(contract_id, amount);
             payment_channel
                 .withdraw(amount, signature)
-                .expect("withdraw failed");
+                .unwrap_or_else(|err| panic!("withdraw failed: {}", err));
 
             // then
             assert_eq!(payment_channel.get_balance(), amount);
@@ -517,7 +517,7 @@ mod payment_channel {
 
             payment_channel
                 .start_sender_close()
-                .expect("start_sender_close failed");
+                .unwrap_or_else(|err| panic!("start_sender_close failed: {}", err));
             advance_block();
 
             // then
@@ -543,7 +543,7 @@ mod payment_channel {
 
             payment_channel
                 .start_sender_close()
-                .expect("start_sender_close failed");
+                .unwrap_or_else(|err| panic!("start_sender_close failed: {}", err));
             advance_block();
 
             // then

--- a/examples/rand-extension/lib.rs
+++ b/examples/rand-extension/lib.rs
@@ -145,7 +145,7 @@ mod rand_extension {
             assert_eq!(rand_extension.get(), [0; 32]);
 
             // when
-            rand_extension.update([0_u8; 32]).expect("update must work");
+            rand_extension.update([0_u8; 32]).unwrap_or_else(|err| panic!("update must work: {}", err));
 
             // then
             assert_eq!(rand_extension.get(), [1; 32]);

--- a/examples/trait-erc20/lib.rs
+++ b/examples/trait-erc20/lib.rs
@@ -277,7 +277,7 @@ mod erc20 {
             expected_value: Balance,
         ) {
             let decoded_event = <Event as scale::Decode>::decode(&mut &event.data[..])
-                .expect("encountered invalid contract event data buffer");
+                .unwrap_or_else(|err| panic!("encountered invalid contract event data buffer: {}", err));
             if let Event::Transfer(Transfer { from, to, value }) = decoded_event {
                 assert_eq!(from, expected_from, "encountered invalid Transfer.from");
                 assert_eq!(to, expected_to, "encountered invalid Transfer.to");
@@ -328,7 +328,7 @@ mod erc20 {
                 event.topics.iter().zip(expected_topics).enumerate()
             {
                 let topic = <Hash as scale::Decode>::decode(&mut &actual_topic[..])
-                    .expect("encountered invalid topic encoding");
+                    .unwrap_or_else(|err| panic!("encountered invalid topic encoding: {}", err));
                 assert_eq!(topic, expected_topic, "encountered invalid topic at {}", n);
             }
         }


### PR DESCRIPTION
A comment worth noting is that the below error messages occurred on the master branch as well, besides my feature branch:

./check-examples.sh: line 47: examples/delegator/: division by 0 (error token is "/")
./check-examples.sh: line 57: pushd: examples/delegator/: No such file or directory
error: no such subcommand: `contract`
./check-examples.sh: line 66: examples/delegator/: division by 0 (error token is "/")
Example Results
===============================================================

error: test failed, to rerun pass '-p ink_allocator --lib'
Workspace Results
-----------------
- 0: ERROR

workspace: Some checks failed
===============================================================
error: test failed, to rerun pass '-p ink_allocator --lib'
Workspace Results
-----------------
- 0: ERROR

workspace: Some checks failed
===============================================================
Do all the examples still compile? 
cargo contract check --manifest-path ./examples/.../Cargo.toml 
shows error: no such subcommand: `contract`
===============================================================
Is the wasm32 target still compiling?

    cargo check --no-default-features --target wasm32-unknown-unknown

error: the wasm32-unknown-unknown target is not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /Users/gangov/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.7/src/lib.rs:235:9
    |
235 | /         compile_error!("the wasm32-unknown-unknown target is not supported by \
236 | |                         default, you may need to enable the \"js\" feature. \
237 | |                         For more information see: \
238 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /Users/gangov/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.7/src/lib.rs:262:5
    |
262 |     imp::getrandom_inner(dest)
    |     ^^^ use of undeclared crate or module `imp`

    Checking ink_allocator v4.0.0-alpha.3 (/Users/gangov/Development/Agoge/ink/crates/allocator)
For more information about this error, try `rustc --explain E0433`.
error: could not compile `getrandom` due to 2 previous errors
===============================================================
cargo test --manifest-path ./examples/.../Cargo.toml
shows error: manifest path `./examples/.../Cargo.toml` does not exist