### PR TITLE
Apply `cargo clippy` suggestions

### DIFF
--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -110,9 +110,7 @@ impl InkE2ETest {
         );
 
         let contracts =
-            already_built_contracts
-                .iter()
-                .map(|(_manifest_path, bundle_path)| {
+            already_built_contracts.values().map(|bundle_path| {
                     quote! { #bundle_path }
                 });
 

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -109,10 +109,9 @@ impl InkE2ETest {
             "built contract artifacts must exist here"
         );
 
-        let contracts =
-            already_built_contracts.values().map(|bundle_path| {
-                    quote! { #bundle_path }
-                });
+        let contracts = already_built_contracts.values().map(|bundle_path| {
+            quote! { #bundle_path }
+        });
 
         quote! {
             #( #attrs )*

--- a/crates/engine/src/test_api.rs
+++ b/crates/engine/src/test_api.rs
@@ -188,12 +188,12 @@ impl Engine {
 
     /// Returns the total number of reads executed.
     pub fn count_reads(&self) -> usize {
-        self.debug_info.count_reads.iter().map(|(_, v)| v).sum()
+        self.debug_info.count_reads.values().sum()
     }
 
     /// Returns the total number of writes executed.
     pub fn count_writes(&self) -> usize {
-        self.debug_info.count_writes.iter().map(|(_, v)| v).sum()
+        self.debug_info.count_writes.values().sum()
     }
 
     /// Sets a caller for the next call.

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -29,7 +29,6 @@
     missing_docs,
     bad_style,
     bare_trait_objects,
-    const_err,
     improper_ctypes,
     non_shorthand_field_patterns,
     no_mangle_generic_items,

--- a/crates/ink/codegen/src/generator/events.rs
+++ b/crates/ink/codegen/src/generator/events.rs
@@ -223,7 +223,7 @@ impl<'a> Events<'a> {
                 ))
             };
             // Anonymous events require 1 fewer topics since they do not include their signature.
-            let anonymous_topics_offset = if event.anonymous { 0 } else { 1 };
+            let anonymous_topics_offset = usize::from(!event.anonymous);
             let remaining_topics_ty = match len_topics + anonymous_topics_offset {
                 0 => quote_spanned!(span=> ::ink::env::topics::state::NoRemainingTopics),
                 n => quote_spanned!(span=> [::ink::env::topics::state::HasRemainingTopics; #n]),

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -29,7 +29,6 @@
     missing_docs,
     bad_style,
     bare_trait_objects,
-    const_err,
     improper_ctypes,
     non_shorthand_field_patterns,
     no_mangle_generic_items,


### PR DESCRIPTION
This PR merely introduces few changes that were suggested by clippy.
It also removed `const_err` from whitelist since it will be a hard error in future: https://github.com/rust-lang/rust/issues/71800