### PR TITLE
Use non-default port for `fail_initialization_with_no_node` test :t-rex: 

### DIFF
--- a/crates/e2e/src/tests.rs
+++ b/crates/e2e/src/tests.rs
@@ -1,10 +1,10 @@
 #[tokio::test]
 #[should_panic(
-    expected = "Error establishing connection to a node at ws://0.0.0.0:9944. Make sure you run a node behind the given url!"
+    expected = "Error establishing connection to a node at ws://0.0.0.0:9999. Make sure you run a node behind the given url!"
 )]
 async fn fail_initialization_with_no_node() {
     let _ = crate::Client::<crate::PolkadotConfig, ink_env::DefaultEnvironment>::new(
-        "ws://0.0.0.0:9944",
+        "ws://0.0.0.0:9999",
     )
     .await;
 }


### PR DESCRIPTION
See failure https://github.com/paritytech/ink/actions/runs/3534340623/jobs/5931094570.

It uses the default port, so it would fail if there is a node running on that port, which there might be if running the E2E tests.