### PR TITLE
dependabot: fix ignoring substrate deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
     # automated Substrate releases cause dependabot PR spam, so these must be updated manually when required.
     ignore:
       - dependency-name: "sp-*"
-        update-types: ["version-update:semver-major"]
+        update-types: [ "version-update:semver-major" ]
       - dependency-name: "pallet-*"
-        update-types: ["version-update:semver-major"]
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: github-actions
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,8 @@ updates:
     schedule:
       interval: daily
   - ignore:
-    - dependency-name: sp-*
-      versions:
-      - ">= 0"
-    - dependency-name: pallet-*
-      versions:
-      - ">= 0"
+      - dependency-name: sp-core
+      - dependency-name: sp-keyring
+      - dependency-name: sp-runtime
+      - dependency-name: sp-weights
+      - dependency-name: pallet-contracts-primitives

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "sp-*"
+        update-types: ["minor", "patch"]
+      - dependency-name: "pallet-*"
+        update-types: ["minor", "patch"]
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: daily
-  - ignore:
-    - dependency-name: sp-core
-    - dependency-name: sp-keyring
-    - dependency-name: sp-runtime
-    - dependency-name: sp-weights
-    - dependency-name: pallet-contracts-primitives

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # ignore Substrate pallets major updates.
+    # automated Substrate releases cause dependabot PR spam, so these must be updated manually when required.
     ignore:
       - dependency-name: "sp-*"
-        update-types: ["minor", "patch"]
+        update-types: ["major"]
       - dependency-name: "pallet-*"
-        update-types: ["minor", "patch"]
+        update-types: ["major"]
   - package-ecosystem: github-actions
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
     # automated Substrate releases cause dependabot PR spam, so these must be updated manually when required.
     ignore:
       - dependency-name: "sp-*"
-        update-types: ["major"]
+        update-types: ["version-update:semver-major"]
       - dependency-name: "pallet-*"
-        update-types: ["major"]
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
     schedule:
       interval: daily
   - ignore:
-      - dependency-name: sp-core
-      - dependency-name: sp-keyring
-      - dependency-name: sp-runtime
-      - dependency-name: sp-weights
-      - dependency-name: pallet-contracts-primitives
+    - dependency-name: sp-core
+    - dependency-name: sp-keyring
+    - dependency-name: sp-runtime
+    - dependency-name: sp-weights
+    - dependency-name: pallet-contracts-primitives


### PR DESCRIPTION
The `ignore` config from #1561 [don't seem to be working](https://github.com/paritytech/ink/pulls?q=is%3Apr+sp-) to prevent dependabot PRs.

This PR moves the ignore section to the `cargo` `updates` section as per the example in the docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore.

Also only ignores major updates since the automatic substrate releases process seems to do frequent major version bumps.