### PR TITLE
Update `scale-info` requirement to `2.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Allows to use `Result<Self, Error>` as a return type in constructors - [#1446](https://github.com/paritytech/ink/pull/1446)
 - Introduces conditional compilation to messages, constructors and events - [#1458](https://github.com/paritytech/ink/pull/1458)
+- Update `scale-info` requirement to `2.3` - [#1467](https://github.com/paritytech/ink/pull/1467)
 
 - Remove random function from ink!.
 

--- a/crates/e2e/src/utils.rs
+++ b/crates/e2e/src/utils.rs
@@ -17,7 +17,7 @@ use super::log_info;
 /// Extracts the Wasm blob from a contract bundle.
 pub fn extract_wasm(contract_path: &str) -> Vec<u8> {
     log_info(&format!("opening {:?}", contract_path));
-    let reader = std::fs::File::open(&contract_path).unwrap_or_else(|err| {
+    let reader = std::fs::File::open(contract_path).unwrap_or_else(|err| {
         panic!("contract path cannot be opened: {:?}", err);
     });
     let contract: contract_metadata::ContractMetadata = serde_json::from_reader(reader)

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -47,7 +47,7 @@ secp256k1 = { version = "0.24", features = ["recovery", "global-context"], optio
 #
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside the off-chain environment!
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [features]
 default = ["std"]

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -31,7 +31,7 @@ ink_metadata = { path = "../metadata", default-features = false }
 
 trybuild = { version = "1.0.60", features = ["diff"] }
 # Required for the doctest of `env_access::EnvAccess::instantiate_contract`
-scale-info = { version = "2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -31,7 +31,7 @@ ink = { path = ".." }
 ink_metadata = { path = "../../metadata" }
 ink_prelude = { path = "../../prelude" }
 ink_storage = { path = "../../storage" }
-scale-info = { version = "2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3", default-features = false, features = ["derive"] }
 
 [lib]
 name = "ink_macro"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -21,7 +21,7 @@ ink_primitives = { version = "4.0.0-alpha.3", path = "../primitives/", default-f
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.4.0"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
-scale-info = { version = "2", default-features = false, features = ["derive", "serde", "decode"] }
+scale-info = { version = "2.3", default-features = false, features = ["derive", "serde", "decode"] }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -18,7 +18,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", features = ["const_xxh32"] }
 
 [features]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -23,7 +23,7 @@ ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude/", default-feature
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1.0"
 array-init = { version = "2.0", default-features = false }
 

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -261,8 +261,8 @@ mod tests {
     fn insert_and_get_work() {
         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
             let mut mapping: Mapping<u8, _> = Mapping::new();
-            mapping.insert(&1, &2);
-            assert_eq!(mapping.get(&1), Some(2));
+            mapping.insert(1, &2);
+            assert_eq!(mapping.get(1), Some(2));
 
             Ok(())
         })
@@ -273,10 +273,10 @@ mod tests {
     fn insert_and_get_work_for_two_mapping_with_same_manual_key() {
         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
             let mut mapping: Mapping<u8, u8, ManualKey<123>> = Mapping::new();
-            mapping.insert(&1, &2);
+            mapping.insert(1, &2);
 
             let mapping2: Mapping<u8, u8, ManualKey<123>> = Mapping::new();
-            assert_eq!(mapping2.get(&1), Some(2));
+            assert_eq!(mapping2.get(1), Some(2));
 
             Ok(())
         })
@@ -287,7 +287,7 @@ mod tests {
     fn gets_default_if_no_key_set() {
         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
             let mapping: Mapping<u8, u8> = Mapping::new();
-            assert_eq!(mapping.get(&1), None);
+            assert_eq!(mapping.get(1), None);
 
             Ok(())
         })
@@ -300,14 +300,14 @@ mod tests {
             // Given
             let mut mapping: Mapping<u8, u8> = Mapping::new();
 
-            mapping.insert(&1, &2);
-            assert_eq!(mapping.get(&1), Some(2));
+            mapping.insert(1, &2);
+            assert_eq!(mapping.get(1), Some(2));
 
             // When
-            mapping.remove(&1);
+            mapping.remove(1);
 
             // Then
-            assert_eq!(mapping.get(&1), None);
+            assert_eq!(mapping.get(1), None);
 
             Ok(())
         })
@@ -321,10 +321,10 @@ mod tests {
             let mapping: Mapping<u8, u8> = Mapping::new();
 
             // When
-            mapping.remove(&1);
+            mapping.remove(1);
 
             // Then
-            assert_eq!(mapping.get(&1), None);
+            assert_eq!(mapping.get(1), None);
 
             Ok(())
         })

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -19,7 +19,7 @@ ink_metadata = { version = "4.0.0-alpha.3", path = "../../metadata", default-fea
 ink_primitives = { version = "4.0.0-alpha.3", path = "../../primitives", default-features = false }
 ink_prelude = { version = "4.0.0-alpha.3", path = "../../prelude", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 syn = { version = "1", features = ["full"] }
 
 [dev-dependencies]

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "contract_terminate"

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 adder = { path = "adder", default-features = false, features = ["ink-as-dependency"] }
 subber = { path = "subber", default-features = false, features = ["ink-as-dependency"] }

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "accumulator"

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -10,7 +10,7 @@ ink = { path = "../../../crates/ink", default-features = false }
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "adder"

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -10,7 +10,7 @@ ink = { path = "../../../crates/ink", default-features = false }
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "subber"

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "dns"

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "erc1155"

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "erc20"

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "erc721"

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "flipper"

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "incrementer"

--- a/examples/mother/Cargo.toml
+++ b/examples/mother/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "mother"

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "multisig"

--- a/examples/payment-channel/Cargo.toml
+++ b/examples/payment-channel/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 hex-literal = { version = "0.3" }

--- a/examples/psp22-extension/Cargo.toml
+++ b/examples/psp22-extension/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "psp22_extension"

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "rand_extension"

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "trait_erc20"

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "trait_flipper"

--- a/examples/trait-incrementer/Cargo.toml
+++ b/examples/trait-incrementer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 traits = { path = "./traits", default-features = false }
 
 [lib]

--- a/examples/trait-incrementer/traits/Cargo.toml
+++ b/examples/trait-incrementer/traits/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "traits"

--- a/examples/upgradeable-contracts/forward-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/forward-calls/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "forward_calls"

--- a/examples/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "incrementer"

--- a/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 ink = { path = "../../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "updated_incrementer"

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -34,7 +34,7 @@ ink_metadata = { path = "../crates/metadata", default-features = false }
 ink_primitives = { path = "../crates/primitives", default-features = false }
 ink_storage = { path = "../crates/storage", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3", default-features = false, features = ["derive"] }
 
 # For the moment we have to include the tests as examples and
 # then use `dylint_testing::ui_test_examples`.


### PR DESCRIPTION
Follow up to #1357 which uses some `2.3` features so now this is the minimum required version.