### PR TITLE
Fix fallible message revert, make `Ok` explicit

### DIFF
--- a/crates/ink/codegen/src/generator/item_impls.rs
+++ b/crates/ink/codegen/src/generator/item_impls.rs
@@ -256,25 +256,14 @@ impl ItemImpls<'_> {
         let vis = message.visibility();
         let receiver = message.receiver();
         let ident = message.ident();
-        let checked_ident = message.checked_ident();
         let inputs = message.inputs();
-        let input_bindings = message.inputs().map(|input| &input.pat).collect::<Vec<_>>();
-        let wrapped_inputs = message.inputs();
         let output_arrow = message.output().map(|_| quote! { -> });
         let output = message.output();
-        let wrapped_output = message.wrapped_output();
         let statements = message.statements();
-
         quote_spanned!(span =>
             #( #attrs )*
             #vis fn #ident(#receiver #( , #inputs )* ) #output_arrow #output {
                 #( #statements )*
-            }
-
-            #( #attrs )*
-            #vis fn #checked_ident(#receiver #( , #wrapped_inputs )* ) -> #wrapped_output {
-                ::core::result::Result::Ok(self.#ident( #( #input_bindings , )* ))
-
             }
         )
     }

--- a/crates/ink/tests/ui/contract/pass/message-checked-variant.rs
+++ b/crates/ink/tests/ui/contract/pass/message-checked-variant.rs
@@ -20,5 +20,4 @@ use contract::Contract;
 fn main() {
     let contract = Contract::default();
     contract.message();
-    contract.message_checked().unwrap();
 }


### PR DESCRIPTION
Suggestions for #1450.

:warning: :beer: :monkey:  Friday night untested suggestions :monkey: :beer: :warning: 

- Fix possible issue with fallible message returning `Err` not reverting
- Move up message dispatch always `Ok` directly to where `return_value` is invoked for clarity.
- Removes inherent `_checked` impl since it is now not used and has not use from user code (always returns `Ok`)