### PR TITLE
Remove `seal_` prefix from `seal_return`

### DIFF
--- a/crates/env/src/engine/on_chain/ext.rs
+++ b/crates/env/src/engine/on_chain/ext.rs
@@ -240,7 +240,7 @@ mod sys {
         ) -> ReturnCode;
 
         pub fn input(buf_ptr: Ptr32Mut<[u8]>, buf_len_ptr: Ptr32Mut<u32>);
-        pub fn seal_return(flags: u32, data_ptr: Ptr32<[u8]>, data_len: u32) -> !;
+        pub fn r#return(flags: u32, data_ptr: Ptr32<[u8]>, data_len: u32) -> !;
 
         pub fn caller(output_ptr: Ptr32Mut<[u8]>, output_len_ptr: Ptr32Mut<u32>);
         pub fn block_number(output_ptr: Ptr32Mut<[u8]>, output_len_ptr: Ptr32Mut<u32>);
@@ -631,7 +631,7 @@ pub fn input(output: &mut &mut [u8]) {
 
 pub fn return_value(flags: ReturnFlags, return_value: &[u8]) -> ! {
     unsafe {
-        sys::seal_return(
+        sys::r#return(
             flags.into_u32(),
             Ptr32::from_slice(return_value),
             return_value.len() as u32,

--- a/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
@@ -1,39 +1,39 @@
 error[E0277]: the trait bound `NonCodec: WrapperTypeEncode` is not satisfied
-  --> tests/ui/trait_def/fail/message_output_non_codec.rs:6:26
-   |
-6  |     fn message(&self) -> NonCodec;
-   |                          ^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NonCodec`
-   |
-   = help: the following other types implement trait `WrapperTypeEncode`:
-             &T
-             &mut T
-             Arc<T>
-             Box<T>
-             Cow<'a, T>
-             Rc<T>
-             String
-             Vec<T>
-             parity_scale_codec::Ref<'a, T, U>
-   = note: required for `NonCodec` to implement `Encode`
+ --> tests/ui/trait_def/fail/message_output_non_codec.rs:6:26
+  |
+6 |     fn message(&self) -> NonCodec;
+  |                          ^^^^^^^^ the trait `WrapperTypeEncode` is not implemented for `NonCodec`
+  |
+  = help: the following other types implement trait `WrapperTypeEncode`:
+            &T
+            &mut T
+            Arc<T>
+            Box<T>
+            Cow<'a, T>
+            Rc<T>
+            String
+            Vec<T>
+            parity_scale_codec::Ref<'a, T, U>
+  = note: required for `NonCodec` to implement `Encode`
 note: required by a bound in `DispatchOutput`
-  --> src/codegen/dispatch/type_check.rs
-   |
-   |     T: scale::Encode + 'static;
-   |        ^^^^^^^^^^^^^ required by this bound in `DispatchOutput`
+ --> src/codegen/dispatch/type_check.rs
+  |
+  |     T: scale::Encode + 'static;
+  |        ^^^^^^^^^^^^^ required by this bound in `DispatchOutput`
 
 error[E0599]: the method `fire` exists for struct `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodec>>>`, but its trait bounds were not satisfied
-   --> tests/ui/trait_def/fail/message_output_non_codec.rs:5:5
-    |
-1   | pub struct NonCodec;
-    | ------------------- doesn't satisfy `NonCodec: parity_scale_codec::Decode`
+ --> tests/ui/trait_def/fail/message_output_non_codec.rs:5:5
+  |
+1 | pub struct NonCodec;
+  | ------------------- doesn't satisfy `NonCodec: parity_scale_codec::Decode`
 ...
-5   |     #[ink(message)]
-    |     ^ method cannot be called on `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodec>>>` due to unsatisfied trait bounds
-    |
-    = note: the following trait bounds were not satisfied:
-            `NonCodec: parity_scale_codec::Decode`
+5 |     #[ink(message)]
+  |     ^ method cannot be called on `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodec>>>` due to unsatisfied trait bounds
+  |
+  = note: the following trait bounds were not satisfied:
+          `NonCodec: parity_scale_codec::Decode`
 note: the following trait must be implemented
-   --> $CARGO/parity-scale-codec-3.2.1/src/codec.rs
-    |
-    | pub trait Decode: Sized {
-    | ^^^^^^^^^^^^^^^^^^^^^^^
+ --> $CARGO/parity-scale-codec-3.2.2/src/codec.rs
+  |
+  | pub trait Decode: Sized {
+  | ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
We removed the prefixes a while back. This functions seem to be overlooked. Maybe because the name is a keyword.