### PR TITLE
Release `v4.0.0-beta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ release. It means that whilst subsequent `beta` releases may contain breaking co
 *code* changes, the ABI will remain the same so that any contract compiled and deployed
 with `4.0.0-beta` continue to be compatible with all future `4.0.0` versions.
 
+### Compatibility
+In order to build contracts which use ink! `v4.0.0-beta` you need to use
+`cargo-contract`
+[`v2.0.0-beta`](https://github.com/paritytech/cargo-contract/releases/tag/v2.0.0-beta).
+You can install it as follows:
+
+`cargo install cargo-contract --version 2.0.0-beta`
+
+You will also need to use a version of [`pallet-contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
+later than [265e3f1](https://github.com/paritytech/substrate/commit/265e3f12a2937fe4f71280b3652471627609d04f)
+(Nov 3, 2022) in your node.
+
+The [`v0.22.1`](https://github.com/paritytech/substrate-contracts-node/releases/tag/v0.22.1)
+release of the [`substrate-contracts-node`](https://github.com/paritytech/substrate-contracts-node) is
+compatible with the ink! `4.0.0-beta` release.
+
 ### Breaking Changes
 
 ## Constructors and Messages now return `LangError`s

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Add E2E testing framework MVP ‒ [#1395](https://github.com/paritytech/ink/pull/1395)
+
 ## Version 4.0.0-beta
 
 The focus of the first `beta` release is to establish the stable ABI for the final `4.0.0`
@@ -76,19 +79,7 @@ We hope to bring this function back in a future release of ink!, the
 best hope right now is that it could come back with [Sassafras](https://wiki.polkadot.network/docs/learn-consensus#badass-babe-sassafras), a block production
 protocol for future versions of Polkadot.
 
-### End-to-End Testing
-
-You can now use the `ink_e2e` crate and accompanying `#[ink_e2e::test]` macro to write
-integration tests directly in Rust 🎉
-
-The contracts in the `examples/lang-err-integration-tests` folder make use of the
-end-to-end testing framework, so check it out if you need some example usage.
-
-Note that it's still pretty fresh off the press, so there are some sharp edges. Feel free
-to file an issue if you come across any.
-
 ### Added
-- Add E2E testing framework MVP ‒ [#1395](https://github.com/paritytech/ink/pull/1395)
 - Allow using `Result<Self, Error>` as a return type in constructors ‒ [#1446](https://github.com/paritytech/ink/pull/1446)
 - Add `Mapping::take()` function allowing to get a value removing it from storage ‒ [#1461](https://github.com/paritytech/ink/pull/1461)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-- Allows to use `Result<Self, Error>` as a return type in constructors - [#1446](https://github.com/paritytech/ink/pull/1446)
-- Checks if `#[ink_e2e::test(ws_url = "…")]` is reachable and throws meaningful error otherwise - [#1490](https://github.com/paritytech/ink/pull/1490)
-- Fix E2E dry-run for `Mapping::insert()` - [#1494](https://github.com/paritytech/ink/pull/1494)
+## Version 4.0.0-beta
+
+The focus of the first `beta` release is to establish the stable ABI for the final `4.0.0`
+release. It means that whilst subsequent `beta` releases may contain breaking contract
+*code* changes, the ABI will remain the same so that any contract compiled and deployed 
+with `4.0.0-beta` continue to be compatible with all future `4.0.0` versions.
 
 ### Breaking Changes
 
+## Constructors and Messages return types
+
+TODO: Describe update to Result with LangError return types: https://github.com/paritytech/ink/issues/1207
+
+## Random function removed
 We had to remove [`ink_env::random`](https://docs.rs/ink_env/3.3.1/ink_env/fn.random.html)
 with [#1442](https://github.com/paritytech/ink/pull/1442).
 This function allowed contract developers getting random entropy.
@@ -28,11 +35,12 @@ protocol for future versions of Polkadot.
 
 ### Added
 - Allow using `Result<Self, Error>` as a return type in constructors ‒ [#1446](https://github.com/paritytech/ink/pull/1446)
-- Introduce conditional compilation for messages, constructors and events ‒ [#1458](https://github.com/paritytech/ink/pull/1458)
 - Add `Mapping::take()` function allowing to get a value removing it from storage ‒ [#1461](https://github.com/paritytech/ink/pull/1461)
 
 
 ### Changed
+- Add support for language level errors (`LangError`) ‒ [#1450](https://github.com/paritytech/ink/pull/1450)
+- Return `LangError`s from constructors ‒ [#1467](https://github.com/paritytech/ink/pull/1504)
 - Update `scale-info` requirement to `2.3` ‒ [#1467](https://github.com/paritytech/ink/pull/1467)
 - Merge `Mapping::insert(key, val)` and `Mapping::insert_return_size(key, val)` into one method - [#1463](https://github.com/paritytech/ink/pull/1463)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,19 @@ We hope to bring this function back in a future release of ink!, the
 best hope right now is that it could come back with [Sassafras](https://wiki.polkadot.network/docs/learn-consensus#badass-babe-sassafras), a block production
 protocol for future versions of Polkadot.
 
+### End-to-End Testing
+
+You can now use the `ink_e2e` crate and accompanying `#[ink_e2e::test]` macro to write
+integration tests directly in Rust 🎉
+
+The contracts in the `examples/lang-err-integration-tests` folder make use of the
+end-to-end testing framework, so check it out if you need some example usage.
+
+Note that it's still pretty fresh off the press, so there are some sharp edges. Feel free
+to file an issue if you come across any.
+
 ### Added
+- Add E2E testing framework MVP ‒ [#1395](https://github.com/paritytech/ink/pull/1395)
 - Allow using `Result<Self, Error>` as a return type in constructors ‒ [#1446](https://github.com/paritytech/ink/pull/1446)
 - Add `Mapping::take()` function allowing to get a value removing it from storage ‒ [#1461](https://github.com/paritytech/ink/pull/1461)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The focus of the first `beta` release is to establish the stable ABI for the final `4.0.0`
 release. It means that whilst subsequent `beta` releases may contain breaking contract
-*code* changes, the ABI will remain the same so that any contract compiled and deployed 
+*code* changes, the ABI will remain the same so that any contract compiled and deployed
 with `4.0.0-beta` continue to be compatible with all future `4.0.0` versions.
 
 ### Breaking Changes
 
-## Constructors and Messages return types
+## Constructors and Messages now return `LangError`s
 
-TODO: Describe update to Result with LangError return types: https://github.com/paritytech/ink/issues/1207
+We have added a way to handle errors that are neither specific to a particular contract,
+nor from the underlying execution environment (e.g `pallet-contracts`). Instead these are
+errors that may come from the smart contracting language itself.
+
+For example, take the case where a contract message is called using an invalid selector.
+This is not something a smart contract author should need to define as failure case, nor
+is it something that the Contracts pallet needs to be aware of.
+
+Previously, the contract execution would trap if an invalid selector was used, leaving
+callers with no way to handle the error gracefully. This can now be handled with the help
+of the newly added `LangError`.
+
+In short, this change means that all ink! messages and constructors now return a
+`Result<R, LangError>`, where `R` is the original return type. Contract callers can
+choose to handle the `LangError`.
+
+In order to make this error compatible with other languages we have also added a
+`lang_error` field to the metadata format. This will be the central registry of all the
+different error variants which languages may want to emit in the future.
+
+Related pull-requests:
+- https://github.com/paritytech/ink/pull/1450
+- https://github.com/paritytech/ink/pull/1504
+
+Related discussions:
+- https://github.com/paritytech/ink/issues/1207
+- https://github.com/paritytech/substrate/issues/11018
+- https://github.com/paritytech/ink/issues/1002
 
 ## Random function removed
 We had to remove [`ink_env::random`](https://docs.rs/ink_env/3.3.1/ink_env/fn.random.html)
@@ -37,10 +64,9 @@ protocol for future versions of Polkadot.
 - Allow using `Result<Self, Error>` as a return type in constructors ‒ [#1446](https://github.com/paritytech/ink/pull/1446)
 - Add `Mapping::take()` function allowing to get a value removing it from storage ‒ [#1461](https://github.com/paritytech/ink/pull/1461)
 
-
 ### Changed
 - Add support for language level errors (`LangError`) ‒ [#1450](https://github.com/paritytech/ink/pull/1450)
-- Return `LangError`s from constructors ‒ [#1467](https://github.com/paritytech/ink/pull/1504)
+- Return `LangError`s from constructors ‒ [#1504](https://github.com/paritytech/ink/pull/1504)
 - Update `scale-info` requirement to `2.3` ‒ [#1467](https://github.com/paritytech/ink/pull/1467)
 - Merge `Mapping::insert(key, val)` and `Mapping::insert_return_size(key, val)` into one method - [#1463](https://github.com/paritytech/ink/pull/1463)
 

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_allocator"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_e2e"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -15,8 +15,8 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_e2e_macro = { version = "4.0.0-alpha.3", path = "./macro" }
-ink_env = { version = "4.0.0-alpha.3", path = "../env" }
+ink_e2e_macro = { version = "4.0.0-beta", path = "./macro" }
+ink_env = { version = "4.0.0-beta", path = "../env" }
 
 contract-metadata = { version = "2.0.0-alpha.4" }
 impl-serde = { version = "0.3.1", default-features = false }

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -3,6 +3,7 @@ name = "ink_e2e"
 version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
+publish = false
 
 license = "Apache-2.0"
 readme = "README.md"

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_e2e_macro"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -19,7 +19,7 @@ name = "ink_e2e_macro"
 proc-macro = true
 
 [dependencies]
-ink_ir = { version = "4.0.0-alpha.3", path = "../../ink/ir" }
+ink_ir = { version = "4.0.0-beta", path = "../../ink/ir" }
 derive_more = "0.99.17"
 env_logger = "0.9.1"
 log = "0.4.17"

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -3,9 +3,10 @@ name = "ink_e2e_macro"
 version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
+publish = false
 
 license = "Apache-2.0"
-readme = "README.md"
+readme = "../README.md"
 repository = "https://github.com/paritytech/ink"
 documentation = "https://docs.rs/ink_macro/"
 homepage = "https://www.parity.io/"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_engine"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Michael Müller <michi@parity.io>"]
 edition = "2021"
 
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_primitives = { version = "4.0.0-alpha.3", path = "../../crates/primitives", default-features = false }
+ink_primitives = { version = "4.0.0-beta", path = "../../crates/primitives", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_env"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "4.0.0-alpha.3", path = "../metadata", default-features = false, features = ["derive"], optional = true }
-ink_allocator = { version = "4.0.0-alpha.3", path = "../allocator", default-features = false }
-ink_storage_traits = { version = "4.0.0-alpha.3", path = "../storage/traits", default-features = false }
-ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude", default-features = false }
-ink_primitives = { version = "4.0.0-alpha.3", path = "../primitives", default-features = false }
+ink_metadata = { version = "4.0.0-beta", path = "../metadata", default-features = false, features = ["derive"], optional = true }
+ink_allocator = { version = "4.0.0-beta", path = "../allocator", default-features = false }
+ink_storage_traits = { version = "4.0.0-beta", path = "../storage/traits", default-features = false }
+ink_prelude = { version = "4.0.0-beta", path = "../prelude", default-features = false }
+ink_primitives = { version = "4.0.0-beta", path = "../primitives", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -33,7 +33,7 @@ static_assertions = "1.1"
 rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ink_engine = { version = "4.0.0-alpha.3", path = "../engine/", optional = true }
+ink_engine = { version = "4.0.0-beta", path = "../engine/", optional = true }
 
 # Hashes for the off-chain environment.
 sha2 = { version = "0.10", optional = true }

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,12 +15,12 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.0.0-alpha.3", path = "../env", default-features = false }
-ink_storage = { version = "4.0.0-alpha.3", path = "../storage", default-features = false }
-ink_primitives = { version = "4.0.0-alpha.3", path = "../primitives", default-features = false }
-ink_metadata = { version = "4.0.0-alpha.3", path = "../metadata", default-features = false, optional = true }
-ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude", default-features = false }
-ink_macro = { version = "4.0.0-alpha.3", path = "macro", default-features = false }
+ink_env = { version = "4.0.0-beta", path = "../env", default-features = false }
+ink_storage = { version = "4.0.0-beta", path = "../storage", default-features = false }
+ink_primitives = { version = "4.0.0-beta", path = "../primitives", default-features = false }
+ink_metadata = { version = "4.0.0-beta", path = "../metadata", default-features = false, optional = true }
+ink_prelude = { version = "4.0.0-beta", path = "../prelude", default-features = false }
+ink_macro = { version = "4.0.0-beta", path = "macro", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_codegen"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -18,8 +18,8 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 name = "ink_codegen"
 
 [dependencies]
-ink_primitives = { version = "4.0.0-alpha.3", path = "../../primitives" }
-ir = { version = "4.0.0-alpha.3", package = "ink_ir", path = "../ir", default-features = false }
+ink_primitives = { version = "4.0.0-beta", path = "../../primitives" }
+ir = { version = "4.0.0-beta", package = "ink_ir", path = "../ir", default-features = false }
 quote = "1"
 syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = "1.0"

--- a/crates/ink/ir/Cargo.toml
+++ b/crates/ink/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_ir"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_macro"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,9 +15,9 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_ir = { version = "4.0.0-alpha.3", path = "../ir", default-features = false }
-ink_codegen = { version = "4.0.0-alpha.3", path = "../codegen", default-features = false }
-ink_primitives = { version = "4.0.0-alpha.3", path = "../../primitives/", default-features = false }
+ink_ir = { version = "4.0.0-beta", path = "../ir", default-features = false }
+ink_codegen = { version = "4.0.0-beta", path = "../codegen", default-features = false }
+ink_primitives = { version = "4.0.0-beta", path = "../../primitives/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 syn = "1"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_metadata"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,8 +15,8 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude/", default-features = false }
-ink_primitives = { version = "4.0.0-alpha.3", path = "../primitives/", default-features = false }
+ink_prelude = { version = "4.0.0-beta", path = "../prelude/", default-features = false }
+ink_primitives = { version = "4.0.0-beta", path = "../primitives/", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.4.0"

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_prelude"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_primitives"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -16,7 +16,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude/", default-features = false }
+ink_prelude = { version = "4.0.0-beta", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", features = ["const_xxh32"] }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.0.0-alpha.3", path = "../env/", default-features = false }
-ink_metadata = { version = "4.0.0-alpha.3", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.0.0-alpha.3", path = "../primitives/", default-features = false }
-ink_storage_traits = { version = "4.0.0-alpha.3", path = "traits", default-features = false }
-ink_prelude = { version = "4.0.0-alpha.3", path = "../prelude/", default-features = false }
+ink_env = { version = "4.0.0-beta", path = "../env/", default-features = false }
+ink_metadata = { version = "4.0.0-beta", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "4.0.0-beta", path = "../primitives/", default-features = false }
+ink_storage_traits = { version = "4.0.0-beta", path = "traits", default-features = false }
+ink_prelude = { version = "4.0.0-beta", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage_traits"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -15,9 +15,9 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "4.0.0-alpha.3", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.0.0-alpha.3", path = "../../primitives", default-features = false }
-ink_prelude = { version = "4.0.0-alpha.3", path = "../../prelude", default-features = false }
+ink_metadata = { version = "4.0.0-beta", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "4.0.0-beta", path = "../../primitives", default-features = false }
+ink_prelude = { version = "4.0.0-beta", path = "../../prelude", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 syn = { version = "1", features = ["full"] }

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_terminate"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_transfer"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegator"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulator"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adder"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subber"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc1155"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc20"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc721"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/lang-err-integration-tests/call-builder/Cargo.toml
+++ b/examples/lang-err-integration-tests/call-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/lang-err-integration-tests/constructors-return-value/Cargo.toml
+++ b/examples/lang-err-integration-tests/constructors-return-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constructors_return_value"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/lang-err-integration-tests/contract-ref/Cargo.toml
+++ b/examples/lang-err-integration-tests/contract-ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_ref"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/lang-err-integration-tests/integration-flipper/Cargo.toml
+++ b/examples/lang-err-integration-tests/integration-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_flipper"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/mother/Cargo.toml
+++ b/examples/mother/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mother"
 description = "Mother of all contracts"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/payment-channel/Cargo.toml
+++ b/examples/payment-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payment_channel"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/psp22-extension/Cargo.toml
+++ b/examples/psp22-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_extension"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_extension"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_erc20"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_flipper"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/Cargo.toml
+++ b/examples/trait-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/traits/Cargo.toml
+++ b/examples/trait-incrementer/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traits"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/forward-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/forward-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forward_calls"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated-incrementer"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_linting"
-version = "4.0.0-alpha.3"
+version = "4.0.0-beta"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false


### PR DESCRIPTION
### Added
- Allow using `Result<Self, Error>` as a return type in constructors ‒ [#1446](https://github.com/paritytech/ink/pull/1446)
- Add `Mapping::take()` function allowing to get a value removing it from storage ‒ [#1461](https://github.com/paritytech/ink/pull/1461)

### Changed
- Add support for language level errors (`LangError`) ‒ [#1450](https://github.com/paritytech/ink/pull/1450)
- Return `LangError`s from constructors ‒ [#1504](https://github.com/paritytech/ink/pull/1504)
- Update `scale-info` requirement to `2.3` ‒ [#1467](https://github.com/paritytech/ink/pull/1467)
- Merge `Mapping::insert(key, val)` and `Mapping::insert_return_size(key, val)` into one method - [#1463](https://github.com/paritytech/ink/pull/1463)

### Removed
- Remove `ink_env::random` function ‒ [#1442](https://github.com/paritytech/ink/pull/1442)

Closes https://github.com/paritytech/ink/issues/1478.

**Post release:**
- [ ] `cargo-contract` companion release (update template) https://github.com/paritytech/cargo-contract/pull/828