### PR TITLE
Bump Dylint dependencies

### DIFF
--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -18,7 +18,7 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 crate-type = ["cdylib"]
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "0cb0f7636851f9fcc57085cf80197a2ef6db098f" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "f4850f7292efa33759b4f7f9b7621268979e9914" }
 dylint_linting = "2.0.0"
 if_chain = "1.0.2"
 log = "0.4.14"

--- a/linting/rust-toolchain.toml
+++ b/linting/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # https://github.com/trailofbits/dylint/tree/master/examples.
 
 [toolchain]
-channel = "nightly-2022-06-30"
-components = ["llvm-tools-preview", "rustc-dev"] 
+channel = "nightly-2022-11-21"
+components = ["llvm-tools-preview", "rustc-dev"]


### PR DESCRIPTION
Bumped according to those found [here](https://github.com/trailofbits/dylint/tree/master/examples/testing/clippy).

I'm hoping that using a newer `nightly` will let me fix #1413 🙈
