### PR TITLE
Fix `no_implicit_prelude` test for case where `Result` is returned

### DIFF
--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -536,7 +536,7 @@ mod tests {
         match syn::parse_quote!( -> Result<Self, ()> ) {
             syn::ReturnType::Type(_, t) => {
                 let actual = Metadata::generate_constructor_return_type(Some(&t));
-                let expected = ":: ink :: metadata :: ReturnTypeSpec :: new (< Result < () , () > as :: ink :: metadata :: ConstructorReturnSpec > :: generate (Some (:: core :: iter :: IntoIterator :: into_iter ([:: core :: stringify ! (Result)]) . map (:: core :: convert :: AsRef :: as_ref))))";
+                let expected = ":: ink :: metadata :: ReturnTypeSpec :: new (< Result < () , () > as :: ink :: metadata :: ConstructorReturnSpec > :: generate (:: core :: option :: Option :: Some (:: core :: iter :: Iterator :: map (:: core :: iter :: IntoIterator :: into_iter ([:: core :: stringify ! (Result)]) , :: core :: convert :: AsRef :: as_ref))))";
                 assert_eq!(&actual.to_string(), expected);
             }
             _ => unreachable!(),

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -187,8 +187,10 @@ impl Metadata<'_> {
                 .collect::<Vec<_>>();
             quote! {
                 ::ink::metadata::TypeSpec::with_name_segs::<#ty, _>(
-                    ::core::iter::IntoIterator::into_iter([ #( ::core::stringify!(#segs) ),* ])
-                        .map(::core::convert::AsRef::as_ref)
+                    ::core::iter::Iterator::map(
+                        ::core::iter::IntoIterator::into_iter([ #( ::core::stringify!(#segs) ),* ]),
+                        ::core::convert::AsRef::as_ref
+                    )
                 )
             }
         } else {
@@ -215,9 +217,10 @@ impl Metadata<'_> {
                 .map(|seg| &seg.ident)
                 .collect::<Vec<_>>();
             quote! {
-                Some(::core::iter::IntoIterator::into_iter([ #( ::core::stringify!(#segs) ),* ])
-                        .map(::core::convert::AsRef::as_ref)
-                )
+                ::core::option::Option::Some(::core::iter::Iterator::map(
+                    ::core::iter::IntoIterator::into_iter([ #( ::core::stringify!(#segs) ),* ]),
+                    ::core::convert::AsRef::as_ref
+                ))
             }
         } else {
             without_display_name()

--- a/crates/ink/tests/ui/contract/pass/no-implicit-prelude.rs
+++ b/crates/ink/tests/ui/contract/pass/no-implicit-prelude.rs
@@ -11,8 +11,18 @@ mod contract {
             Self {}
         }
 
+        #[ink(constructor)]
+        pub fn constructor_result() -> ::core::result::Result<Self, ()> {
+            ::core::result::Result::Ok(Self {})
+        }
+
         #[ink(message)]
         pub fn message(&self) {}
+
+        #[ink(message)]
+        pub fn message_result(&self) -> ::core::result::Result<(), ()> {
+            ::core::result::Result::Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
Right now the UI tests which uses the [no_implicit_prelude](https://doc.rust-lang.org/reference/names/preludes.html#the-no_implicit_prelude-attribute) fails if we return a `Result`
from a message or constructor. 

This PR updates some of the generated code in that codepath to be more explicit so we can
continue building without the `std/core` prelude.

This is espeically relevant given some of the changes in #1450.
