### PR TITLE
[🦖]: fix an import in chain extension runtime example

### DIFF
--- a/integration-tests/rand-extension/runtime/chain-extension-example.rs
+++ b/integration-tests/rand-extension/runtime/chain-extension-example.rs
@@ -10,8 +10,8 @@ use pallet_contracts::chain_extension::{
     InitState,
     RetVal,
     SysConfig,
-    UncheckedFrom,
 };
+use sp_core::crypto::UncheckedFrom;
 use sp_runtime::DispatchError;
 
 /// Contract extension for `FetchRandom`


### PR DESCRIPTION
We need to fix [this CI](https://gitlab.parity.io/parity/mirrors/scripts/-/jobs/2469482#L4952) in order to make ink-waterfall-ci docker image great again.

That re-export has been [removed](https://github.com/paritytech/substrate/pull/12883/files#diff-731558866f91e1d1d74430b8363c323e3f2c15883df8410af6533a4d215fd8daL86) from the pallet side a while ago.