### PR TITLE
Examples CI: ignore lang-err-integration-tests dir :t-rex: 

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -112,6 +112,7 @@ jobs:
            cargo contract ${{ matrix.job }} --verbose --manifest-path examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml;
            foreach ($example in Get-ChildItem  -Directory "examples\*") {
                if ($example -Match 'upgradeable-contracts') { continue }
+               if ($example -Match 'lang-err-integration-tests') { continue }
                echo "Processing example: $example";
                cargo contract ${{ matrix.job }} --verbose --manifest-path=$example/Cargo.toml;
                cargo clean --manifest-path=$example/Cargo.toml;
@@ -131,6 +132,7 @@ jobs:
            cargo contract ${{ matrix.job }} --verbose --manifest-path=examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml;
            for example in examples/*/; do
                if [ "$example" = "examples/upgradeable-contracts/" ]; then continue; fi;
+               if [ "$example" = "examples/lang-err-integration-tests/" ]; then continue; fi;
                echo "Processing example: $example";
                cargo contract ${{ matrix.job }} --verbose --manifest-path=$example/Cargo.toml;
            done


### PR DESCRIPTION
Fix CI error https://github.com/paritytech/ink/actions/runs/3547091364/jobs/5956837605#step:14:5234.

For now it will just ignore that directory, I don't think we need to attempt to compile those examples for all OSs.

We should attempt to make these CI scripts less brittle and traverse the `examples` dir. I will open an issue for that, https://github.com/paritytech/ink/issues/1520