### PR TITLE
Stabilize `take_storage`

### DIFF
--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -319,8 +319,6 @@ mod sys {
             output_ptr: Ptr32Mut<[u8]>,
         ) -> ReturnCode;
 
-        /// **WARNING**: this function is from the [unstable interface](https://github.com/paritytech/substrate/tree/master/frame/contracts#unstable-interfaces),
-        /// which is unsafe and normally is not available on production chains.
         pub fn take_storage(
             key_ptr: Ptr32<[u8]>,
             key_len: u32,


### PR DESCRIPTION
Follow-up to [substrate#13007](https://github.com/paritytech/substrate/pull/13007).

As we don't have `__unstable__` wasm module anymore, stabilizing here is basically just removal of the warning from the docs.