### PR TITLE
Change `NO_STD_TARGET` to `aarch64-unknown-none` :t-rex:

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ variables:
   # This is a target that does not have a standard library in contrast to Wasm. We compile against
   # this target to make sure that we don't pull in `std` by accident (through dependencies).
   # See https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-2.
-  NO_STD_TARGET:                   "thumbv7m-none-eabi"
+  NO_STD_TARGET:                   "aarch64-unknown-none"
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,8 @@ variables:
   CLIPPY_ALLOWED:                  "clippy::extra_unused_lifetimes"
   # This is a target that does not have a standard library in contrast to Wasm. We compile against
   # this target to make sure that we don't pull in `std` by accident (through dependencies).
-  NO_STD_TARGET:                   "bpfel-unknown-none"
+  # See https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-2.
+  NO_STD_TARGET:                   "thumbv7m-none-eabi"
 
 workflow:
   rules:


### PR DESCRIPTION
Since Rust `1.68`, [`check-no-std` fails](https://gitlab.parity.io/parity/mirrors/ink/-/jobs/2515968). Lots of errors missing definitions from [`atomic.rs` ](https://github.com/rust-lang/rust/blob/474ea87943c3077feb7d7f2a6f295bd06654ef82/library/core/src/sync/atomic.rs) e.g.

``cannot find macro `atomic_int` in this scope``

I have confirmed this by running the check with `cargo +1.67.1` and it works okay.

This looks to be an occurrence of https://github.com/rust-lang/rust/issues/106795, which is fixed by https://github.com/rust-lang/rust/pull/106856, but not stabilized yet (I'm not sure exactly how to tell). In any case it works with `cargo +nightly` so I assume this target will be fixed in a upcoming stable release.

In the meantime I have chosen a different target which has the same property of only supporting `no_std`: `aarch64-unknown-none`. This is a tier-2 target which is guaranteed to build, see https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-2