### PR TITLE
 FFI: no more `__unstable__` wasm import module

### DIFF
--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -318,6 +318,13 @@ mod sys {
             public_key_ptr: Ptr32<[u8]>,
             output_ptr: Ptr32Mut<[u8]>,
         ) -> ReturnCode;
+
+        pub fn take_storage(
+            key_ptr: Ptr32<[u8]>,
+            key_len: u32,
+            out_ptr: Ptr32Mut<[u8]>,
+            out_len_ptr: Ptr32Mut<u32>,
+        ) -> ReturnCode;
     }
 
     #[link(wasm_import_module = "seal1")]
@@ -383,29 +390,6 @@ mod sys {
         //
         // `ReturnCode::KeyNotFound`
         pub fn get_storage(
-            key_ptr: Ptr32<[u8]>,
-            key_len: u32,
-            out_ptr: Ptr32Mut<[u8]>,
-            out_len_ptr: Ptr32Mut<u32>,
-        ) -> ReturnCode;
-    }
-
-    #[link(wasm_import_module = "__unstable__")]
-    extern "C" {
-        /// Retrieve and remove the value under the given key from storage.
-        ///
-        /// # Parameters
-        ///
-        /// - `key_ptr`: pointer into the linear memory where the key of the requested value is placed.
-        /// - `key_len`: the length of the key in bytes.
-        /// - `out_ptr`: pointer to the linear memory where the value is written to.
-        /// - `out_len_ptr`: in-out pointer into linear memory where the buffer length is read from and
-        ///   the value length is written to.
-        ///
-        /// # Errors
-        ///
-        /// `ReturnCode::KeyNotFound`
-        pub fn take_storage(
             key_ptr: Ptr32<[u8]>,
             key_len: u32,
             out_ptr: Ptr32Mut<[u8]>,

--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -319,6 +319,8 @@ mod sys {
             output_ptr: Ptr32Mut<[u8]>,
         ) -> ReturnCode;
 
+        /// **WARNING**: this function is from the [unstable interface](https://github.com/paritytech/substrate/tree/master/frame/contracts#unstable-interfaces),
+        /// which is unsafe and normally is not available on production chains.
         pub fn take_storage(
             key_ptr: Ptr32<[u8]>,
             key_len: u32,

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -157,6 +157,8 @@ where
     /// Removes the `value` at `key`, returning the previous `value` at `key` from storage.
     ///
     /// Returns `None` if no `value` exists at the given `key`.
+    /// **WARNING**: this method uses the [unstable interface](https://github.com/paritytech/substrate/tree/master/frame/contracts#unstable-interfaces),
+    /// which is unsafe and normally is not available on production chains.
     #[inline]
     pub fn take<Q>(&self, key: Q) -> Option<V>
     where


### PR DESCRIPTION
Follow-up to [substrate#12781](https://github.com/paritytech/substrate/pull/12781): there's no `__unstable__` module anymore