### PR TITLE
`[ink_e2e]` housekeeping

### DIFF
--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -35,7 +35,6 @@ use super::{
     ContractExecResult,
     ContractInstantiateResult,
     ContractsApi,
-    InkMessage,
     Signer,
 };
 use contract_metadata::ContractMetadata;
@@ -61,27 +60,6 @@ use subxt::{
     },
     tx::ExtrinsicParams,
 };
-
-/// An encoded `#[ink(message)]`.
-#[derive(Clone)]
-pub struct EncodedMessage(Vec<u8>);
-
-impl EncodedMessage {
-    fn new<M: InkMessage>(call: &M) -> Self {
-        let mut call_data = M::SELECTOR.to_vec();
-        <M as scale::Encode>::encode_to(call, &mut call_data);
-        Self(call_data)
-    }
-}
-
-impl<M> From<M> for EncodedMessage
-where
-    M: InkMessage,
-{
-    fn from(msg: M) -> Self {
-        EncodedMessage::new(&msg)
-    }
-}
 
 /// Result of a contract instantiation.
 pub struct InstantiationResult<C: subxt::Config, E: Environment> {

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -319,7 +319,7 @@ where
     pub async fn instantiate<Args, R>(
         &mut self,
         contract_name: &str,
-        signer: &mut Signer<C>,
+        signer: &Signer<C>,
         constructor: CreateBuilderPartial<E, Args, R>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
@@ -374,7 +374,7 @@ where
     /// Executes an `instantiate_with_code` call and captures the resulting events.
     async fn exec_instantiate<Args, R>(
         &mut self,
-        signer: &mut Signer<C>,
+        signer: &Signer<C>,
         code: Vec<u8>,
         constructor: CreateBuilderPartial<E, Args, R>,
         value: E::Balance,
@@ -491,7 +491,7 @@ where
     pub async fn upload(
         &mut self,
         contract_name: &str,
-        signer: &mut Signer<C>,
+        signer: &Signer<C>,
         storage_deposit_limit: Option<E::Balance>,
     ) -> Result<UploadResult<C, E>, Error<C, E>> {
         let contract_metadata = self
@@ -509,7 +509,7 @@ where
     /// Executes an `upload` call and captures the resulting events.
     pub async fn exec_upload(
         &mut self,
-        signer: &mut Signer<C>,
+        signer: &Signer<C>,
         code: Vec<u8>,
         storage_deposit_limit: Option<E::Balance>,
     ) -> Result<UploadResult<C, E>, Error<C, E>> {
@@ -589,7 +589,7 @@ where
     /// contains all events that are associated with this transaction.
     pub async fn call<RetType>(
         &mut self,
-        signer: &mut Signer<C>,
+        signer: &Signer<C>,
         message: Message<E, RetType>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -93,27 +93,6 @@ pub type PolkadotConfig = subxt::config::WithExtrinsicParams<
 /// cryptography.
 pub type Signer<C> = PairSigner<C, sr25519::Pair>;
 
-/// Trait for contract constructors.
-// TODO(#1421) Merge this with `InkMessage` to be just `InkSelector`. Requires forking `smart-bench-macro`.
-pub trait InkConstructor: scale::Encode {
-    /// Return type of the constructor.
-    type ReturnType;
-    /// An ink! selector consists of four bytes.
-    const SELECTOR: [u8; 4];
-    /// Path to the contract bundle.
-    const CONTRACT_PATH: &'static str;
-}
-
-/// Trait for contract messages.
-pub trait InkMessage: scale::Encode {
-    /// Return type of the message.
-    type ReturnType;
-    /// An ink! selector consists of four bytes.
-    const SELECTOR: [u8; 4];
-    /// Path to the contract bundle.
-    const CONTRACT_PATH: &'static str;
-}
-
 /// We use this to only initialize `env_logger` once.
 pub static INIT: Once = Once::new();
 

--- a/examples/contract-transfer/lib.rs
+++ b/examples/contract-transfer/lib.rs
@@ -194,7 +194,7 @@ pub mod give_me {
             let contract_acc_id = client
                 .instantiate(
                     "contract_transfer",
-                    &mut ink_e2e::alice(),
+                    &ink_e2e::alice(),
                     constructor,
                     1000,
                     None,
@@ -207,7 +207,7 @@ pub mod give_me {
             let transfer = ink_e2e::build_message::<GiveMeRef>(contract_acc_id)
                 .call(|contract| contract.give_me(120));
 
-            let call_res = client.call(&mut ink_e2e::bob(), transfer, 10, None).await;
+            let call_res = client.call(&ink_e2e::bob(), transfer, 10, None).await;
 
             // then
             assert!(call_res.is_err());
@@ -231,7 +231,7 @@ pub mod give_me {
             let contract_acc_id = client
                 .instantiate(
                     "contract_transfer",
-                    &mut ink_e2e::bob(),
+                    &ink_e2e::bob(),
                     constructor,
                     1337,
                     None,
@@ -249,7 +249,7 @@ pub mod give_me {
                 .call(|contract| contract.give_me(120));
 
             let call_res = client
-                .call(&mut ink_e2e::eve(), transfer, 0, None)
+                .call(&ink_e2e::eve(), transfer, 0, None)
                 .await
                 .expect("call failed");
 

--- a/examples/delegator/lib.rs
+++ b/examples/delegator/lib.rs
@@ -136,19 +136,19 @@ mod delegator {
         async fn e2e_delegator(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
             // given
             let accumulator_hash = client
-                .upload("accumulator", &mut ink_e2e::alice(), None)
+                .upload("accumulator", &ink_e2e::alice(), None)
                 .await
                 .expect("uploading `accumulator` failed")
                 .code_hash;
 
             let adder_hash = client
-                .upload("adder", &mut ink_e2e::alice(), None)
+                .upload("adder", &ink_e2e::alice(), None)
                 .await
                 .expect("uploading `adder` failed")
                 .code_hash;
 
             let subber_hash = client
-                .upload("subber", &mut ink_e2e::alice(), None)
+                .upload("subber", &ink_e2e::alice(), None)
                 .await
                 .expect("uploading `subber` failed")
                 .code_hash;
@@ -162,7 +162,7 @@ mod delegator {
             );
 
             let delegator_acc_id = client
-                .instantiate("delegator", &mut ink_e2e::alice(), constructor, 0, None)
+                .instantiate("delegator", &ink_e2e::alice(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;
@@ -171,7 +171,7 @@ mod delegator {
             let get = build_message::<DelegatorRef>(delegator_acc_id.clone())
                 .call(|contract| contract.get());
             let value = client
-                .call(&mut ink_e2e::bob(), get, 0, None)
+                .call(&ink_e2e::bob(), get, 0, None)
                 .await
                 .expect("calling `get` failed")
                 .value
@@ -180,7 +180,7 @@ mod delegator {
             let change = build_message::<DelegatorRef>(delegator_acc_id.clone())
                 .call(|contract| contract.change(6));
             let _ = client
-                .call(&mut ink_e2e::bob(), change, 0, None)
+                .call(&ink_e2e::bob(), change, 0, None)
                 .await
                 .expect("calling `change` failed");
 
@@ -188,7 +188,7 @@ mod delegator {
             let get = build_message::<DelegatorRef>(delegator_acc_id.clone())
                 .call(|contract| contract.get());
             let value = client
-                .call(&mut ink_e2e::bob(), get, 0, None)
+                .call(&ink_e2e::bob(), get, 0, None)
                 .await
                 .expect("calling `get` failed")
                 .value
@@ -199,13 +199,13 @@ mod delegator {
             let switch = build_message::<DelegatorRef>(delegator_acc_id.clone())
                 .call(|contract| contract.switch());
             let _ = client
-                .call(&mut ink_e2e::bob(), switch, 0, None)
+                .call(&ink_e2e::bob(), switch, 0, None)
                 .await
                 .expect("calling `switch` failed");
             let change = build_message::<DelegatorRef>(delegator_acc_id.clone())
                 .call(|contract| contract.change(3));
             let _ = client
-                .call(&mut ink_e2e::bob(), change, 0, None)
+                .call(&ink_e2e::bob(), change, 0, None)
                 .await
                 .expect("calling `change` failed");
 
@@ -213,7 +213,7 @@ mod delegator {
             let get = build_message::<DelegatorRef>(delegator_acc_id.clone())
                 .call(|contract| contract.get());
             let value = client
-                .call(&mut ink_e2e::bob(), get, 0, None)
+                .call(&ink_e2e::bob(), get, 0, None)
                 .await
                 .expect("calling `get` failed")
                 .value

--- a/examples/lang-err-integration-tests/call-builder/lib.rs
+++ b/examples/lang-err-integration-tests/call-builder/lib.rs
@@ -101,7 +101,7 @@ mod call_builder {
             let contract_acc_id = client
                 .instantiate(
                     "call_builder",
-                    &mut ink_e2e::charlie(),
+                    &ink_e2e::charlie(),
                     constructor,
                     0,
                     None,
@@ -114,7 +114,7 @@ mod call_builder {
             let flipper_acc_id = client
                 .instantiate(
                     "integration_flipper",
-                    &mut ink_e2e::charlie(),
+                    &ink_e2e::charlie(),
                     flipper_constructor,
                     0,
                     None,
@@ -126,7 +126,7 @@ mod call_builder {
             let flipper_get = build_message::<FlipperRef>(flipper_acc_id)
                 .call(|contract| contract.get());
             let get_call_result = client
-                .call(&mut ink_e2e::charlie(), flipper_get, 0, None)
+                .call(&ink_e2e::charlie(), flipper_get, 0, None)
                 .await
                 .expect("Calling `flipper::get` failed");
             let initial_value = get_call_result
@@ -137,7 +137,7 @@ mod call_builder {
             let call = build_message::<CallBuilderTestRef>(contract_acc_id)
                 .call(|contract| contract.call(flipper_acc_id, invalid_selector));
             let call_result = client
-                .call(&mut ink_e2e::charlie(), call, 0, None)
+                .call(&ink_e2e::charlie(), call, 0, None)
                 .await
                 .expect("Calling `call_builder::call` failed");
 
@@ -153,7 +153,7 @@ mod call_builder {
             let flipper_get = build_message::<FlipperRef>(flipper_acc_id)
                 .call(|contract| contract.get());
             let get_call_result = client
-                .call(&mut ink_e2e::charlie(), flipper_get, 0, None)
+                .call(&ink_e2e::charlie(), flipper_get, 0, None)
                 .await
                 .expect("Calling `flipper::get` failed");
             let flipped_value = get_call_result
@@ -170,13 +170,13 @@ mod call_builder {
         ) -> E2EResult<()> {
             let constructor = CallBuilderTestRef::new();
             let contract_acc_id = client
-                .instantiate("call_builder", &mut ink_e2e::dave(), constructor, 0, None)
+                .instantiate("call_builder", &ink_e2e::dave(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;
 
             let code_hash = client
-                .upload("constructors_return_value", &mut ink_e2e::dave(), None)
+                .upload("constructors_return_value", &ink_e2e::dave(), None)
                 .await
                 .expect("upload `constructors_return_value` failed")
                 .code_hash;
@@ -187,7 +187,7 @@ mod call_builder {
                     contract.call_instantiate(code_hash, new_selector, true)
                 });
             let call_result = client
-                .call(&mut ink_e2e::dave(), call, 0, None)
+                .call(&ink_e2e::dave(), call, 0, None)
                 .await
                 .expect("Client failed to call `call_builder::call_instantiate`.")
                 .value
@@ -207,13 +207,13 @@ mod call_builder {
         ) -> E2EResult<()> {
             let constructor = CallBuilderTestRef::new();
             let contract_acc_id = client
-                .instantiate("call_builder", &mut ink_e2e::eve(), constructor, 0, None)
+                .instantiate("call_builder", &ink_e2e::eve(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;
 
             let code_hash = client
-                .upload("constructors_return_value", &mut ink_e2e::eve(), None)
+                .upload("constructors_return_value", &ink_e2e::eve(), None)
                 .await
                 .expect("upload `constructors_return_value` failed")
                 .code_hash;
@@ -224,7 +224,7 @@ mod call_builder {
                     contract.call_instantiate(code_hash, invalid_selector, true)
                 });
             let call_result = client
-                .call(&mut ink_e2e::eve(), call, 0, None)
+                .call(&ink_e2e::eve(), call, 0, None)
                 .await
                 .expect("Client failed to call `call_builder::call_instantiate`.")
                 .value

--- a/examples/lang-err-integration-tests/call-builder/lib.rs
+++ b/examples/lang-err-integration-tests/call-builder/lib.rs
@@ -99,13 +99,7 @@ mod call_builder {
         ) -> E2EResult<()> {
             let constructor = CallBuilderTestRef::new();
             let contract_acc_id = client
-                .instantiate(
-                    "call_builder",
-                    &ink_e2e::charlie(),
-                    constructor,
-                    0,
-                    None,
-                )
+                .instantiate("call_builder", &ink_e2e::charlie(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;

--- a/examples/lang-err-integration-tests/constructors-return-value/lib.rs
+++ b/examples/lang-err-integration-tests/constructors-return-value/lib.rs
@@ -125,7 +125,7 @@ pub mod constructors_return_value {
             let success = client
                 .instantiate(
                     "constructors_return_value",
-                    &mut ink_e2e::alice(),
+                    &ink_e2e::alice(),
                     constructor,
                     0,
                     None,
@@ -175,7 +175,7 @@ pub mod constructors_return_value {
             let contract_acc_id = client
                 .instantiate(
                     "constructors_return_value",
-                    &mut ink_e2e::bob(),
+                    &ink_e2e::bob(),
                     constructor,
                     0,
                     None,
@@ -188,7 +188,7 @@ pub mod constructors_return_value {
                 ink_e2e::build_message::<ConstructorsReturnValueRef>(contract_acc_id)
                     .call(|contract| contract.get_value());
             let value = client
-                .call(&mut ink_e2e::bob(), get, 0, None)
+                .call(&ink_e2e::bob(), get, 0, None)
                 .await
                 .expect("Calling `get_value` failed")
                 .value
@@ -240,7 +240,7 @@ pub mod constructors_return_value {
             let result = client
                 .instantiate(
                     "constructors_return_value",
-                    &mut ink_e2e::charlie(),
+                    &ink_e2e::charlie(),
                     constructor,
                     0,
                     None,

--- a/examples/lang-err-integration-tests/contract-ref/lib.rs
+++ b/examples/lang-err-integration-tests/contract-ref/lib.rs
@@ -62,14 +62,14 @@ mod contract_ref {
             mut client: ink_e2e::Client<C, E>,
         ) -> E2EResult<()> {
             let flipper_hash = client
-                .upload("integration_flipper", &mut ink_e2e::alice(), None)
+                .upload("integration_flipper", &ink_e2e::alice(), None)
                 .await
                 .expect("uploading `flipper` failed")
                 .code_hash;
 
             let constructor = ContractRefRef::new(0, flipper_hash);
             let contract_acc_id = client
-                .instantiate("contract_ref", &mut ink_e2e::alice(), constructor, 0, None)
+                .instantiate("contract_ref", &ink_e2e::alice(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;
@@ -77,7 +77,7 @@ mod contract_ref {
             let get_check = build_message::<ContractRefRef>(contract_acc_id.clone())
                 .call(|contract| contract.get_check());
             let get_call_result = client
-                .call(&mut ink_e2e::alice(), get_check, 0, None)
+                .call(&ink_e2e::alice(), get_check, 0, None)
                 .await
                 .expect("Calling `get_check` failed");
             let initial_value = get_call_result
@@ -87,7 +87,7 @@ mod contract_ref {
             let flip_check = build_message::<ContractRefRef>(contract_acc_id.clone())
                 .call(|contract| contract.flip_check());
             let flip_call_result = client
-                .call(&mut ink_e2e::alice(), flip_check, 0, None)
+                .call(&ink_e2e::alice(), flip_check, 0, None)
                 .await
                 .expect("Calling `flip` failed");
             assert!(
@@ -98,7 +98,7 @@ mod contract_ref {
             let get_check = build_message::<ContractRefRef>(contract_acc_id.clone())
                 .call(|contract| contract.get_check());
             let get_call_result = client
-                .call(&mut ink_e2e::alice(), get_check, 0, None)
+                .call(&ink_e2e::alice(), get_check, 0, None)
                 .await
                 .expect("Calling `get_check` failed");
             let flipped_value = get_call_result

--- a/examples/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/examples/lang-err-integration-tests/integration-flipper/lib.rs
@@ -62,7 +62,7 @@ pub mod integration_flipper {
             let contract_acc_id = client
                 .instantiate(
                     "integration_flipper",
-                    &mut ink_e2e::alice(),
+                    &ink_e2e::alice(),
                     constructor,
                     0,
                     None,
@@ -74,7 +74,7 @@ pub mod integration_flipper {
             let get = build_message::<FlipperRef>(contract_acc_id.clone())
                 .call(|contract| contract.get());
             let get_call_result = client
-                .call(&mut ink_e2e::alice(), get, 0, None)
+                .call(&ink_e2e::alice(), get, 0, None)
                 .await
                 .expect("Calling `get` failed");
             let initial_value = get_call_result
@@ -84,7 +84,7 @@ pub mod integration_flipper {
             let flip = build_message::<FlipperRef>(contract_acc_id)
                 .call(|contract| contract.flip());
             let flip_call_result = client
-                .call(&mut ink_e2e::alice(), flip, 0, None)
+                .call(&ink_e2e::alice(), flip, 0, None)
                 .await
                 .expect("Calling `flip` failed");
             assert!(
@@ -95,7 +95,7 @@ pub mod integration_flipper {
             let get = build_message::<FlipperRef>(contract_acc_id.clone())
                 .call(|contract| contract.get());
             let get_call_result = client
-                .call(&mut ink_e2e::alice(), get, 0, None)
+                .call(&ink_e2e::alice(), get, 0, None)
                 .await
                 .expect("Calling `get` failed");
             let flipped_value = get_call_result
@@ -114,7 +114,7 @@ pub mod integration_flipper {
             let contract_acc_id = client
                 .instantiate(
                     "integration_flipper",
-                    &mut ink_e2e::bob(),
+                    &ink_e2e::bob(),
                     constructor,
                     0,
                     None,
@@ -126,7 +126,7 @@ pub mod integration_flipper {
             let get = build_message::<FlipperRef>(contract_acc_id.clone())
                 .call(|contract| contract.get());
             let get_call_result = client
-                .call(&mut ink_e2e::bob(), get, 0, None)
+                .call(&ink_e2e::bob(), get, 0, None)
                 .await
                 .expect("Calling `get` failed");
             let initial_value = get_call_result
@@ -136,7 +136,7 @@ pub mod integration_flipper {
             let err_flip = build_message::<FlipperRef>(contract_acc_id)
                 .call(|contract| contract.err_flip());
             let err_flip_call_result =
-                client.call(&mut ink_e2e::bob(), err_flip, 0, None).await;
+                client.call(&ink_e2e::bob(), err_flip, 0, None).await;
 
             assert!(matches!(
                 err_flip_call_result,
@@ -146,7 +146,7 @@ pub mod integration_flipper {
             let get = build_message::<FlipperRef>(contract_acc_id.clone())
                 .call(|contract| contract.get());
             let get_call_result = client
-                .call(&mut ink_e2e::bob(), get, 0, None)
+                .call(&ink_e2e::bob(), get, 0, None)
                 .await
                 .expect("Calling `get` failed");
             let flipped_value = get_call_result

--- a/examples/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/examples/lang-err-integration-tests/integration-flipper/lib.rs
@@ -112,13 +112,7 @@ pub mod integration_flipper {
         ) -> E2EResult<()> {
             let constructor = FlipperRef::default();
             let contract_acc_id = client
-                .instantiate(
-                    "integration_flipper",
-                    &ink_e2e::bob(),
-                    constructor,
-                    0,
-                    None,
-                )
+                .instantiate("integration_flipper", &ink_e2e::bob(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;


### PR DESCRIPTION
- Remove unused traits and struct, following on from #1518 
- Remove `mut` from signer ref, not required since the signer doesn't increment the nonce anymore. 