### PR TITLE
`[ink_e2e]` upgrade requirement for `contract-build` to `2.0.2`

### DIFF
--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -20,7 +20,7 @@ proc-macro = true
 
 [dependencies]
 ink_ir = { version = "4.0.1", path = "../../ink/ir" }
-contract-build = "2.0.0"
+contract-build = "2.0.2"
 derive_more = "0.99.17"
 env_logger = "0.10.0"
 log = "0.4.17"


### PR DESCRIPTION
Fixes #1692 and https://github.com/paritytech/ink/issues/1677.