### PR TITLE
Release `v4.0.0-beta.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,26 +4,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-- Add E2E testing framework MVP ‒ [#1395](https://github.com/paritytech/ink/pull/1395)
-- Add E2E tests for `Mapping` functions - [#1492](https://github.com/paritytech/ink/pull/1492)
-- Make CallBuilder and CreateBuilder error handling optional - [#1602](https://github.com/paritytech/ink/pull/1602)
-- Rename `CallBuilder::fire()` method to `invoke()` - [#1604](https://github.com/paritytech/ink/pull/1604)
-- Chain Extension: Evaluation of method return type at compile time - [#1569](https://github.com/paritytech/ink/pull/1569).
+## [Unreleased]
+
+## Version 4.0.0-beta.1
+The coolest feature included in this release is the first first published version of
+ink!'s native ["end-to-end" (E2E) testing framework](https://github.com/paritytech/ink/issues/1234).
+
+This enables testing of a contract by deploying and calling it on a Substrate node with
+`pallet-contracts`. See the [`erc20` example](./examples/erc20/lib.rs) for usage.
 
 ### Breaking Changes
-With this release there are three breaking changes related to the `CallBuilder`
-`CreateBuilder` and the Chain Extension API.
+This release includes a couple of breaking changes.
 
-1. The `invoke()` methods now unwrap the `Result` from `pallet-contracts` under the hood
-   ([#1602](https://github.com/paritytech/ink/pull/1602)).
+1. The `CallBuilder::returns()` method does not require an extra `MessageResult` anymore
+   as the type is now added under the hood [(#1525)](https://github.com/paritytech/ink/pull/1525)
+1. The `CallBuilder::invoke()` and `CreateBuilder::instantiate() `methods now unwrap the
+   `Result` from `pallet-contracts` under the hood ([#1602](https://github.com/paritytech/ink/pull/1602))
    If you wish to handle the error use the new `try_` variants of those methods instead.
 1. The `CallBuilder::fire()` method has been renamed to `invoke()`
    ([#1604](https://github.com/paritytech/ink/pull/1604))
 1. The `returns_result` flag has been removed from the `#[ink(extension = …)]` attribute
