### PR TITLE
Add more detailed error and fail during initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Allows to use `Result<Self, Error>` as a return type in constructors - [#1446](https://github.com/paritytech/ink/pull/1446)
+- Checks if `#[ink_e2e::test(ws_url = "…")]` is reachable and throws meaningful error otherwise - [#1490](https://github.com/paritytech/ink/pull/1490)
 
 ### Breaking Changes
 

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -132,6 +132,17 @@ impl InkE2ETest {
 
                 ::ink_e2e::INIT.call_once(|| {
                     ::ink_e2e::env_logger::init();
+                    let check_async = ::ink_e2e::Client::<
+                        ::ink_e2e::PolkadotConfig,
+                        ink::env::DefaultEnvironment
+                    >::new(&#ws_url);
+
+                    ::ink_e2e::tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .unwrap_or_else(|err|
+                            panic!("Failed building the Runtime during initialization: {}", err))
+                        .block_on(check_async);
                 });
 
                 #( #meta )*

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -279,12 +279,14 @@ where
         let client = subxt::OnlineClient::from_url(url)
             .await
             .unwrap_or_else(|err| {
+                if let subxt::Error::Rpc(subxt::error::RpcError::ClientError(_)) = err {
+                    let error_msg = format!("Error establishing connection to a node at {}. Make sure you run a node behind the given url!", url);
+                    log_error(&error_msg);
+                    panic!("{}", error_msg);
+                }
                 log_error(
                     "Unable to create client! Please check that your node is running.",
                 );
-                if let subxt::Error::Rpc(subxt::error::RpcError::ClientError(_)) = err {
-                    panic!("\n\nError establishing connection to a node at {}\nMake sure your node is running.", url);
-                }
                 panic!("Unable to create client: {:?}", err);
             });
 

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -282,6 +282,9 @@ where
                 log_error(
                     "Unable to create client! Please check that your node is running.",
                 );
+                if let subxt::Error::Rpc(subxt::error::RpcError::ClientError(_)) = err {
+                    panic!("\n\nError establishing connection to a node at {}\nMake sure your node is running.", url);
+                }
                 panic!("Unable to create client: {:?}", err);
             });
 

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -21,6 +21,8 @@
 
 mod client;
 mod default_accounts;
+#[cfg(test)]
+mod tests;
 pub mod utils;
 mod xts;
 

--- a/crates/e2e/src/tests.rs
+++ b/crates/e2e/src/tests.rs
@@ -1,15 +1,10 @@
-#[test]
+#[tokio::test]
 #[should_panic(
     expected = "Error establishing connection to a node at ws://0.0.0.0:9944. Make sure you run a node behind the given url!"
 )]
-fn fail_initialization_with_no_node() {
-    let client_init =
-        crate::Client::<crate::PolkadotConfig, ink_env::DefaultEnvironment>::new(
-            "ws://0.0.0.0:9944",
-        );
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap_or_else(|err| panic!("Failed building the Runtime during test: {}", err))
-        .block_on(client_init);
+async fn fail_initialization_with_no_node() {
+    let _ = crate::Client::<crate::PolkadotConfig, ink_env::DefaultEnvironment>::new(
+        "ws://0.0.0.0:9944",
+    )
+    .await;
 }

--- a/crates/e2e/src/tests.rs
+++ b/crates/e2e/src/tests.rs
@@ -1,0 +1,15 @@
+#[test]
+#[should_panic(
+    expected = "\n\nError establishing connection to a node at ws://0.0.0.0:9944\nMake sure your node is running."
+)]
+fn fail_initialization_with_no_node() {
+    let client_init =
+        crate::Client::<crate::PolkadotConfig, ink_env::DefaultEnvironment>::new(
+            "ws://0.0.0.0:9944",
+        );
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap_or_else(|err| panic!("Failed building the Runtime during test: {}", err))
+        .block_on(client_init);
+}

--- a/crates/e2e/src/tests.rs
+++ b/crates/e2e/src/tests.rs
@@ -1,6 +1,6 @@
 #[test]
 #[should_panic(
-    expected = "\n\nError establishing connection to a node at ws://0.0.0.0:9944\nMake sure your node is running."
+    expected = "Error establishing connection to a node at ws://0.0.0.0:9944. Make sure you run a node behind the given url!"
 )]
 fn fail_initialization_with_no_node() {
     let client_init =

--- a/examples/mother/Cargo.toml
+++ b/examples/mother/Cargo.toml
@@ -12,6 +12,9 @@ ink = { path = "../../crates/ink", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
+[dev-dependencies]
+ink_e2e = { path = "../../crates/e2e" }
+
 [lib]
 name = "mother"
 path = "lib.rs"

--- a/examples/mother/lib.rs
+++ b/examples/mother/lib.rs
@@ -20,10 +20,7 @@
 #[ink::contract]
 mod mother {
     use ink::prelude::{
-        string::{
-            String,
-            ToString,
-        },
+        string::{String, ToString},
         vec::Vec,
     };
 
@@ -234,5 +231,14 @@ mod mother {
             let mut contract = Mother::default();
             let _ = contract.revert_or_trap(Some(Failure::Panic));
         }
+    }
+
+    #[cfg(test)]
+    mod e2e_tests {
+        use super::*;
+
+        #[ink_e2e::test(ws_url = "ws:://0.0.0.0:9944")]
+        #[should_panic]
+        async fn e2e_must_fail_without_connection(mut client: ink_e2e::Client<C, E>) {}
     }
 }

--- a/examples/mother/lib.rs
+++ b/examples/mother/lib.rs
@@ -20,7 +20,10 @@
 #[ink::contract]
 mod mother {
     use ink::prelude::{
-        string::{String, ToString},
+        string::{
+            String,
+            ToString,
+        },
         vec::Vec,
     };
 


### PR DESCRIPTION
This PR closes #1470.

If there is no node running behind the url, the following error will be thrown:
```
failures:

---- give_me::e2e_tests::e2e_contract_must_transfer_value_to_sender stdout ----
thread 'give_me::e2e_tests::e2e_contract_must_transfer_value_to_sender' panicked at '

Error establishing connection to a node at ws://0.0.0.0:9944
Make sure your node is running.', /Users/skyman/Projects/ink/crates/e2e/src/client.rs:286:21

---- give_me::e2e_tests::e2e_sending_value_to_give_me_must_fail stdout ----
thread 'give_me::e2e_tests::e2e_sending_value_to_give_me_must_fail' panicked at 'Once instance has previously been poisoned', lib.rs:188:9
```

And no tests will be run.