### PR TITLE
Make ink! compile on `no_std`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -435,6 +435,8 @@ examples-no-std-check:
   stage:                           examples
   <<:                              *docker-env
   <<:                              *test-refs
+  variables:
+    RUSTC_BOOTSTRAP:               "1"
   script:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -430,12 +430,11 @@ examples-contract-build:
       done
     - cargo +stable contract build --manifest-path ./integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
 
+# we only check a few basic contracts here. no need to check them all.
 examples-no-std-check:
   stage:                           examples
   <<:                              *docker-env
   <<:                              *test-refs
-  variables:
-    RUSTC_BOOTSTRAP:               "1"
   script:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V
@@ -446,14 +445,6 @@ examples-no-std-check:
         cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" &&
         popd;
       done
-    - pushd ./integration-tests/delegator/ && ./build-all.sh && popd
-    - for contract in ${UPGRADEABLE_CONTRACTS}; do
-        cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" --manifest-path ./integration-tests/upgradeable-contracts/${contract}/Cargo.toml;
-      done
-    - for contract in ${LANG_ERR_INTEGRATION_CONTRACTS}; do
-        cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" --manifest-path ./integration-tests/lang-err-integration-tests/${contract}/Cargo.toml;
-      done
-    - cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc"  --manifest-path ./integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
 
 examples-docs:
   stage:                           examples

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,9 @@ variables:
   # this fix not yet in stable: https://github.com/rust-lang/rust-clippy/issues/8895.
   # Remove the following line again as soon as `clippy` on stable succeeds again.
   CLIPPY_ALLOWED:                  "clippy::extra_unused_lifetimes"
+  # This is a target that does not have a std lib in contrast to wasm. We compile against
+  # this target to make sure that we don't pull in std by accident (through dependencies).
+  NO_STD_TARGET:                   "bpfel-unknown-none"
 
 workflow:
   rules:
@@ -227,7 +230,7 @@ check-no-std:
     RUSTC_BOOTSTRAP:               "1"
   script:
     - for crate in ${ALSO_WASM_CRATES}; do
-        cargo check --verbose --no-default-features --target bpfel-unknown-none -Zbuild-std="core,alloc" --manifest-path ./crates/${crate}/Cargo.toml;
+        cargo check --verbose --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
 dylint:
@@ -440,17 +443,17 @@ examples-no-std-check:
         if [ "$example" = "examples/upgradeable-contracts/" ]; then continue; fi;
         if [ "$example" = "examples/lang-err-integration-tests/" ]; then continue; fi;
         pushd $example &&
-        cargo +stable check --no-default-features --target bpfel-unknown-none -Zbuild-std="core,alloc" &&
+        cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" &&
         popd;
       done
     - pushd ./examples/delegator/ && ./build-all.sh && popd
     - for contract in ${UPGRADEABLE_CONTRACTS}; do
-        cargo +stable check --no-default-features --target bpfel-unknown-none -Zbuild-std="core,alloc" --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml;
+        cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml;
       done
     - for contract in ${LANG_ERR_INTEGRATION_CONTRACTS}; do
-        cargo +stable check --no-default-features --target bpfel-unknown-none -Zbuild-std="core,alloc" --manifest-path ./examples/lang-err-integration-tests/${contract}/Cargo.toml;
+        cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" --manifest-path ./examples/lang-err-integration-tests/${contract}/Cargo.toml;
       done
-    - cargo +stable check --no-default-features --target bpfel-unknown-none -Zbuild-std="core,alloc"  --manifest-path ./examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+    - cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc"  --manifest-path ./examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
 
 examples-docs:
   stage:                           examples

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,8 +40,8 @@ variables:
   # this fix not yet in stable: https://github.com/rust-lang/rust-clippy/issues/8895.
   # Remove the following line again as soon as `clippy` on stable succeeds again.
   CLIPPY_ALLOWED:                  "clippy::extra_unused_lifetimes"
-  # This is a target that does not have a std lib in contrast to wasm. We compile against
-  # this target to make sure that we don't pull in std by accident (through dependencies).
+  # This is a target that does not have a standard library in contrast to Wasm. We compile against
+  # this target to make sure that we don't pull in `std` by accident (through dependencies).
   NO_STD_TARGET:                   "bpfel-unknown-none"
 
 workflow:
@@ -221,7 +221,7 @@ check-wasm:
         cargo check --verbose --no-default-features --target wasm32-unknown-unknown --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
