### PR TITLE
Remove `+nightly` from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,22 @@ More relevant links:
 
 ## Table of Contents
 
-* [Play with It](#play-with-it)
-* [Usage](#usage)
-* [Hello, World! ‒ The Flipper](#hello-world--the-flipper)
-* [Examples](#examples)
-* [How it Works](#how-it-works)
-* [ink! Macros & Attributes Overview](#ink-macros--attributes-overview)
-  * [Entry Point](#entry-point)
-  * [Trait Definitions](#trait-definitions)
-  * [Off-chain Testing](#off-chain-testing)
-* [Developer Documentation](#developer-documentation)
-* [Community Badges](#community-badges)
-* [Contributing](#contributing)
-* [License](#license)
+- [Table of Contents](#table-of-contents)
+- [Play with It](#play-with-it)
+- [Usage](#usage)
+- [Hello, World! ‒ The Flipper](#hello-world--the-flipper)
+- [Examples](#examples)
+- [How it Works](#how-it-works)
+- [ink! Macros \& Attributes Overview](#ink-macros--attributes-overview)
+  - [Entry Point](#entry-point)
+  - [Trait Definitions](#trait-definitions)
+  - [Off-chain Testing](#off-chain-testing)
+- [Developer Documentation](#developer-documentation)
+- [Community Badges](#community-badges)
+  - [Normal Design](#normal-design)
+  - [Flat Design](#flat-design)
+- [Contributing](#contributing)
+- [License](#license)
 
 
 ## Play with It
@@ -162,7 +165,7 @@ mod flipper {
     #[cfg(test)]
     mod tests {
         use super::*;
-        
+
         #[ink::test]
         fn it_works() {
             let mut flipper = Flipper::new(false);
@@ -192,7 +195,7 @@ Some of the most interesting ones:
 
 To build a single example navigate to the root of the example and run:
 ```
-cargo contract +nightly build
+cargo contract build
 ```
 
 You should now have an `<name>.contract` file in the `target` folder of the contract.
@@ -208,7 +211,7 @@ This module is called the `contracts` pallet,
 * The `contracts` pallet requires smart contracts to be uploaded to the blockchain as a Wasm blob.
 * ink! is a smart contract language which targets the API exposed by `contracts`.
 Hence ink! contracts are compiled to Wasm.
-* When executing `cargo contract +nightly build` an additional file `metadata.json` is created.
+* When executing `cargo contract build` an additional file `metadata.json` is created.
 It contains information about e.g. what methods the contract provides for others to call.
 
 ## ink! Macros & Attributes Overview

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The `lib.rs` contains our hello world contract ‒ the `Flipper`, which we expla
 
 In order to build the contract just execute this command in the `flipper` folder:
 ```
-cargo +nightly contract build
+cargo contract build
 ```
 
 As a result you'll get a `target/flipper.wasm` file, a `metadata.json` file and a `<contract-name>.contract` file in the `target` folder of your contract.
@@ -178,7 +178,7 @@ mod flipper {
 ```
 
 The [`flipper/src/lib.rs`](https://github.com/paritytech/ink/blob/master/examples/flipper/lib.rs)
-file in our examples folder contains exactly this code. Run `cargo +nightly contract build` to build your
+file in our examples folder contains exactly this code. Run `cargo contract build` to build your
 first ink! smart contract.
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ More relevant links:
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
 - [Play with It](#play-with-it)
 - [Usage](#usage)
 - [Hello, World! ‒ The Flipper](#hello-world--the-flipper)

--- a/crates/metadata/README.md
+++ b/crates/metadata/README.md
@@ -31,7 +31,7 @@ Next, we'll build our contract's metadata:
 
 ```bash
 # At the top level of the ink! repo
-cargo +nightly contract build --manifest-path ./examples/flipper/Cargo.toml
+cargo contract build --manifest-path ./examples/flipper/Cargo.toml
 ```
 
 The generated metadata will be in: `$PATH_TO_INK_REPO/examples/flipper/target/ink/metadata.json`.
@@ -77,7 +77,7 @@ Right now the schemas are generated using a set of cobbled branches across `scal
 Now, in your patched version of `cargo-contract` run the following:
 
 ```
-cargo +nightly run -- contract build --manifest-path $PATH_TO_INK_REPO/examples/flipper/Cargo.toml > schema.json
+cargo run -- contract build --manifest-path $PATH_TO_INK_REPO/examples/flipper/Cargo.toml > schema.json
 ```
 
 In `src/cmd/metadata.rs` you can change the schema being printed depending on what struct

--- a/examples/upgradeable-contracts/forward-calls/README.md
+++ b/examples/upgradeable-contracts/forward-calls/README.md
@@ -14,13 +14,13 @@ In order to test it out you need to do the following:
 
 1. Build a contract containing some logic, e.g. our flipper example:
    ```
-   cargo +nightly contract build --manifest-path=examples/flipper/Cargo.toml
+   cargo contract build --manifest-path=examples/flipper/Cargo.toml
    ```
    You will receive the respective `flipper.contract` bundle in the `examples/flipper/target/ink/` folder.
 1. Build the proxy contract:
    ```
    cd upgradeable-contracts/forward-calls/
-   cargo +nightly contract build
+   cargo contract build
    ```
    You will receive the respective `forwards_calls.contract` bundle in the `target/ink/` folder.
 1. Upload the `flipper.contract` to the chain.


### PR DESCRIPTION
New release of `cargo-contract` and `ink!` no longer require nightly toolchain for compiling smart contracts. Therefore, we remove it from docs.