### PR TITLE
Fix E2E dry-run for `Mapping::insert()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Allows to use `Result<Self, Error>` as a return type in constructors - [#1446](https://github.com/paritytech/ink/pull/1446)
-- Fix E2E dry-run for `Mappping::insert()` - [#1494](https://github.com/paritytech/ink/pull/1494)
+- Fix E2E dry-run for `Mapping::insert()` - [#1494](https://github.com/paritytech/ink/pull/1494)
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Allows to use `Result<Self, Error>` as a return type in constructors - [#1446](https://github.com/paritytech/ink/pull/1446)
+- Fix E2E dry-run for `Mappping::insert()` - [#1494](https://github.com/paritytech/ink/pull/1494)
 
 ### Breaking Changes
 

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -544,7 +544,13 @@ where
 
         let dry_run = self
             .api
-            .call_dry_run(account_id.clone(), value, None, contract_call.0.clone())
+            .call_dry_run(
+                signer.account_id().clone(),
+                account_id.clone(),
+                value,
+                None,
+                contract_call.0.clone(),
+            )
             .await;
         log_info(&format!("call dry run: {:?}", &dry_run.result));
         log_info(&format!(

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -358,7 +358,7 @@ where
         input_data: Vec<u8>,
     ) -> ContractExecResult<E::Balance> {
         let call_request = RpcCallRequest::<C, E> {
-            origin: account_id,
+            origin,
             dest: contract,
             value,
             gas_limit: DRY_RUN_GAS_LIMIT,

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -351,7 +351,7 @@ where
     /// Dry runs a call of the contract at `contract` with the given parameters.
     pub async fn call_dry_run(
         &self,
-        account_id: C::AccountId,
+        origin: C::AccountId,
         contract: C::AccountId,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -351,13 +351,14 @@ where
     /// Dry runs a call of the contract at `contract` with the given parameters.
     pub async fn call_dry_run(
         &self,
+        account_id: C::AccountId,
         contract: C::AccountId,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
         input_data: Vec<u8>,
     ) -> ContractExecResult<E::Balance> {
         let call_request = RpcCallRequest::<C, E> {
-            origin: contract.clone(),
+            origin: account_id,
             dest: contract,
             value,
             gas_limit: DRY_RUN_GAS_LIMIT,


### PR DESCRIPTION
This PR fixes #1488 by correctly submitting the origin of the dry-run call during E2E test.