### PR TITLE
Feature flag e2e tests

### DIFF
--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -27,3 +27,4 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
+e2e-tests = []

--- a/examples/contract-transfer/lib.rs
+++ b/examples/contract-transfer/lib.rs
@@ -180,7 +180,7 @@ pub mod give_me {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
         use super::*;
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -35,6 +35,7 @@ std = [
     "accumulator/std",
 ]
 ink-as-dependency = []
+e2e-tests = []
 
 [workspace]
 members = [

--- a/examples/delegator/lib.rs
+++ b/examples/delegator/lib.rs
@@ -123,7 +123,7 @@ mod delegator {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 


### PR DESCRIPTION
At the moment the e2e tests are failing because of temporary `substrate-contracts-node` incompatibility.

Ultimately we do want these e2e tests run on CI, but we need to disable them temporarily to get CI green in order to generate a new image.

This PR adds a feature `e2e-tests` to the two relevant examples. This can be enabled again once compatibility has been restored.