### PR TITLE
Make cross-contract callee non-optional

### DIFF
--- a/crates/env/src/call/call_builder.rs
+++ b/crates/env/src/call/call_builder.rs
@@ -28,7 +28,6 @@ use crate::{
     Error,
 };
 use core::marker::PhantomData;
-use ink_primitives::Clear;
 use num_traits::Zero;
 
 /// The final parameters to the cross-contract call.
@@ -265,8 +264,7 @@ where
 /// # use ink_primitives::Clear;
 /// # type AccountId = <DefaultEnvironment as Environment>::AccountId;
 /// let my_return_value: i32 = build_call::<DefaultEnvironment>()
-///     .call_type(DelegateCall::new()
-///                 .code_hash(<DefaultEnvironment as Environment>::Hash::CLEAR_HASH))
+///     .code_hash(<DefaultEnvironment as Environment>::Hash::CLEAR_HASH)
 ///     .exec_input(
 ///         ExecutionInput::new(Selector::new([0xDE, 0xAD, 0xBE, 0xEF]))
 ///             .push_arg(42u8)
@@ -381,16 +379,8 @@ pub struct DelegateCall<E: Environment> {
 
 impl<E: Environment> DelegateCall<E> {
     /// Returns a clean builder for [`DelegateCall`]
-    pub const fn new() -> Self {
-        DelegateCall {
-            code_hash: E::Hash::CLEAR_HASH,
-        }
-    }
-}
-
-impl<E: Environment> Default for DelegateCall<E> {
-    fn default() -> Self {
-        Self::new()
+    pub const fn new(code_hash: E::Hash) -> Self {
+        DelegateCall { code_hash }
     }
 }
 
@@ -509,6 +499,20 @@ where
     ) -> CallBuilder<E, Set<Call<E>>, Args, RetType> {
         CallBuilder {
             call_type: Set(Call::new(callee)),
+            call_flags: self.call_flags,
+            exec_input: self.exec_input,
+            return_type: self.return_type,
+            _phantom: Default::default(),
+        }
+    }
+
+    /// Sets the `code_hash` for the current cross-contract delegate call.
+    pub fn code_hash(
+        self,
+        code_hash: E::Hash,
+    ) -> CallBuilder<E, Set<DelegateCall<E>>, Args, RetType> {
+        CallBuilder {
+            call_type: Set(DelegateCall::new(code_hash)),
             call_flags: self.call_flags,
             exec_input: self.exec_input,
             return_type: self.return_type,

--- a/crates/env/src/call/call_builder.rs
+++ b/crates/env/src/call/call_builder.rs
@@ -202,7 +202,7 @@ where
 /// # type AccountId = <DefaultEnvironment as Environment>::AccountId;
 /// # type Balance = <DefaultEnvironment as Environment>::Balance;
 /// build_call::<DefaultEnvironment>()
-///     .callee(AccountId::from([0x42; 32]))
+///     .call(AccountId::from([0x42; 32]))
 ///     .gas_limit(5000)
 ///     .transferred_value(10)
 ///     .exec_input(
@@ -236,7 +236,7 @@ where
 /// # };
 /// # type AccountId = <DefaultEnvironment as Environment>::AccountId;
 /// let my_return_value: i32 = build_call::<DefaultEnvironment>()
-///     .callee(AccountId::from([0x42; 32]))
+///     .call_type(Call::new(AccountId::from([0x42; 32])))
 ///     .gas_limit(5000)
 ///     .transferred_value(10)
 ///     .exec_input(
@@ -264,7 +264,7 @@ where
 /// # use ink_primitives::Clear;
 /// # type AccountId = <DefaultEnvironment as Environment>::AccountId;
 /// let my_return_value: i32 = build_call::<DefaultEnvironment>()
-///     .code_hash(<DefaultEnvironment as Environment>::Hash::CLEAR_HASH)
+///     .delegate(<DefaultEnvironment as Environment>::Hash::CLEAR_HASH)
 ///     .exec_input(
 ///         ExecutionInput::new(Selector::new([0xDE, 0xAD, 0xBE, 0xEF]))
 ///             .push_arg(42u8)
@@ -299,7 +299,7 @@ where
 /// # type AccountId = <DefaultEnvironment as Environment>::AccountId;
 /// # type Balance = <DefaultEnvironment as Environment>::Balance;
 /// let call_result = build_call::<DefaultEnvironment>()
-///     .callee(AccountId::from([0x42; 32]))
+///     .call(AccountId::from([0x42; 32]))
 ///     .gas_limit(5000)
 ///     .transferred_value(10)
 ///     .try_invoke()
@@ -492,8 +492,8 @@ impl<E, CallType, Args, RetType> CallBuilder<E, Unset<CallType>, Args, RetType>
 where
     E: Environment,
 {
-    /// Sets the `callee` for the current cross-contract call.
-    pub fn callee(
+    /// Prepares the `CallBuilder` for a cross-contract [`Call`].
+    pub fn call(
         self,
         callee: E::AccountId,
     ) -> CallBuilder<E, Set<Call<E>>, Args, RetType> {
@@ -506,8 +506,8 @@ where
         }
     }
 
-    /// Sets the `code_hash` for the current cross-contract delegate call.
-    pub fn code_hash(
+    /// Prepares the `CallBuilder` for a cross-contract [`DelegateCall`].
+    pub fn delegate(
         self,
         code_hash: E::Hash,
     ) -> CallBuilder<E, Set<DelegateCall<E>>, Args, RetType> {

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -412,11 +412,7 @@ impl TypedEnvBackend for EnvInstance {
     {
         let mut scope = self.scoped_buffer();
         let gas_limit = params.gas_limit();
-        let callee = params
-            .callee()
-            .as_ref()
-            .expect("An account ID must be set in order to call a contract.");
-        let enc_callee = scope.take_encoded(callee);
+        let enc_callee = scope.take_encoded(params.callee());
         let enc_transferred_value = scope.take_encoded(params.transferred_value());
         let call_flags = params.call_flags();
         let enc_input = if !call_flags.forward_input() && !call_flags.clone_input() {

--- a/crates/ink/codegen/src/generator/as_dependency/call_builder.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/call_builder.rs
@@ -391,7 +391,7 @@ impl CallBuilder<'_> {
                 #( , #input_bindings : #input_types )*
             ) -> #output_type {
                 ::ink::env::call::build_call::<Environment>()
-                    .callee(::ink::ToAccountId::to_account_id(self))
+                    .call(::ink::ToAccountId::to_account_id(self))
                     .exec_input(
                         ::ink::env::call::ExecutionInput::new(
                             ::ink::env::call::Selector::new([ #( #selector_bytes ),* ])

--- a/crates/ink/codegen/src/generator/as_dependency/call_builder.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/call_builder.rs
@@ -391,7 +391,7 @@ impl CallBuilder<'_> {
                 #( , #input_bindings : #input_types )*
             ) -> #output_type {
                 ::ink::env::call::build_call::<Environment>()
-                    .call_type(::ink::env::call::Call::new().callee(::ink::ToAccountId::to_account_id(self)))
+                    .callee(::ink::ToAccountId::to_account_id(self))
                     .exec_input(
                         ::ink::env::call::ExecutionInput::new(
                             ::ink::env::call::Selector::new([ #( #selector_bytes ),* ])

--- a/crates/ink/codegen/src/generator/trait_def/call_builder.rs
+++ b/crates/ink/codegen/src/generator/trait_def/call_builder.rs
@@ -319,7 +319,7 @@ impl CallBuilder<'_> {
                 #( , #input_bindings : #input_types )*
             ) -> Self::#output_ident {
                 ::ink::env::call::build_call::<Self::Env>()
-                    .call_type(::ink::env::call::Call::new().callee(::ink::ToAccountId::to_account_id(self)))
+                    .callee(::ink::ToAccountId::to_account_id(self))
                     .exec_input(
                         ::ink::env::call::ExecutionInput::new(
                             ::ink::env::call::Selector::new([ #( #selector_bytes ),* ])

--- a/crates/ink/codegen/src/generator/trait_def/call_builder.rs
+++ b/crates/ink/codegen/src/generator/trait_def/call_builder.rs
@@ -319,7 +319,7 @@ impl CallBuilder<'_> {
                 #( , #input_bindings : #input_types )*
             ) -> Self::#output_ident {
                 ::ink::env::call::build_call::<Self::Env>()
-                    .callee(::ink::ToAccountId::to_account_id(self))
+                    .call(::ink::ToAccountId::to_account_id(self))
                     .exec_input(
                         ::ink::env::call::ExecutionInput::new(
                             ::ink::env::call::Selector::new([ #( #selector_bytes ),* ])

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -266,7 +266,7 @@ where
     /// # Example
     ///
     /// ```
-    /// 
+    ///
     /// #[ink::contract]
     /// pub mod only_owner {
     ///     #[ink(storage)]
@@ -344,7 +344,7 @@ where
     /// # Example
     ///
     /// ```
-    /// 
+    ///
     /// #[ink::contract]
     /// pub mod my_contract {
     ///     #[ink(storage)]
@@ -524,8 +524,7 @@ where
     /// pub fn invoke_contract(&self) -> i32 {
     ///     let call_params = build_call::<DefaultEnvironment>()
     ///             .call_type(
-    ///                 Call::new()
-    ///                     .callee(AccountId::from([0x42; 32]))
+    ///                 Call::new(AccountId::from([0x42; 32]))
     ///                     .gas_limit(5000)
     ///                     .transferred_value(10))
     ///             .exec_input(
@@ -588,8 +587,7 @@ where
     /// pub fn invoke_contract_delegate(&self) -> i32 {
     ///     let call_params = build_call::<DefaultEnvironment>()
     ///             .call_type(
-    ///                 DelegateCall::new()
-    ///                  .code_hash(<DefaultEnvironment as ink::env::Environment>::Hash::CLEAR_HASH))
+    ///                 DelegateCall::new(<DefaultEnvironment as ink::env::Environment>::Hash::CLEAR_HASH))
     ///             .exec_input(
     ///                 ExecutionInput::new(Selector::new([0xCA, 0xFE, 0xBA, 0xBE]))
     ///                  .push_arg(42u8)

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -266,7 +266,7 @@ where
     /// # Example
     ///
     /// ```
-    ///
+    /// 
     /// #[ink::contract]
     /// pub mod only_owner {
     ///     #[ink(storage)]
@@ -344,7 +344,7 @@ where
     /// # Example
     ///
     /// ```
-    ///
+    /// 
     /// #[ink::contract]
     /// pub mod my_contract {
     ///     #[ink(storage)]

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -373,7 +373,8 @@ mod erc1155 {
                             .push_arg(from)
                             .push_arg(token_id)
                             .push_arg(value)
-                            .push_arg(data),Call::new()
+                            .push_arg(data),
+                        Call::new(),
                     )
                     .returns::<Vec<u8>>()
                     .params()

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -366,7 +366,8 @@ mod erc1155 {
                 // If our recipient is a smart contract we need to see if they accept or
                 // reject this transfer. If they reject it we need to revert the call.
                 let result = build_call::<Environment>()
-                    .call_type(Call::new().callee(to).gas_limit(5000))
+                    .callee(to)
+                    .gas_limit(5000)
                     .exec_input(
                         ExecutionInput::new(Selector::new(ON_ERC_1155_RECEIVED_SELECTOR))
                             .push_arg(caller)

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -365,7 +365,7 @@ mod erc1155 {
                 // If our recipient is a smart contract we need to see if they accept or
                 // reject this transfer. If they reject it we need to revert the call.
                 let result = build_call::<Environment>()
-                    .callee(to)
+                    .call(to)
                     .gas_limit(5000)
                     .exec_input(
                         ExecutionInput::new(Selector::new(ON_ERC_1155_RECEIVED_SELECTOR))

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -358,7 +358,6 @@ mod erc1155 {
             {
                 use ink::env::call::{
                     build_call,
-                    Call,
                     ExecutionInput,
                     Selector,
                 };
@@ -374,7 +373,7 @@ mod erc1155 {
                             .push_arg(from)
                             .push_arg(token_id)
                             .push_arg(value)
-                            .push_arg(data),
+                            .push_arg(data),Call::new()
                     )
                     .returns::<Vec<u8>>()
                     .params()

--- a/examples/erc1155/lib.rs
+++ b/examples/erc1155/lib.rs
@@ -374,7 +374,6 @@ mod erc1155 {
                             .push_arg(token_id)
                             .push_arg(value)
                             .push_arg(data),
-                        Call::new(),
                     )
                     .returns::<Vec<u8>>()
                     .params()

--- a/examples/lang-err-integration-tests/call-builder/lib.rs
+++ b/examples/lang-err-integration-tests/call-builder/lib.rs
@@ -52,7 +52,7 @@ mod call_builder {
             selector: [u8; 4],
         ) -> Option<ink::LangError> {
             let result = build_call::<DefaultEnvironment>()
-                .call_type(Call::new().callee(address))
+                .callee(address)
                 .exec_input(ExecutionInput::new(Selector::new(selector)))
                 .returns::<()>()
                 .try_invoke()
@@ -79,7 +79,7 @@ mod call_builder {
             use ink::env::call::build_call;
 
             build_call::<DefaultEnvironment>()
-                .call_type(Call::new().callee(address))
+                .callee(address)
                 .exec_input(ExecutionInput::new(Selector::new(selector)))
                 .returns::<()>()
                 .invoke()

--- a/examples/lang-err-integration-tests/call-builder/lib.rs
+++ b/examples/lang-err-integration-tests/call-builder/lib.rs
@@ -21,7 +21,6 @@ mod call_builder {
     use ink::env::{
         call::{
             build_call,
-            Call,
             ExecutionInput,
             Selector,
         },

--- a/examples/lang-err-integration-tests/call-builder/lib.rs
+++ b/examples/lang-err-integration-tests/call-builder/lib.rs
@@ -51,7 +51,7 @@ mod call_builder {
             selector: [u8; 4],
         ) -> Option<ink::LangError> {
             let result = build_call::<DefaultEnvironment>()
-                .callee(address)
+                .call(address)
                 .exec_input(ExecutionInput::new(Selector::new(selector)))
                 .returns::<()>()
                 .try_invoke()
@@ -78,7 +78,7 @@ mod call_builder {
             use ink::env::call::build_call;
 
             build_call::<DefaultEnvironment>()
-                .callee(address)
+                .call(address)
                 .exec_input(ExecutionInput::new(Selector::new(selector)))
                 .returns::<()>()
                 .invoke()

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -536,12 +536,9 @@ mod multisig {
             let t = self.take_transaction(trans_id).expect(WRONG_TRANSACTION_ID);
             assert!(self.env().transferred_value() == t.transferred_value);
             let result = build_call::<<Self as ::ink::env::ContractEnv>::Env>()
-                .call_type(
-                    Call::new()
-                        .callee(t.callee)
-                        .gas_limit(t.gas_limit)
-                        .transferred_value(t.transferred_value),
-                )
+                .callee(t.callee)
+                .gas_limit(t.gas_limit)
+                .transferred_value(t.transferred_value)
                 .call_flags(CallFlags::default().set_allow_reentry(t.allow_reentry))
                 .exec_input(
                     ExecutionInput::new(t.selector.into()).push_arg(CallInput(&t.input)),
@@ -574,12 +571,9 @@ mod multisig {
             self.ensure_confirmed(trans_id);
             let t = self.take_transaction(trans_id).expect(WRONG_TRANSACTION_ID);
             let result = build_call::<<Self as ::ink::env::ContractEnv>::Env>()
-                .call_type(
-                    Call::new()
-                        .callee(t.callee)
-                        .gas_limit(t.gas_limit)
-                        .transferred_value(t.transferred_value),
-                )
+                .callee(t.callee)
+                .gas_limit(t.gas_limit)
+                .transferred_value(t.transferred_value)
                 .call_flags(CallFlags::default().set_allow_reentry(t.allow_reentry))
                 .exec_input(
                     ExecutionInput::new(t.selector.into()).push_arg(CallInput(&t.input)),

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -67,7 +67,6 @@ mod multisig {
         env::{
             call::{
                 build_call,
-                Call,
                 ExecutionInput,
             },
             CallFlags,

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -534,7 +534,7 @@ mod multisig {
             let t = self.take_transaction(trans_id).expect(WRONG_TRANSACTION_ID);
             assert!(self.env().transferred_value() == t.transferred_value);
             let result = build_call::<<Self as ::ink::env::ContractEnv>::Env>()
-                .callee(t.callee)
+                .call(t.callee)
                 .gas_limit(t.gas_limit)
                 .transferred_value(t.transferred_value)
                 .call_flags(CallFlags::default().set_allow_reentry(t.allow_reentry))
@@ -569,7 +569,7 @@ mod multisig {
             self.ensure_confirmed(trans_id);
             let t = self.take_transaction(trans_id).expect(WRONG_TRANSACTION_ID);
             let result = build_call::<<Self as ::ink::env::ContractEnv>::Env>()
-                .callee(t.callee)
+                .call(t.callee)
                 .gas_limit(t.gas_limit)
                 .transferred_value(t.transferred_value)
                 .call_flags(CallFlags::default().set_allow_reentry(t.allow_reentry))

--- a/examples/multisig/lib.rs
+++ b/examples/multisig/lib.rs
@@ -309,7 +309,6 @@ mod multisig {
         /// use ink::env::{
         ///     call::{
         ///         utils::ArgumentList,
-        ///         Call,
         ///         CallParams,
         ///         ExecutionInput,
         ///         Selector,

--- a/examples/upgradeable-contracts/forward-calls/lib.rs
+++ b/examples/upgradeable-contracts/forward-calls/lib.rs
@@ -70,12 +70,9 @@ pub mod proxy {
         #[ink(message, payable, selector = _)]
         pub fn forward(&self) -> u32 {
             ink::env::call::build_call::<ink::env::DefaultEnvironment>()
-                .call_type(
-                    Call::new()
-                        .callee(self.forward_to)
-                        .transferred_value(self.env().transferred_value())
-                        .gas_limit(0),
-                )
+                .callee(self.forward_to)
+                .transferred_value(self.env().transferred_value())
+                .gas_limit(0)
                 .call_flags(
                     ink::env::CallFlags::default()
                         .set_forward_input(true)

--- a/examples/upgradeable-contracts/forward-calls/lib.rs
+++ b/examples/upgradeable-contracts/forward-calls/lib.rs
@@ -69,7 +69,7 @@ pub mod proxy {
         #[ink(message, payable, selector = _)]
         pub fn forward(&self) -> u32 {
             ink::env::call::build_call::<ink::env::DefaultEnvironment>()
-                .callee(self.forward_to)
+                .call(self.forward_to)
                 .transferred_value(self.env().transferred_value())
                 .gas_limit(0)
                 .call_flags(

--- a/examples/upgradeable-contracts/forward-calls/lib.rs
+++ b/examples/upgradeable-contracts/forward-calls/lib.rs
@@ -17,7 +17,6 @@
 
 #[ink::contract]
 pub mod proxy {
-    use ink::env::call::Call;
 
     /// A simple proxy contract.
     #[ink(storage)]


### PR DESCRIPTION
Suggestion for how to enforce `callee` in #1255.

This breaks the `CallBuilder` API by introducing two new methods: `call` and `delegate`, which can
be used to streamline the `CallBuilder` set-up for the respective call types.