### PR TITLE
Remove `set_balance()` from the off-chain test_api as a duplicate function

### DIFF
--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -175,19 +175,6 @@ where
     })
 }
 
-/// Sets the balance of `account_id` to `new_balance`.
-pub fn set_balance<T>(account_id: T::AccountId, new_balance: T::Balance)
-where
-    T: Environment<Balance = u128>, // Just temporary for the MVP!
-    <T as Environment>::AccountId: From<[u8; 32]>,
-{
-    <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance
-            .engine
-            .set_balance(scale::Encode::encode(&account_id), new_balance);
-    })
-}
-
 /// Sets the value transferred from the caller to the callee as part of the call.
 ///
 /// Please note that the acting accounts should be set with [`set_caller()`] and [`set_callee()`] beforehand.


### PR DESCRIPTION
`ink::env::test::set_balance()` is just the same as `ink::env::test::set_account_balance()`. It was apparently mistakenly added during making the experimental off-chain engine the default one (see [ink#1144](https://github.com/paritytech/ink/pull/1144/files#diff-d388925fdaa4ef71cf03648e80d5e087cbb248271c13a396dd7d09516e59c93eR190))