### PR TITLE
Trim whitespaces in events docs

### DIFF
--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -785,13 +785,17 @@ where
     }
 
     /// Sets the input arguments of the event specification.
-    pub fn docs<D>(self, docs: D) -> Self
+    pub fn docs<'a, D>(self, docs: D) -> Self
     where
-        D: IntoIterator<Item = <F as Form>::String>,
+        D: IntoIterator<Item = &'a str>,
+        F::String: From<&'a str>,
     {
         let mut this = self;
         debug_assert!(this.spec.docs.is_empty());
-        this.spec.docs = docs.into_iter().collect::<Vec<_>>();
+        this.spec.docs = docs
+            .into_iter()
+            .map(|s| trim_extra_whitespace(s).into())
+            .collect::<Vec<_>>();
         this
     }
 
@@ -823,7 +827,6 @@ where
 {
     /// Creates a new event specification builder.
     pub fn new(label: <F as Form>::String) -> EventSpecBuilder<F> {
-        println!("hello there!");
         EventSpecBuilder {
             spec: Self {
                 label,

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -812,7 +812,7 @@ impl IntoPortable for EventSpec {
                 .into_iter()
                 .map(|arg| arg.into_portable(registry))
                 .collect::<Vec<_>>(),
-            docs: self.docs.into_iter().map(|s| s.into()).collect(),
+            docs: self.docs.into_iter().map(|s| trim_extra_whitespace(s).into()).collect(),
         }
     }
 }

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -812,7 +812,7 @@ impl IntoPortable for EventSpec {
                 .into_iter()
                 .map(|arg| arg.into_portable(registry))
                 .collect::<Vec<_>>(),
-            docs: self.docs.into_iter().map(|s| trim_extra_whitespace(s).into()).collect(),
+            docs: self.docs.into_iter().map(|s| s.into()).collect(),
         }
     }
 }
@@ -823,6 +823,7 @@ where
 {
     /// Creates a new event specification builder.
     pub fn new(label: <F as Form>::String) -> EventSpecBuilder<F> {
+        println!("hello there!");
         EventSpecBuilder {
             spec: Self {
                 label,

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -310,7 +310,7 @@ fn should_trim_whitespaces_in_events() {
     let args = [EventParamSpec::new("something".into())
         .of_type(spec)
         .indexed(true)
-        .docs(vec![])
+        .docs(vec!["test".to_string()])
         .done()];
     let es = EventSpec::new("foobar".into())
         .args(args)
@@ -324,7 +324,7 @@ fn should_trim_whitespaces_in_events() {
         {
             "args": [
               {
-                "docs": [],
+                "docs": ["test"],
                 "indexed": true,
                 "label": "something",
                 "type": {

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -302,7 +302,7 @@ fn trim_docs_with_code() {
 }
 
 #[test]
-fn should_trim_whitespaces_in_events() {
+fn should_trim_whitespaces_in_events_docs() {
     // GIVEN
     let path: Path<PortableForm> =
         Path::from_segments_unchecked(["FooBarEvent".to_string()]);
@@ -314,7 +314,7 @@ fn should_trim_whitespaces_in_events() {
         .done()];
     let es = EventSpec::new("foobar".into())
         .args(args)
-        .docs([" Foo event".into()])
+        .docs([" FooBarEvent  ".into()])
         .done();
 
     let event_spec_name = serde_json::to_value(&es).unwrap();
@@ -323,23 +323,22 @@ fn should_trim_whitespaces_in_events() {
     let expected_event_spec = serde_json::json!(
         {
             "args": [
-              {
+            {
                 "docs": ["test"],
                 "indexed": true,
                 "label": "something",
                 "type": {
-                  "displayName": [
-                    "FooBarEvent"
-                  ],
-                  "type": 789
+                    "displayName": [
+                        "FooBarEvent"
+                    ],
+                    "type": 789
                 }
-              }
-            ],
+            }],
             "docs": [
-              "Foo event"
+                "FooBarEvent"
             ],
             "label": "foobar"
-          }
+        }
     );
 
     // THEN

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -301,6 +301,51 @@ fn trim_docs_with_code() {
     assert_eq!(deserialized.docs, compact_spec.docs);
 }
 
+#[test]
+fn should_trim_whitespaces_in_events() {
+    // GIVEN
+    let path: Path<PortableForm> =
+        Path::from_segments_unchecked(["FooBarEvent".to_string()]);
+    let spec = TypeSpec::new(789.into(), path);
+    let args = [EventParamSpec::new("something".into())
+        .of_type(spec)
+        .indexed(true)
+        .docs(vec![])
+        .done()];
+    let es = EventSpec::new("foobar".into())
+        .args(args)
+        .docs([" Foo event".into()])
+        .done();
+
+    let event_spec_name = serde_json::to_value(&es).unwrap();
+
+    // WHEN
+    let expected_event_spec = serde_json::json!(
+        {
+            "args": [
+              {
+                "docs": [],
+                "indexed": true,
+                "label": "something",
+                "type": {
+                  "displayName": [
+                    "FooBarEvent"
+                  ],
+                  "type": 789
+                }
+              }
+            ],
+            "docs": [
+              "Foo event"
+            ],
+            "label": "foobar"
+          }
+    );
+
+    // THEN
+    assert_eq!(event_spec_name, expected_event_spec);
+}
+
 /// Helper for creating a constructor spec at runtime
 fn runtime_constructor_spec() -> ConstructorSpec<PortableForm> {
     let path: Path<PortableForm> = Path::from_segments_unchecked(["FooType".to_string()]);


### PR DESCRIPTION
Looks like I have solved trimming whitespaces in `events.docs`. When I pass as an input ` FooBarEvent  ` (one whitespace at the beginning, and two whitespaces at the end) the output is `FooBarEvent` as is required.

Feel free to write comments if something is bad.


I was not believing that this is so rocket science, I just needed more pissed off.

[Direct link to the issue](https://github.com/paritytech/ink/issues/1448)