-# We just check on a target which doesn't have std to make sure that we don't pull in std by accident
+# We just check on a target which doesn't have `std` to make sure that we don't pull in `std` by accident
 check-no-std:
   stage:                           check
   <<:                              *docker-env
@@ -430,7 +430,7 @@ examples-contract-build:
       done
     - cargo +stable contract build --manifest-path ./integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
 
-# we only check a few basic contracts here. no need to check them all.
+# We only check a few basic contracts here, no need to check them all.
 examples-no-std-check:
   stage:                           examples
   <<:                              *docker-env
@@ -441,7 +441,6 @@ examples-no-std-check:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V
     - for example in integration-tests/*/; do
-        if [ "$example" = "integration-tests/upgradeable-contracts/" ]; then continue; fi;
         if [ "$example" = "integration-tests/lang-err-integration-tests/" ]; then continue; fi;
         pushd $example &&
         cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" &&

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -218,6 +218,18 @@ check-wasm:
         cargo check --verbose --no-default-features --target wasm32-unknown-unknown --manifest-path ./crates/${crate}/Cargo.toml;
       done
 
+# We just check on a target which doesn't have std to make sure that we don't pull in std by accident
+check-nostd:
+  stage:                           check
+  <<:                              *docker-env
+  <<:                              *test-refs
+  variables:
+    RUSTC_BOOTSTRAP:               "1"
+  script:
+    - for crate in ${ALSO_WASM_CRATES}; do
+        cargo check --verbose --no-default-features --target bpfel-unknown-none -Zbuild-std="core,alloc" --manifest-path ./crates/${crate}/Cargo.toml;
+      done
+
 dylint:
     stage:                           check
     <<:                              *docker-env
@@ -414,6 +426,31 @@ examples-contract-build:
         cargo +stable contract build --manifest-path ./integration-tests/lang-err-integration-tests/${contract}/Cargo.toml;
       done
     - cargo +stable contract build --manifest-path ./integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+
+examples-nostd-check:
+  stage:                           examples
+  <<:                              *docker-env
+  <<:                              *test-refs
+  variables:
+    RUSTC_BOOTSTRAP:               "1"
+  script:
+    - rustup component add rust-src --toolchain stable
+    - cargo contract -V
+    - for example in examples/*/; do
+        if [ "$example" = "examples/upgradeable-contracts/" ]; then continue; fi;
+        if [ "$example" = "examples/lang-err-integration-tests/" ]; then continue; fi;
+        pushd $example &&
+        cargo +stable check --no-default-features --target bpfel-unknown-none -Zbuild-std="core,alloc" &&
+        popd;
+      done
+    - pushd ./examples/delegator/ && ./build-all.sh && popd
+    - for contract in ${UPGRADEABLE_CONTRACTS}; do
+        cargo +stable check --no-default-features --target bpfel-unknown-none -Zbuild-std="core,alloc" --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml;
+      done
+    - for contract in ${LANG_ERR_INTEGRATION_CONTRACTS}; do
+        cargo +stable check --no-default-features --target bpfel-unknown-none -Zbuild-std="core,alloc" --manifest-path ./examples/lang-err-integration-tests/${contract}/Cargo.toml;
+      done
+    - cargo +stable check --no-default-features --target bpfel-unknown-none -Zbuild-std="core,alloc"  --manifest-path ./examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
 
 examples-docs:
   stage:                           examples

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,7 +219,7 @@ check-wasm:
       done
 
 # We just check on a target which doesn't have std to make sure that we don't pull in std by accident
-check-nostd:
+check-no-std:
   stage:                           check
   <<:                              *docker-env
   <<:                              *test-refs
@@ -427,7 +427,7 @@ examples-contract-build:
       done
     - cargo +stable contract build --manifest-path ./integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
 
-examples-nostd-check:
+examples-no-std-check:
   stage:                           examples
   <<:                              *docker-env
   <<:                              *test-refs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -439,21 +439,21 @@ examples-no-std-check:
   script:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V
-    - for example in examples/*/; do
-        if [ "$example" = "examples/upgradeable-contracts/" ]; then continue; fi;
-        if [ "$example" = "examples/lang-err-integration-tests/" ]; then continue; fi;
+    - for example in integration-tests/*/; do
+        if [ "$example" = "integration-tests/upgradeable-contracts/" ]; then continue; fi;
+        if [ "$example" = "integration-tests/lang-err-integration-tests/" ]; then continue; fi;
         pushd $example &&
         cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" &&
         popd;
       done
