### PR TITLE
Disable ink-waterfall CI step :t-rex:

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -450,7 +450,9 @@ examples-docs:
 
 #### stage:                        ink-waterfall
 
-ink-waterfall:
+# Temporarily disabled until https://github.com/paritytech/ink-waterfall/issues/41
+# is fixed.
+.ink-waterfall:
   stage:                           ink-waterfall
   image:                           paritytech/tools:latest
   <<:                              *kubernetes-env


### PR DESCRIPTION
https://github.com/paritytech/ink-waterfall/issues/41 means that `ink-waterfall` always fails. This PR disables it until we can fix it so we can have a passing CI