### PR TITLE
Bump `secp256k1` to `v0.24.2`

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -24,7 +24,7 @@ sha3 = { version = "0.10" }
 blake2 = { version = "0.10" }
 
 # ECDSA for the off-chain environment.
-secp256k1 = { version = "0.24", features = ["recovery", "global-context"], optional = true }
+secp256k1 = { version = "0.24.2", features = ["recovery", "global-context"], optional = true }
 
 [features]
 default = ["std"]

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -41,7 +41,7 @@ sha3 = { version = "0.10", optional = true }
 blake2 = { version = "0.10", optional = true }
 
 # ECDSA for the off-chain environment.
-secp256k1 = { version = "0.24", features = ["recovery", "global-context"], optional = true }
+secp256k1 = { version = "0.24.2", features = ["recovery", "global-context"], optional = true }
 
 # Only used in the off-chain environment.
 #


### PR DESCRIPTION
Versions `>= 0.24.0` have a soundness bug, so we need to ensure people
are using `>= 0.24.2`

See here for more: https://github.com/rustsec/advisory-db/pull/1480