-    - pushd ./examples/delegator/ && ./build-all.sh && popd
+    - pushd ./integration-tests/delegator/ && ./build-all.sh && popd
     - for contract in ${UPGRADEABLE_CONTRACTS}; do
-        cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" --manifest-path ./examples/upgradeable-contracts/${contract}/Cargo.toml;
+        cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" --manifest-path ./integration-tests/upgradeable-contracts/${contract}/Cargo.toml;
       done
     - for contract in ${LANG_ERR_INTEGRATION_CONTRACTS}; do
-        cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" --manifest-path ./examples/lang-err-integration-tests/${contract}/Cargo.toml;
+        cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" --manifest-path ./integration-tests/lang-err-integration-tests/${contract}/Cargo.toml;
       done
-    - cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc"  --manifest-path ./examples/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+    - cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc"  --manifest-path ./integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
 
 examples-docs:
   stage:                           examples

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,8 @@ variables:
   # CI_IMAGE is changed to "-:staging" when the CI image gets rebuilt
   # read more https://github.com/paritytech/scripts/pull/244
   CI_IMAGE:                        "paritytech/ink-ci-linux:production"
-  PURELY_STD_CRATES:               "ink/codegen metadata engine e2e e2e/macro"
-  ALSO_WASM_CRATES:                "env storage storage/traits allocator prelude primitives ink ink/macro ink/ir"
+  PURELY_STD_CRATES:               "ink/codegen metadata engine e2e e2e/macro ink/ir"
+  ALSO_WASM_CRATES:                "env storage storage/traits allocator prelude primitives ink ink/macro"
   ALL_CRATES:                      "${PURELY_STD_CRATES} ${ALSO_WASM_CRATES}"
   DELEGATOR_SUBCONTRACTS:          "accumulator adder subber"
   UPGRADEABLE_CONTRACTS:           "forward-calls set-code-hash"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -440,8 +440,19 @@ examples-no-std-check:
   script:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V
