### PR TITLE
Add another breaking change to the `CHANGELOG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ breaking or otherwise.
    the `sr25519` and `ed25519` curves ([#1255](https://github.com/paritytech/ink/pull/1255)).
 1. We have replaced the `CallBuilder::callee()` method with a `call()` method and also
    added a `delegate()` method. This streamlines the `Call` and `DelegateCall` workflows
+   ([#1636](https://github.com/paritytech/ink/pull/1636))
 
 ### Added
 - E2E: expose call dry-run method ‒ [#1624](https://github.com/paritytech/ink/pull/1624)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 4.0.0-rc
 
-The first release candidate is here! This is the first release which could become the final 
-`v4.0.0`. Any subsequent release candidates should only contain bug fixes: no API changes, 
+The first release candidate is here! This is the first release which could become the final
+`v4.0.0`. Any subsequent release candidates should only contain bug fixes: no API changes,
 breaking or otherwise.
 
 ### Breaking Changes
@@ -17,14 +17,19 @@ breaking or otherwise.
 1. We have removed the `Default` implementation for `AccountId`s. This is because of
    security concerns around the use of the zero address which has a known private key in
    the `sr25519` and `ed25519` curves ([#1255](https://github.com/paritytech/ink/pull/1255)).
+1. We have replaced the `CallBuilder::callee()` method with a `call()` method and also
+   added a `delegate()` method. This streamlines the `Call` and `DelegateCall` workflows
 
 ### Added
 - E2E: expose call dry-run method ‒ [#1624](https://github.com/paritytech/ink/pull/1624)
+- Make cross-contract callee non-optional ‒ [#1636](https://github.com/paritytech/ink/pull/1636)
 
 ### Changed
-- Remove `Default` implementation for AccountId ‒ [#1255](https://github.com/paritytech/ink/pull/1255)
 - Rename `_checked` codegen call methods with `try_` ‒ [#1621](https://github.com/paritytech/ink/pull/1621)
 - Bump Substrate and `subxt` dependencies ‒ [#1549](https://github.com/paritytech/ink/pull/1549)
+
+### Removed
+- Remove `Default` implementation for AccountId ‒ [#1255](https://github.com/paritytech/ink/pull/1255)
 
 ## Version 4.0.0-beta.1
 The coolest feature included in this release is the first first published version of


### PR DESCRIPTION
We didn't mention some of the `CallBuilder` changes in the `CHANGELOG`.
