### PR TITLE
Ignore Substrate related dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+  - ignore:
+    - dependency-name: sp-*
+      versions:
+      - ">= 0"
+    - dependency-name: pallet-*
+      versions:
+      - ">= 0"


### PR DESCRIPTION
We need to manually update these in one go anyways, it doesn't make
sense to have dependabot open up 5+ PRs.
