### PR TITLE
Migrate `flipper` waterfall test to e2e

### DIFF
--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -11,6 +11,9 @@ ink = { path = "../../crates/ink", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
+[dev-dependencies]
+ink_e2e = { path = "../../crates/e2e" }
+
 [lib]
 name = "flipper"
 path = "lib.rs"
@@ -24,3 +27,4 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
+e2e-tests = []

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -96,5 +96,29 @@ pub mod flipper {
 
             Ok(())
         }
+
+        #[ink_e2e::test]
+        async fn default_constructor(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let constructor = FlipperRef::new_default();
+
+            // when
+            let contract_acc_id = client
+                .instantiate("flipper", &ink_e2e::bob(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            // then
+            let get = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.get());
+            let get_res = client
+                .call(&ink_e2e::bob(), get, 0, None)
+                .await
+                .expect("get failed");
+            assert!(matches!(get_res.return_value(), Ok(false)));
+
+            Ok(())
+        }
     }
 }

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -51,4 +51,50 @@ pub mod flipper {
             assert!(flipper.get());
         }
     }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use super::*;
+        use ink_e2e::build_message;
+
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn flip(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let constructor = FlipperRef::new(false);
+            let contract_acc_id = client
+                .instantiate("flipper", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            let get = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.get());
+            let get_res = client
+                .call(&ink_e2e::bob(), get, 0, None)
+                .await
+                .expect("get failed");
+            assert!(matches!(get_res.return_value(), Ok(false)));
+
+            // when
+            let flip = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.flip());
+            let _flip_res = client
+                .call(&ink_e2e::bob(), flip, 0, None)
+                .await
+                .expect("flip failed");
+
+            // then
+            let get = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.get());
+            let get_res = client
+                .call(&ink_e2e::bob(), get, 0, None)
+                .await
+                .expect("get failed");
+            assert!(matches!(get_res.return_value(), Ok(true)));
+
+            Ok(())
+        }
+    }
 }

--- a/examples/flipper/lib.rs
+++ b/examples/flipper/lib.rs
@@ -60,7 +60,7 @@ pub mod flipper {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn flip(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn it_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
             // given
             let constructor = FlipperRef::new(false);
             let contract_acc_id = client
@@ -98,7 +98,7 @@ pub mod flipper {
         }
 
         #[ink_e2e::test]
-        async fn default_constructor(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn default_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
             // given
             let constructor = FlipperRef::new_default();
 


### PR DESCRIPTION
Part of https://github.com/paritytech/ink/issues/1510.

Tests copied from https://github.com/paritytech/ink-waterfall/blob/master/src/tests/flipper.rs#L32