### PR TITLE
Temporarily add `Determinism` enum from `pallet-contracts`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ variables:
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   # CI_IMAGE is changed to "-:staging" when the CI image gets rebuilt
   # read more https://github.com/paritytech/scripts/pull/244
-  CI_IMAGE:                        "paritytech/ink-ci-linux:production"
+  CI_IMAGE:                        "paritytech/ink-ci-linux:staging"
   PURELY_STD_CRATES:               "ink/codegen metadata engine"
   ALSO_WASM_CRATES:                "env storage storage/traits allocator prelude primitives ink ink/macro ink/ir"
   ALL_CRATES:                      "${PURELY_STD_CRATES} ${ALSO_WASM_CRATES}"

--- a/crates/ink/tests/ui/contract/fail/message-hygiene-checked.stderr
+++ b/crates/ink/tests/ui/contract/fail/message-hygiene-checked.stderr
@@ -1,8 +1,8 @@
-error[E0201]: duplicate definitions with name `message_checked`:
+error[E0592]: duplicate definitions with name `message_checked`
   --> tests/ui/contract/fail/message-hygiene-checked.rs:16:9
    |
 1  | #[ink::contract]
-   | ---------------- previous definition of `message_checked` here
+   | ---------------- other definition for `message_checked`
 ...
 16 |         pub fn message_checked(&self) {}