+    # We skip some examples for those reasons:
+    # There are no manifests in those two directories and hence it would fall back to the workspace. 
+    #  - lang-err-integration-tests
+    #  - upgradeable-contracts
+    # This uses dlmalloc which is only supported on select targets.
+    #   - custom_allocator
+    # Pulls in sp-std which needlessly requires atomic pointers.
+    #   - call-runtime
     - for example in integration-tests/*/; do
         if [ "$example" = "integration-tests/lang-err-integration-tests/" ]; then continue; fi;
+        if [ "$example" = "integration-tests/upgradeable-contracts/" ]; then continue; fi;
+        if [ "$example" = "integration-tests/custom_allocator/" ]; then continue; fi;
+        if [ "$example" = "integration-tests/call-runtime/" ]; then continue; fi;
         pushd $example &&
         cargo +stable check --no-default-features --target $NO_STD_TARGET -Zbuild-std="core,alloc" &&
         popd;

--- a/crates/allocator/src/bump.rs
+++ b/crates/allocator/src/bump.rs
@@ -104,8 +104,9 @@ impl InnerAlloc {
                 prev_page.checked_mul(PAGE_SIZE)
             }
         } else {
-            compile_error! {
-                "ink! only supports compilation as `std` or `no_std` + `wasm32-unknown`"
+            /// On other architectures growing memory probably doesn't make sense.
+            fn request_pages(&mut self, _pages: usize) -> Option<usize> {
+                None
             }
         }
     }

--- a/crates/allocator/src/handlers.rs
+++ b/crates/allocator/src/handlers.rs
@@ -14,5 +14,18 @@
 
 #[alloc_error_handler]
 fn oom(_: core::alloc::Layout) -> ! {
-    core::arch::wasm32::unreachable()
+    #[cfg(target_arch = "wasm32")]
+    core::arch::wasm32::unreachable();
+
+    // For any other nostd architecture we just call an imaginary
+    // `abort` function. No other architecture is supported. We
+    // just have this to check if compilation does not break
+    // for other true nostd targets.
+    #[cfg(not(target_arch = "wasm32"))]
+    unsafe {
+        extern "C" {
+            fn abort() -> !;
+        }
+        abort();
+    }
 }

--- a/crates/allocator/src/handlers.rs
+++ b/crates/allocator/src/handlers.rs
@@ -17,7 +17,7 @@ fn oom(_: core::alloc::Layout) -> ! {
     #[cfg(target_arch = "wasm32")]
     core::arch::wasm32::unreachable();
 
-    // For any other nostd architecture we just call an imaginary
+    // For any other `no_std` architecture we just call an imaginary
     // `abort` function. No other architecture is supported. We
     // just have this to check if compilation does not break
     // for other true nostd targets.

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = { version = "1.0.81" }
 tokio = { version = "1.18.2", features = ["rt-multi-thread"] }
 log = { version = "0.4" }
 env_logger = { version = "0.10" }
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 subxt = "0.27.0"
 
 # Substrate

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -16,7 +16,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
 ink_primitives = { version = "4.0.1", path = "../../crates/primitives", default-features = false }
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 
 sha2 = { version = "0.10" }

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -21,7 +21,7 @@ ink_storage_traits = { version = "4.0.1", path = "../storage/traits", default-fe
 ink_prelude = { version = "4.0.1", path = "../prelude", default-features = false }
 ink_primitives = { version = "4.0.1", path = "../primitives", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 num-traits = { version = "0.2", default-features = false, features = ["i128"] }
 cfg-if = "1.0"

--- a/crates/env/src/engine/mod.rs
+++ b/crates/env/src/engine/mod.rs
@@ -38,16 +38,12 @@ pub trait OnInstance: EnvBackend + TypedEnvBackend {
 }
 
 cfg_if! {
-    if #[cfg(all(not(feature = "std"), target_arch = "wasm32"))] {
+    if #[cfg(not(feature = "std"))] {
         mod on_chain;
         pub use self::on_chain::EnvInstance;
-    } else if #[cfg(feature = "std")] {
+    } else {
         pub mod off_chain;
         pub use self::off_chain::EnvInstance;
-    } else {
-        compile_error! {
-            "ink! only support compilation as `std` or `no_std` + `wasm32-unknown`"
-        }
     }
 }
 

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -23,7 +23,7 @@ ink_metadata = { version = "4.0.1", path = "../metadata", default-features = fal
 ink_prelude = { version = "4.0.1", path = "../prelude", default-features = false }
 ink_macro = { version = "4.0.1", path = "macro", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
 
 [dev-dependencies]

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -28,7 +28,7 @@ itertools = "0.10"
 either = { version = "1.5", default-features = false }
 blake2 = "0.10"
 heck = "0.4.0"
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 impl-serde = "0.4.0"
 
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -19,7 +19,7 @@ ink_ir = { version = "4.0.1", path = "../ir", default-features = false }
 ink_codegen = { version = "4.0.1", path = "../codegen", default-features = false }
 ink_primitives = { version = "4.0.1", path = "../../primitives/", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 syn = "1"
 synstructure = "0.12.6"
 proc-macro2 = "1"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -17,7 +17,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 [dependencies]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 ink_prelude = { version = "4.0.1", path = "../prelude/", default-features = false }
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", features = ["const_xxh32"] }
 

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -21,7 +21,7 @@ ink_primitives = { version = "4.0.1", path = "../primitives/", default-features 
 ink_storage_traits = { version = "4.0.1", path = "traits", default-features = false }
 ink_prelude = { version = "4.0.1", path = "../prelude/", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1.0"

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -20,7 +20,6 @@ ink_primitives = { version = "4.0.1", path = "../../primitives", default-feature
 ink_prelude = { version = "4.0.1", path = "../../prelude", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
-syn = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 paste = "1.0"

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -18,7 +18,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 ink_metadata = { version = "4.0.1", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
 ink_primitives = { version = "4.0.1", path = "../../primitives", default-features = false }
 ink_prelude = { version = "4.0.1", path = "../../prelude", default-features = false }
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive", "full"] }
+scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -33,7 +33,7 @@ ink = { path = "../crates/ink", default-features = false }
 ink_metadata = { path = "../crates/metadata", default-features = false }
 ink_primitives = { path = "../crates/primitives", default-features = false }
 ink_storage = { path = "../crates/storage", default-features = false }
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"] }
 
 # For the moment we have to include the tests as examples and


### PR DESCRIPTION
Contrary to popular belief `wasm32-unknown-unknown` actually has `std`. This is why we never noticed that we were pulling in std crates from our nostd builds.

For that to never happen again (after fixing) this I added a CI pass which compiles ink! and the examples for a true `nostd` target. I also needed to remove a few `nostd == wasm32` assumptions.