### PR TITLE
Revert "Conditional Codegen for Messages, Constructors and Events" PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Allows to use `Result<Self, Error>` as a return type in constructors - [#1446](https://github.com/paritytech/ink/pull/1446)
 
 ### Breaking Changes
 

--- a/crates/ink/codegen/src/generator/dispatch.rs
+++ b/crates/ink/codegen/src/generator/dispatch.rs
@@ -30,6 +30,7 @@ use quote::{
     quote_spanned,
 };
 use syn::spanned::Spanned as _;
+
 /// Generates code for the message and constructor dispatcher.
 ///
 /// This code efficiently selects the dispatched ink! constructor or message
@@ -164,6 +165,7 @@ impl Dispatch<'_> {
             .map(|(trait_path, message)| {
                 let span = message.span();
                 message_spans.push(span);
+
                 if let Some(trait_path) = trait_path {
                     let local_id = message.local_id().hex_padded_suffixed();
                     quote_spanned!(span=>
@@ -311,6 +313,7 @@ impl Dispatch<'_> {
                         type Input = #input_tuple_type;
                         type Output = #output_tuple_type;
                         type Storage = #storage_ident;
+
                         const CALLABLE: fn(&mut Self::Storage, Self::Input) -> Self::Output =
                             |storage, #input_tuple_bindings| {
                                 #storage_ident::#message_ident( storage #( , #input_bindings )* )

--- a/crates/ink/codegen/src/generator/events.rs
+++ b/crates/ink/codegen/src/generator/events.rs
@@ -184,8 +184,7 @@ impl<'a> Events<'a> {
     /// Generates the `Topics` trait implementations for the user defined events.
     fn generate_topics_impls(&'a self) -> impl Iterator<Item = TokenStream2> + 'a {
         let contract_ident = self.contract.module().storage().ident();
-        self.contract.module().events()
-            .map(move |event| {
+        self.contract.module().events().map(move |event| {
             let span = event.span();
             let event_ident = event.ident();
             let event_signature = syn::LitByteStr::new(

--- a/crates/ink/ir/src/ir/item_impl/iter.rs
+++ b/crates/ink/ir/src/ir/item_impl/iter.rs
@@ -13,14 +13,13 @@
 // limitations under the License.
 
 use super::{
-    is_code_span_enabled,
     CallableWithSelector,
     ImplItem,
     ItemImpl,
 };
 use crate::ir;
 
-/// Iterator yielding all ink! constructors within a source ink!
+/// Iterator yielding all ink! constructor within a source ink!
 /// [`ir::ItemImpl`](`crate::ir::ItemImpl`).
 pub struct IterConstructors<'a> {
     item_impl: &'a ir::ItemImpl,
@@ -46,12 +45,10 @@ impl<'a> Iterator for IterConstructors<'a> {
                 None => return None,
                 Some(impl_item) => {
                     if let Some(constructor) = impl_item.filter_map_constructor() {
-                        if is_code_span_enabled(constructor.attrs()) {
-                            return Some(CallableWithSelector::new(
-                                self.item_impl,
-                                constructor,
-                            ))
-                        }
+                        return Some(CallableWithSelector::new(
+                            self.item_impl,
+                            constructor,
+                        ))
                     }
                     continue 'repeat
                 }
@@ -86,12 +83,7 @@ impl<'a> Iterator for IterMessages<'a> {
                 None => return None,
                 Some(impl_item) => {
                     if let Some(message) = impl_item.filter_map_message() {
-                        if is_code_span_enabled(message.attrs()) {
-                            return Some(CallableWithSelector::new(
-                                self.item_impl,
-                                message,
-                            ))
-                        }
+                        return Some(CallableWithSelector::new(self.item_impl, message))
                     }
                     continue 'repeat
                 }

--- a/crates/ink/ir/src/ir/item_impl/mod.rs
+++ b/crates/ink/ir/src/ir/item_impl/mod.rs
@@ -51,14 +51,8 @@ pub use self::{
         Receiver,
     },
 };
-use quote::{
-    ToTokens,
-    TokenStreamExt as _,
-};
-use syn::{
-    spanned::Spanned,
-    Attribute,
-};
+use quote::TokenStreamExt as _;
+use syn::spanned::Spanned;
 
 /// An ink! implementation block.
 ///
@@ -315,7 +309,7 @@ impl TryFrom<syn::ItemImpl> for ItemImpl {
             return Err(format_err!(
                 impl_block_span,
                 "namespace ink! property is not allowed on ink! trait implementation blocks",
-            ));
+            ))
         }
         Ok(Self {
             attrs: other_attrs,
@@ -378,36 +372,4 @@ impl ItemImpl {
     pub fn items(&self) -> &[ir::ImplItem] {
         &self.items
     }
-}
-
-/// Check if the the conditional compilation expression
-/// for any `cfg` attributes is satisfied.
-///
-/// # Example
-/// If we have an annotated item (e.g. message)
-/// ```ignore
-/// #[ink(message)]
-/// #[cfg(feature = "foo")]
-/// #[cfg(feature = "baz")]
-/// pub fn get(&self) -> String {
-///     self.value.clone()
-/// }
-/// ```
-/// The function would would iterate over the `cfg` attributes
-/// and return `true` if any of the feature flags are set
-pub fn is_code_span_enabled(attrs: &[Attribute]) -> bool {
-    let cfg_attrs = attrs
-        .iter()
-        .filter(|a| a.path.is_ident("cfg"))
-        .map(|a| &a.tokens);
-    if cfg_attrs.clone().count() == 0 {
-        return true
-    }
-    for attr_tokens in cfg_attrs {
-        let _s = attr_tokens.to_token_stream();
-        if cfg!(_s) {
-            return true
-        }
-    }
-    false
 }

--- a/crates/ink/ir/src/ir/item_mod.rs
+++ b/crates/ink/ir/src/ir/item_mod.rs
@@ -28,8 +28,6 @@ use syn::{
     token,
 };
 
-use super::item_impl::is_code_span_enabled;
-
 /// The ink! module.
 ///
 /// This is the root of all ink! smart contracts and is defined similarly to
@@ -265,7 +263,7 @@ impl ItemMod {
                         .into_combine(format_err!(
                             overlap.span(),
                             "first ink! message with overlapping wildcard selector here",
-                        )));
+                        )))
                     }
                 }
             }
@@ -285,7 +283,7 @@ impl ItemMod {
                             .into_combine(format_err!(
                             overlap.span(),
                             "first ink! constructor with overlapping wildcard selector here",
-                        )));
+                        )))
                     }
                 }
             }
@@ -545,9 +543,7 @@ impl<'a> Iterator for IterEvents<'a> {
                 None => return None,
                 Some(ink_item) => {
                     if let Some(event) = ink_item.filter_map_event_item() {
-                        if is_code_span_enabled(event.attrs()) {
-                            return Some(event)
-                        }
+                        return Some(event)
                     }
                     continue 'repeat
                 }

--- a/examples/mother/Cargo.toml
+++ b/examples/mother/Cargo.toml
@@ -22,7 +22,6 @@ crate-type = [
 
 [features]
 default = ["std"]
-foo = []
 std = [
     "ink/std",
     "scale/std",

--- a/examples/mother/lib.rs
+++ b/examples/mother/lib.rs
@@ -128,13 +128,6 @@ mod mother {
         auction: Auction,
     }
 
-    /// Event emitted when an auction being echoed.
-    #[ink(event)]
-    #[cfg(feature = "foo")]
-    pub struct FeaturedAuctionEchoed {
-        auction: Auction,
-    }
-
     /// Storage of the contract.
     #[ink(storage)]
     #[derive(Default)]
@@ -146,15 +139,6 @@ mod mother {
     impl Mother {
         #[ink(constructor)]
         pub fn new(auction: Auction) -> Self {
-            Self {
-                balances: Default::default(),
-                auction,
-            }
-        }
-
-        #[ink(constructor)]
-        #[cfg(feature = "foo")]
-        pub fn conditional_new(auction: Auction) -> Self {
             Self {
                 balances: Default::default(),
                 auction,
@@ -202,13 +186,6 @@ mod mother {
         /// Prints the specified string into node's debug log.
         #[ink(message)]
         pub fn debug_log(&mut self, _message: String) {
-            ink::env::debug_println!("debug_log: {}", _message);
-        }
-
-        /// Prints the specified string into node's debug log.
-        #[ink(message)]
-        #[cfg(feature = "foo")]
-        pub fn conditional_debug_log(&mut self, _message: String) {
             ink::env::debug_println!("debug_log: {}", _message);
         }
     }


### PR DESCRIPTION
This reverts #1458 as functionality is not working. Need to rethink the approach

This reverts commit 06e9cf2bfdc611aea0b9414fab880f8c4f1fb25c.