-   ([#1569](https://github.com/paritytech/ink/pull/1569)).
+   ([#1569](https://github.com/paritytech/ink/pull/1569))
    We now infer this information at compile time. If `handle_status` is set to `true`,
    the return type will still be wrapped into `Result` as before.
+1. The Minimum Supported Rust Version (MSRV) has been set to `1.63.0`. This was already
+   the case, but previously it was enforced by `cargo-contract` instead of ink!
+   ([#1609](https://github.com/paritytech/ink/pull/1609))
+
+### Added
+- Add E2E testing framework MVP ‒ [#1395](https://github.com/paritytech/ink/pull/1395)
+- Add E2E tests for `Mapping` functions - [#1492](https://github.com/paritytech/ink/pull/1492)
+
+### Fixed
+- Add Determinism enum from pallet-contracts ‒ [#1547](https://github.com/paritytech/ink/pull/1547)
+- Added missed `WhereClosure` for the generics into `storage_item` ‒ [#1536](https://github.com/paritytech/ink/pull/1536)
+
+### Changed
+- Handle `LangError` from instantiate ‒ [#1512](https://github.com/paritytech/ink/pull/1512)
+- FFI: no more `__unstable__` wasm import module ‒ [#1522](https://github.com/paritytech/ink/pull/1522)
+- Clean up CallBuilder `return()` type ‒ [#1525](https://github.com/paritytech/ink/pull/1525)
+- Fix trait message return type metadata ‒ [#1531](https://github.com/paritytech/ink/pull/1531)
+- Bump Dylint dependencies ‒ [#1551](https://github.com/paritytech/ink/pull/1551)
+- Stabilize `take_storage` ‒ [#1568](https://github.com/paritytech/ink/pull/1568)
+- Chain Extension: Evaluation of method return type at compile time ‒ [#1569](https://github.com/paritytech/ink/pull/1569).
+- Make more functions be const ‒ [#1574](https://github.com/paritytech/ink/pull/1574)
+- Unify fallible and non fallible `instantiate` methods ‒ [#1591](https://github.com/paritytech/ink/pull/1591)
+- Make `CallBuilder` and `CreateBuilder` error handling optional ‒ [#1602](https://github.com/paritytech/ink/pull/1602)
+- Rename `CallBuilder::fire()` method to `invoke()` ‒ [#1604](https://github.com/paritytech/ink/pull/1604)
+- chore: add minimum rust version to the ink crate ‒ [#1609](https://github.com/paritytech/ink/pull/1609)
 
 ## Version 4.0.0-beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ This release includes a couple of breaking changes.
 
 ### Fixed
 - Add Determinism enum from pallet-contracts ‒ [#1547](https://github.com/paritytech/ink/pull/1547)
-- Added missed `WhereClosure` for the generics into `storage_item` ‒ [#1536](https://github.com/paritytech/ink/pull/1536)
+- Added missed `WhereClosure` for the generics into `storage_item` ‒ [#1536](https://github.com/paritytech/ink/pull/1536) (thanks [@xgreenx](https://github.com/xgreenx))
 
 ### Changed
 - Handle `LangError` from instantiate ‒ [#1512](https://github.com/paritytech/ink/pull/1512)
@@ -46,12 +46,12 @@ This release includes a couple of breaking changes.
 - Fix trait message return type metadata ‒ [#1531](https://github.com/paritytech/ink/pull/1531)
 - Bump Dylint dependencies ‒ [#1551](https://github.com/paritytech/ink/pull/1551)
 - Stabilize `take_storage` ‒ [#1568](https://github.com/paritytech/ink/pull/1568)
-- Chain Extension: Evaluation of method return type at compile time ‒ [#1569](https://github.com/paritytech/ink/pull/1569).
-- Make more functions be const ‒ [#1574](https://github.com/paritytech/ink/pull/1574)
+- Chain Extension: Evaluation of method return type at compile time ‒ [#1569](https://github.com/paritytech/ink/pull/1569)
+- Make more functions be const ‒ [#1574](https://github.com/paritytech/ink/pull/1574) (thanks [@yjhmelody](https://github.com/yjhmelody))
 - Unify fallible and non fallible `instantiate` methods ‒ [#1591](https://github.com/paritytech/ink/pull/1591)
 - Make `CallBuilder` and `CreateBuilder` error handling optional ‒ [#1602](https://github.com/paritytech/ink/pull/1602)
 - Rename `CallBuilder::fire()` method to `invoke()` ‒ [#1604](https://github.com/paritytech/ink/pull/1604)
-- chore: add minimum rust version to the ink crate ‒ [#1609](https://github.com/paritytech/ink/pull/1609)
+- chore: add minimum rust version to the ink crate ‒ [#1609](https://github.com/paritytech/ink/pull/1609) (thanks [@Kurtsley](https://github.com/Kurtsley))
 
 ## Version 4.0.0-beta
 

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_allocator"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -3,7 +3,6 @@ name = "ink_e2e"
 version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-publish = false
 
 license = "Apache-2.0"
 readme = "README.md"

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_e2e"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
@@ -16,10 +16,10 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_e2e_macro = { version = "4.0.0-beta", path = "./macro" }
-ink = { version = "4.0.0-beta", path = "../ink" }
-ink_env = { version = "4.0.0-beta", path = "../env" }
-ink_primitives = { version = "4.0.0-beta", path = "../primitives" }
+ink_e2e_macro = { version = "4.0.0-beta.1", path = "./macro" }
+ink = { version = "4.0.0-beta.1", path = "../ink" }
+ink_env = { version = "4.0.0-beta.1", path = "../env" }
+ink_primitives = { version = "4.0.0-beta.1", path = "../primitives" }
 
 contract-metadata = { version = "2.0.0-rc" }
 impl-serde = { version = "0.3.1", default-features = false }

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -3,7 +3,6 @@ name = "ink_e2e_macro"
 version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-publish = false
 
 license = "Apache-2.0"
 readme = "../README.md"

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_e2e_macro"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
@@ -20,7 +20,7 @@ name = "ink_e2e_macro"
 proc-macro = true
 
 [dependencies]
-ink_ir = { version = "4.0.0-beta", path = "../../ink/ir" }
+ink_ir = { version = "4.0.0-beta.1", path = "../../ink/ir" }
 contract-build = "2.0.0-beta.1"
 derive_more = "0.99.17"
 env_logger = "0.10.0"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_engine"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Michael Müller <michi@parity.io>"]
 edition = "2021"
 
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_primitives = { version = "4.0.0-beta", path = "../../crates/primitives", default-features = false }
+ink_primitives = { version = "4.0.0-beta.1", path = "../../crates/primitives", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_env"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "4.0.0-beta", path = "../metadata", default-features = false, features = ["derive"], optional = true }
-ink_allocator = { version = "4.0.0-beta", path = "../allocator", default-features = false }
-ink_storage_traits = { version = "4.0.0-beta", path = "../storage/traits", default-features = false }
-ink_prelude = { version = "4.0.0-beta", path = "../prelude", default-features = false }
-ink_primitives = { version = "4.0.0-beta", path = "../primitives", default-features = false }
+ink_metadata = { version = "4.0.0-beta.1", path = "../metadata", default-features = false, features = ["derive"], optional = true }
+ink_allocator = { version = "4.0.0-beta.1", path = "../allocator", default-features = false }
+ink_storage_traits = { version = "4.0.0-beta.1", path = "../storage/traits", default-features = false }
+ink_prelude = { version = "4.0.0-beta.1", path = "../prelude", default-features = false }
+ink_primitives = { version = "4.0.0-beta.1", path = "../primitives", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -33,7 +33,7 @@ static_assertions = "1.1"
 rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ink_engine = { version = "4.0.0-beta", path = "../engine/", optional = true }
+ink_engine = { version = "4.0.0-beta.1", path = "../engine/", optional = true }
 
 # Hashes for the off-chain environment.
 sha2 = { version = "0.10", optional = true }

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 rust-version = "1.63"
@@ -16,12 +16,12 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.0.0-beta", path = "../env", default-features = false }
-ink_storage = { version = "4.0.0-beta", path = "../storage", default-features = false }
-ink_primitives = { version = "4.0.0-beta", path = "../primitives", default-features = false }
-ink_metadata = { version = "4.0.0-beta", path = "../metadata", default-features = false, optional = true }
-ink_prelude = { version = "4.0.0-beta", path = "../prelude", default-features = false }
-ink_macro = { version = "4.0.0-beta", path = "macro", default-features = false }
+ink_env = { version = "4.0.0-beta.1", path = "../env", default-features = false }
+ink_storage = { version = "4.0.0-beta.1", path = "../storage", default-features = false }
+ink_primitives = { version = "4.0.0-beta.1", path = "../primitives", default-features = false }
+ink_metadata = { version = "4.0.0-beta.1", path = "../metadata", default-features = false, optional = true }
+ink_prelude = { version = "4.0.0-beta.1", path = "../prelude", default-features = false }
+ink_macro = { version = "4.0.0-beta.1", path = "macro", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_codegen"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -18,8 +18,8 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 name = "ink_codegen"
 
 [dependencies]
-ink_primitives = { version = "4.0.0-beta", path = "../../primitives" }
-ir = { version = "4.0.0-beta", package = "ink_ir", path = "../ir", default-features = false }
+ink_primitives = { version = "4.0.0-beta.1", path = "../../primitives" }
+ir = { version = "4.0.0-beta.1", package = "ink_ir", path = "../ir", default-features = false }
 quote = "1"
 syn = { version = "1.0", features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = "1.0"

--- a/crates/ink/ir/Cargo.toml
+++ b/crates/ink/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_ir"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_macro"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,9 +15,9 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_ir = { version = "4.0.0-beta", path = "../ir", default-features = false }
-ink_codegen = { version = "4.0.0-beta", path = "../codegen", default-features = false }
-ink_primitives = { version = "4.0.0-beta", path = "../../primitives/", default-features = false }
+ink_ir = { version = "4.0.0-beta.1", path = "../ir", default-features = false }
+ink_codegen = { version = "4.0.0-beta.1", path = "../codegen", default-features = false }
+ink_primitives = { version = "4.0.0-beta.1", path = "../../primitives/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 syn = "1"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_metadata"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,8 +15,8 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "4.0.0-beta", path = "../prelude/", default-features = false }
-ink_primitives = { version = "4.0.0-beta", path = "../primitives/", default-features = false }
+ink_prelude = { version = "4.0.0-beta.1", path = "../prelude/", default-features = false }
+ink_primitives = { version = "4.0.0-beta.1", path = "../primitives/", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.4.0"

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_prelude"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_primitives"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -16,7 +16,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-ink_prelude = { version = "4.0.0-beta", path = "../prelude/", default-features = false }
+ink_prelude = { version = "4.0.0-beta.1", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", features = ["const_xxh32"] }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.0.0-beta", path = "../env/", default-features = false }
-ink_metadata = { version = "4.0.0-beta", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.0.0-beta", path = "../primitives/", default-features = false }
-ink_storage_traits = { version = "4.0.0-beta", path = "traits", default-features = false }
-ink_prelude = { version = "4.0.0-beta", path = "../prelude/", default-features = false }
+ink_env = { version = "4.0.0-beta.1", path = "../env/", default-features = false }
+ink_metadata = { version = "4.0.0-beta.1", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "4.0.0-beta.1", path = "../primitives/", default-features = false }
+ink_storage_traits = { version = "4.0.0-beta.1", path = "traits", default-features = false }
+ink_prelude = { version = "4.0.0-beta.1", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage_traits"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -15,9 +15,9 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "4.0.0-beta", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.0.0-beta", path = "../../primitives", default-features = false }
-ink_prelude = { version = "4.0.0-beta", path = "../../prelude", default-features = false }
+ink_metadata = { version = "4.0.0-beta.1", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "4.0.0-beta.1", path = "../../primitives", default-features = false }
+ink_prelude = { version = "4.0.0-beta.1", path = "../../prelude", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 syn = { version = "1", features = ["full"] }

--- a/examples/contract-terminate/Cargo.toml
+++ b/examples/contract-terminate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_terminate"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/contract-transfer/Cargo.toml
+++ b/examples/contract-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_transfer"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/Cargo.toml
+++ b/examples/delegator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegator"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/delegator/accumulator/Cargo.toml
+++ b/examples/delegator/accumulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulator"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/adder/Cargo.toml
+++ b/examples/delegator/adder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adder"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/delegator/subber/Cargo.toml
+++ b/examples/delegator/subber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subber"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/dns/Cargo.toml
+++ b/examples/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc1155"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc20"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc721"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/flipper/Cargo.toml
+++ b/examples/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/incrementer/Cargo.toml
+++ b/examples/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/lang-err-integration-tests/call-builder/Cargo.toml
+++ b/examples/lang-err-integration-tests/call-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/lang-err-integration-tests/constructors-return-value/Cargo.toml
+++ b/examples/lang-err-integration-tests/constructors-return-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constructors_return_value"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/lang-err-integration-tests/contract-ref/Cargo.toml
+++ b/examples/lang-err-integration-tests/contract-ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_ref"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/examples/lang-err-integration-tests/integration-flipper/Cargo.toml
+++ b/examples/lang-err-integration-tests/integration-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_flipper"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/mapping_integration_tests/Cargo.toml
+++ b/examples/mapping_integration_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mapping-integration-tests"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/mother/Cargo.toml
+++ b/examples/mother/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mother"
 description = "Mother of all contracts"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/multisig/Cargo.toml
+++ b/examples/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/payment-channel/Cargo.toml
+++ b/examples/payment-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payment_channel"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/psp22-extension/Cargo.toml
+++ b/examples/psp22-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_extension"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/rand-extension/Cargo.toml
+++ b/examples/rand-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_extension"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-erc20/Cargo.toml
+++ b/examples/trait-erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_erc20"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-flipper/Cargo.toml
+++ b/examples/trait-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_flipper"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/Cargo.toml
+++ b/examples/trait-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/trait-incrementer/traits/Cargo.toml
+++ b/examples/trait-incrementer/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traits"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/forward-calls/Cargo.toml
+++ b/examples/upgradeable-contracts/forward-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forward_calls"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false

--- a/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated-incrementer"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_linting"
-version = "4.0.0-beta"
+version = "4.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false


### PR DESCRIPTION
_This supersedes #1590, but RC coming soon™_

## Version 4.0.0-beta.1
The coolest feature included in this release is the first first published version of
ink!'s native ["end-to-end" (E2E) testing framework](https://github.com/paritytech/ink/issues/1234).

This enables testing of a contract by deploying and calling it on a Substrate node with
`pallet-contracts`. See the [`erc20` example](./examples/erc20/lib.rs) for usage.

### Breaking Changes
This release includes a couple of breaking changes.

1. The `CallBuilder::returns()` method does not require an extra `MessageResult` anymore
   as the type is now added under the hood [(#1525)](https://github.com/paritytech/ink/pull/1525)
1. The `CallBuilder::invoke()` and `CreateBuilder::instantiate() `methods now unwrap the
   `Result` from `pallet-contracts` under the hood ([#1602](https://github.com/paritytech/ink/pull/1602))
   If you wish to handle the error use the new `try_` variants of those methods instead.
1. The `CallBuilder::fire()` method has been renamed to `invoke()`
   ([#1604](https://github.com/paritytech/ink/pull/1604))
1. The `returns_result` flag has been removed from the `#[ink(extension = …)]` attribute
   ([#1569](https://github.com/paritytech/ink/pull/1569))
   We now infer this information at compile time. If `handle_status` is set to `true`,
   the return type will still be wrapped into `Result` as before.
1. The Minimum Supported Rust Version (MSRV) has been set to `1.63.0`. This was already
   the case, but previously it was enforced by `cargo-contract` instead of ink!
   ([#1609](https://github.com/paritytech/ink/pull/1609))

### Added
- Add E2E testing framework MVP ‒ [#1395](https://github.com/paritytech/ink/pull/1395)
- Add E2E tests for `Mapping` functions - [#1492](https://github.com/paritytech/ink/pull/1492)

### Fixed
- Add Determinism enum from pallet-contracts ‒ [#1547](https://github.com/paritytech/ink/pull/1547)
- Added missed `WhereClosure` for the generics into `storage_item` ‒ [#1536](https://github.com/paritytech/ink/pull/1536) (thanks [@xgreenx](https://github.com/xgreenx))

### Changed
- Handle `LangError` from instantiate ‒ [#1512](https://github.com/paritytech/ink/pull/1512)
- FFI: no more `__unstable__` wasm import module ‒ [#1522](https://github.com/paritytech/ink/pull/1522)
- Clean up CallBuilder `return()` type ‒ [#1525](https://github.com/paritytech/ink/pull/1525)
- Fix trait message return type metadata ‒ [#1531](https://github.com/paritytech/ink/pull/1531)
- Bump Dylint dependencies ‒ [#1551](https://github.com/paritytech/ink/pull/1551)
- Stabilize `take_storage` ‒ [#1568](https://github.com/paritytech/ink/pull/1568)
- Chain Extension: Evaluation of method return type at compile time ‒ [#1569](https://github.com/paritytech/ink/pull/1569)
- Make more functions be const ‒ [#1574](https://github.com/paritytech/ink/pull/1574) (thanks [@yjhmelody](https://github.com/yjhmelody))
- Unify fallible and non fallible `instantiate` methods ‒ [#1591](https://github.com/paritytech/ink/pull/1591)
- Make `CallBuilder` and `CreateBuilder` error handling optional ‒ [#1602](https://github.com/paritytech/ink/pull/1602)
- Rename `CallBuilder::fire()` method to `invoke()` ‒ [#1604](https://github.com/paritytech/ink/pull/1604)
- chore: add minimum rust version to the ink crate ‒ [#1609](https://github.com/paritytech/ink/pull/1609) (thanks [@Kurtsley](https://github.com/Kurtsley))
