### PR TITLE
Added Debug trait for EmittedEvent

### DIFF
--- a/crates/engine/src/test_api.rs
+++ b/crates/engine/src/test_api.rs
@@ -24,7 +24,7 @@ use crate::{
 use std::collections::HashMap;
 
 /// Record for an emitted event.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct EmittedEvent {
     /// Recorded topics of the emitted event.
     pub topics: Vec<Vec<u8>>,


### PR DESCRIPTION
Issue raised in #1577.


**Motivation**:
<img width="955" alt="image" src="https://user-images.githubusercontent.com/16472948/211474015-0c511587-2919-46d7-ad20-ca90c2a4f00a.png">

**Solution**:
Added a `Debug` trait for `EmittedEvent` to view the details in unit tests