### PR TITLE
Restrict wildcard selectors to have exactly one other message

### DIFF
--- a/crates/ink/ir/src/ir/item_mod.rs
+++ b/crates/ink/ir/src/ir/item_mod.rs
@@ -1078,5 +1078,24 @@ mod tests {
         );
     }
 
-    // todo: test well known selector used not in combination with a wildcard selector
+    #[test]
+    fn wildcard_reserved_selector_used_without_wildcard_fails() {
+        assert_fail(
+            syn::parse_quote! {
+                mod my_module {
+                    #[ink(storage)]
+                    pub struct MyStorage {}
+
+                    impl MyStorage {
+                        #[ink(constructor)]
+                        pub fn my_constructor() -> Self {}
+
+                        #[ink(message, selector = 0x00000000)]
+                        pub fn uses_reserved_wildcard_other_message_selector(&self) {}
+                    }
+                }
+            },
+            "the selector TODO is reserved for use in tandem with a wildcard selector",
+        );
+    }
 }


### PR DESCRIPTION
**Draft: a WIP implementation of https://github.com/paritytech/ink/issues/1676, one of the possible solutions to https://github.com/paritytech/ink/issues/1643. Will mark as ready to review once complete and if/when we decide this is the correct course of action.**

The current implementation here differs slightly from the spec, in that it requires a contract to always define the message with the well-known reserved selector when using the wildcard selector. In the spec it is optional. This allows the user to control what happens when a message with that selector when it is sent. The alternatives are to trap, or to pass the message into the wildcard handler.

## todo

- [ ] decide whether to require the user to always define the other message complementing the wildcard, or to default to throwing an error or passing through to the wildcard handler.
- [ ] define well-known reserved constant for the other message required when using a wildcard.
- [ ] prevent this well-known reserved selector being used for normal messages.