-   |         ^^^ duplicate definition
+   |         ^^^ duplicate definitions for `message_checked`

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -16,7 +16,7 @@ pub mod flipper {
 
         /// Creates a new flipper smart contract initialized to `false`.
         #[ink(constructor)]
-        pub fn default() -> Self {
+        pub fn default_value() -> Self {
             Self::new(Default::default())
         }
 
@@ -39,7 +39,7 @@ pub mod flipper {
 
         #[ink::test]
         fn default_works() {
-            let flipper = Flipper::default();
+            let flipper = Flipper::default_value();
             assert!(!flipper.get());
         }
 

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -16,7 +16,7 @@ pub mod flipper {
 
         /// Creates a new flipper smart contract initialized to `false`.
         #[ink(constructor)]
-        pub fn default_value() -> Self {
+        pub fn new_default() -> Self {
             Self::new(Default::default())
         }
 
@@ -39,7 +39,7 @@ pub mod flipper {
 
         #[ink::test]
         fn default_works() {
-            let flipper = Flipper::default_value();
+            let flipper = Flipper::new_default();
             assert!(!flipper.get());
         }
 

--- a/examples/incrementer/lib.rs
+++ b/examples/incrementer/lib.rs
@@ -14,7 +14,7 @@ mod incrementer {
         }
 
         #[ink(constructor)]
-        pub fn default() -> Self {
+        pub fn new_default() -> Self {
             Self::new(Default::default())
         }
 
@@ -35,7 +35,7 @@ mod incrementer {
 
         #[ink::test]
         fn default_works() {
-            let contract = Incrementer::default();
+            let contract = Incrementer::new_default();
             assert_eq!(contract.get(), 0);
         }
 

--- a/examples/lang-err-integration-tests/call-builder/lib.rs
+++ b/examples/lang-err-integration-tests/call-builder/lib.rs
@@ -104,7 +104,7 @@ mod call_builder {
                 .expect("instantiate failed")
                 .account_id;
 
-            let flipper_constructor = FlipperRef::default();
+            let flipper_constructor = FlipperRef::new_default();
             let flipper_acc_id = client
                 .instantiate(
                     "integration_flipper",

--- a/examples/lang-err-integration-tests/contract-ref/lib.rs
+++ b/examples/lang-err-integration-tests/contract-ref/lib.rs
@@ -13,7 +13,7 @@ mod contract_ref {
         #[ink(constructor)]
         pub fn new(version: u32, flipper_code_hash: Hash) -> Self {
             let salt = version.to_le_bytes();
-            let flipper = FlipperRef::default()
+            let flipper = FlipperRef::new_default()
                 .endowment(0)
                 .code_hash(flipper_code_hash)
                 .salt_bytes(salt)

--- a/examples/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/examples/lang-err-integration-tests/integration-flipper/lib.rs
@@ -21,7 +21,7 @@ pub mod integration_flipper {
 
         /// Creates a new integration_flipper smart contract initialized to `false`.
         #[ink(constructor)]
-        pub fn default() -> Self {
+        pub fn new_default() -> Self {
             Self::new(Default::default())
         }
 
@@ -58,7 +58,7 @@ pub mod integration_flipper {
         async fn e2e_can_flip_correctly(
             mut client: ink_e2e::Client<C, E>,
         ) -> E2EResult<()> {
-            let constructor = FlipperRef::default();
+            let constructor = FlipperRef::new_default();
             let contract_acc_id = client
                 .instantiate(
                     "integration_flipper",
@@ -110,7 +110,7 @@ pub mod integration_flipper {
         async fn e2e_message_error_reverts_state(
             mut client: ink_e2e::Client<C, E>,
         ) -> E2EResult<()> {
-            let constructor = FlipperRef::default();
+            let constructor = FlipperRef::new_default();
             let contract_acc_id = client
                 .instantiate("integration_flipper", &ink_e2e::bob(), constructor, 0, None)
                 .await

--- a/examples/mother/lib.rs
+++ b/examples/mother/lib.rs
@@ -146,7 +146,7 @@ mod mother {
         }
 
         #[ink(constructor)]
-        pub fn default() -> Self {
+        pub fn new_default() -> Self {
             Default::default()
         }
 
@@ -197,7 +197,7 @@ mod mother {
         #[ink::test]
         fn echo_auction_works() {
             let auction = Auction::default();
-            let mut contract = Mother::default();
+            let mut contract = Mother::new_default();
             assert_eq!(contract.echo_auction(auction.clone()), auction);
         }
 

--- a/examples/rand-extension/lib.rs
+++ b/examples/rand-extension/lib.rs
@@ -80,7 +80,7 @@ mod rand_extension {
         ///
         /// Constructors may delegate to other constructors.
         #[ink(constructor)]
-        pub fn default() -> Self {
+        pub fn new_default() -> Self {
             Self::new(Default::default())
         }
 
@@ -114,7 +114,7 @@ mod rand_extension {
         /// We test if the default constructor does its job.
         #[ink::test]
         fn default_works() {
-            let rand_extension = RandExtension::default();
+            let rand_extension = RandExtension::new_default();
             assert_eq!(rand_extension.get(), [0; 32]);
         }
 
@@ -141,7 +141,7 @@ mod rand_extension {
                 }
             }
             ink::env::test::register_chain_extension(MockedExtension);
-            let mut rand_extension = RandExtension::default();
+            let mut rand_extension = RandExtension::new_default();
             assert_eq!(rand_extension.get(), [0; 32]);
 
             // when

--- a/examples/upgradeable-contracts/set-code-hash/lib.rs
+++ b/examples/upgradeable-contracts/set-code-hash/lib.rs
@@ -19,7 +19,7 @@ pub mod incrementer {
 
         /// Creates a new counter smart contract initialized to `0`.
         #[ink(constructor)]
-        pub fn default() -> Self {
+        pub fn new_default() -> Self {
             Self::new(0)
         }
 

--- a/examples/upgradeable-contracts/set-code-hash/updated-incrementer/lib.rs
+++ b/examples/upgradeable-contracts/set-code-hash/updated-incrementer/lib.rs
@@ -24,7 +24,7 @@ pub mod incrementer {
 
         /// Creates a new counter smart contract initialized to `0`.
         #[ink(constructor)]
-        pub fn default() -> Self {
+        pub fn new_default() -> Self {
             Self::new(0)
         }
 


### PR DESCRIPTION
[Recent](https://github.com/paritytech/substrate-contracts-node/releases/tag/v0.23.0) release of substrate-contracts-node introduce new parameter `determinism` in [`upload_code()`](https://github.com/paritytech/substrate-contracts-node/blob/87a3d76c88058667d8c028b886a5e404ef9a70ea/runtime/src/lib.rs#L567) which needs to be specified on the ink! and cargo-contract sides, otherwise no E2E tests can be run with the latest substrate-contracts-node version.
`pallet-contracts` currently do not expose `pallet_contracts::Determinism` publicly.
Therefore, the temporary solution is to copy-paste the enum into the ink! codebase until the next release of `polkadot` branch in substrate and synchronisation of substrate-contracts-node