### PR TITLE
Add `#[ink(default)]` attribute for constructors and messages

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -15,7 +15,7 @@ KECCAK
 Polkadot
 RPC
 SHA
-UI
+UI/S
 URI
 Wasm
 Wasm32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Upgraded `syn` to version `2` - [#1731](https://github.com/paritytech/ink/pull/1731)
+- Added `default` attribute to constructors and messages - [#1703](https://github.com/paritytech/ink/pull/1724)
 
 ## Version 4.1.0
 

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -140,6 +140,7 @@ impl Metadata<'_> {
         let selector_bytes = constructor.composed_selector().hex_lits();
         let selector_id = constructor.composed_selector().into_be_u32();
         let is_payable = constructor.is_payable();
+        let is_default = constructor.is_default();
         let constructor = constructor.callable();
         let ident = constructor.ident();
         let args = constructor.inputs().map(Self::generate_dispatch_argument);
@@ -156,6 +157,7 @@ impl Metadata<'_> {
                     #( #args ),*
                 ])
                 .payable(#is_payable)
+                .default(#is_default)
                 .returns(#ret_ty)
                 .docs([
                     #( #docs ),*
@@ -235,6 +237,7 @@ impl Metadata<'_> {
                     .filter_map(|attr| attr.extract_docs());
                 let selector_bytes = message.composed_selector().hex_lits();
                 let is_payable = message.is_payable();
+                let is_default = message.is_default();
                 let message = message.callable();
                 let mutates = message.receiver().is_ref_mut();
                 let ident = message.ident();
@@ -253,6 +256,7 @@ impl Metadata<'_> {
                         .returns(#ret_ty)
                         .mutates(#mutates)
                         .payable(#is_payable)
+                        .default(#is_default)
                         .docs([
                             #( #docs ),*
                         ])

--- a/crates/ink/ir/src/ir/attrs.rs
+++ b/crates/ink/ir/src/ir/attrs.rs
@@ -519,7 +519,7 @@ impl core::fmt::Display for AttributeArg {
             }
             Self::Implementation => write!(f, "impl"),
             Self::HandleStatus(value) => write!(f, "handle_status = {value:?}"),
-            Self::Default => write!(f, "default")
+            Self::Default => write!(f, "default"),
         }
     }
 }
@@ -1238,7 +1238,7 @@ mod tests {
             syn::parse_quote! {
                 #[ink(default)]
             },
-            Ok(test::Attribute::Ink(vec![AttributeArg::Default]))
+            Ok(test::Attribute::Ink(vec![AttributeArg::Default])),
         )
     }
 

--- a/crates/ink/ir/src/ir/item_impl/callable.rs
+++ b/crates/ink/ir/src/ir/item_impl/callable.rs
@@ -116,6 +116,10 @@ where
         <C as Callable>::is_payable(self.callable)
     }
 
+    fn is_default(&self) -> bool {
+        <C as Callable>::is_default(self.callable)
+    }
+
     fn has_wildcard_selector(&self) -> bool {
         <C as Callable>::has_wildcard_selector(self.callable)
     }
@@ -165,6 +169,13 @@ pub trait Callable {
     ///
     /// Flagging as payable is done using the `#[ink(payable)]` attribute.
     fn is_payable(&self) -> bool;
+
+    /// Returns `true` if the ink! callable is flagged as default.
+    ///
+    /// # Note
+    ///
+    /// Flagging as default is done using the `#[ink(default)]` attribute.
+    fn is_default(&self) -> bool;
 
     /// Returns `true` if the ink! callable is flagged as a wildcard selector.
     fn has_wildcard_selector(&self) -> bool;

--- a/crates/ink/ir/src/ir/item_impl/constructor.rs
+++ b/crates/ink/ir/src/ir/item_impl/constructor.rs
@@ -223,7 +223,6 @@ impl Callable for Constructor {
     fn statements(&self) -> &[syn::Stmt] {
         &self.item.block.stmts
     }
-
 }
 
 impl Constructor {

--- a/crates/ink/ir/src/ir/item_impl/constructor.rs
+++ b/crates/ink/ir/src/ir/item_impl/constructor.rs
@@ -70,6 +70,8 @@ pub struct Constructor {
     pub(super) item: syn::ImplItemFn,
     /// If the ink! constructor can receive funds.
     is_payable: bool,
+    /// If the ink! constructor is default.
+    is_default: bool,
     /// An optional user provided selector.
     ///
     /// # Note
@@ -139,6 +141,7 @@ impl Constructor {
                 match arg.kind() {
                     ir::AttributeArg::Constructor
                     | ir::AttributeArg::Payable
+                    | ir::AttributeArg::Default
                     | ir::AttributeArg::Selector(_) => Ok(()),
                     _ => Err(None),
                 }
@@ -156,10 +159,12 @@ impl TryFrom<syn::ImplItemFn> for Constructor {
         Self::ensure_no_self_receiver(&method_item)?;
         let (ink_attrs, other_attrs) = Self::sanitize_attributes(&method_item)?;
         let is_payable = ink_attrs.is_payable();
+        let is_default = ink_attrs.is_default();
         let selector = ink_attrs.selector();
         Ok(Constructor {
             selector,
             is_payable,
+            is_default,
             item: syn::ImplItemFn {
                 attrs: other_attrs,
                 ..method_item
@@ -195,6 +200,10 @@ impl Callable for Constructor {
         self.is_payable
     }
 
+    fn is_default(&self) -> bool {
+        self.is_default
+    }
+
     fn visibility(&self) -> Visibility {
         match &self.item.vis {
             syn::Visibility::Public(vis_public) => Visibility::Public(*vis_public),
@@ -214,6 +223,7 @@ impl Callable for Constructor {
     fn statements(&self) -> &[syn::Stmt] {
         &self.item.block.stmts
     }
+
 }
 
 impl Constructor {
@@ -333,6 +343,34 @@ mod tests {
                 .unwrap()
                 .is_payable();
             assert_eq!(is_payable, expect_payable);
+        }
+    }
+
+    #[test]
+    fn is_default_works() {
+        let test_inputs: Vec<(bool, syn::ImplItemFn)> = vec![
+            // Not default.
+            (
+                false,
+                syn::parse_quote! {
+                    #[ink(constructor)]
+                    fn my_constructor() -> Self {}
+                },
+            ),
+            // Default constructor.
+            (
+                true,
+                syn::parse_quote! {
+                    #[ink(constructor, default)]
+                    pub fn my_constructor() -> Self {}
+                },
+            ),
+        ];
+        for (expect_default, item_method) in test_inputs {
+            let is_default = <ir::Constructor as TryFrom<_>>::try_from(item_method)
+                .unwrap()
+                .is_default();
+            assert_eq!(is_default, expect_default);
         }
     }
 

--- a/crates/ink/ir/src/ir/trait_def/item/trait_item.rs
+++ b/crates/ink/ir/src/ir/trait_def/item/trait_item.rs
@@ -92,6 +92,7 @@ impl<'a> InkTraitMessage<'a> {
                         Err(Some(format_err!(arg.span(), "wildcard selectors are only supported for inherent ink! messages or constructors, not for traits."))),
                     ir::AttributeArg::Message
                     | ir::AttributeArg::Payable
+                    | ir::AttributeArg::Default
                     | ir::AttributeArg::Selector(_) => Ok(()),
                     _ => Err(None),
                 }

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -228,10 +228,14 @@ where
             !self.spec.messages.is_empty(),
             "must have at least one message"
         );
-        assert!(self.spec.constructors.iter().filter(|c| c.default).count() < 2,
-                "only one default constructor is allowed");
-        assert!(self.spec.messages.iter().filter(|m| m.default).count() < 2,
-                "only one default message is allowed");
+        assert!(
+            self.spec.constructors.iter().filter(|c| c.default).count() < 2,
+            "only one default constructor is allowed"
+        );
+        assert!(
+            self.spec.messages.iter().filter(|m| m.default).count() < 2,
+            "only one default message is allowed"
+        );
         self.spec
     }
 }
@@ -280,7 +284,7 @@ pub struct ConstructorSpec<F: Form = MetaForm> {
     /// The deployment handler documentation.
     pub docs: Vec<F::String>,
     /// If the constructor is default
-    default: bool
+    default: bool,
 }
 
 impl IntoPortable for ConstructorSpec {
@@ -340,7 +344,9 @@ where
         &self.docs
     }
 
-    pub fn default(&self) -> &bool { &self.default }
+    pub fn default(&self) -> &bool {
+        &self.default
+    }
 }
 
 /// A builder for constructors.
@@ -473,8 +479,7 @@ where
     }
 
     /// Sets the default of the constructor specification.
-    pub fn default(self, default: bool) -> Self
-    {
+    pub fn default(self, default: bool) -> Self {
         ConstructorSpecBuilder {
             spec: ConstructorSpec {
                 default,
@@ -483,7 +488,6 @@ where
             marker: PhantomData,
         }
     }
-
 }
 
 impl<F> ConstructorSpecBuilder<F, state::Selector, state::IsPayable, state::Returns>
@@ -522,7 +526,7 @@ pub struct MessageSpec<F: Form = MetaForm> {
     /// The message documentation.
     docs: Vec<F::String>,
     /// If the message is default
-    default: bool
+    default: bool,
 }
 
 /// Type state for builders to tell that some mandatory state has not yet been set
@@ -615,7 +619,9 @@ where
         &self.docs
     }
 
-    pub fn default(&self) -> &bool { &self.default }
+    pub fn default(&self) -> &bool {
+        &self.default
+    }
 }
 
 /// A builder for messages.
@@ -739,8 +745,7 @@ where
     }
 
     /// Sets the default of the message specification.
-    pub fn default(self, default: bool) -> Self
-    {
+    pub fn default(self, default: bool) -> Self {
         MessageSpecBuilder {
             spec: MessageSpec {
                 default,
@@ -749,7 +754,6 @@ where
             marker: PhantomData,
         }
     }
-
 }
 
 impl<F>

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -283,7 +283,7 @@ pub struct ConstructorSpec<F: Form = MetaForm> {
     pub return_type: ReturnTypeSpec<F>,
     /// The deployment handler documentation.
     pub docs: Vec<F::String>,
-    /// If the constructor is default
+    /// If the constructor is default.
     default: bool,
 }
 

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -283,7 +283,7 @@ pub struct ConstructorSpec<F: Form = MetaForm> {
     pub return_type: ReturnTypeSpec<F>,
     /// The deployment handler documentation.
     pub docs: Vec<F::String>,
-    /// If the constructor is default.
+    /// If the constructor is the default for off-chain consumers (e.g UIs).
     default: bool,
 }
 
@@ -525,7 +525,7 @@ pub struct MessageSpec<F: Form = MetaForm> {
     return_type: ReturnTypeSpec<F>,
     /// The message documentation.
     docs: Vec<F::String>,
-    /// If the message is default.
+    /// If the message is the default for off-chain consumers (e.g UIs).
     default: bool,
 }
 

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -525,7 +525,7 @@ pub struct MessageSpec<F: Form = MetaForm> {
     return_type: ReturnTypeSpec<F>,
     /// The message documentation.
     docs: Vec<F::String>,
-    /// If the message is default
+    /// If the message is default.
     default: bool,
 }
 

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -47,10 +47,112 @@ fn spec_constructor_selector_must_serialize_to_hex() {
             "selector": "0x075bcd15",
             "returnType": null,
             "args": [],
-            "docs": []
+            "docs": [],
+            "default": false,
         })
     );
     assert_eq!(deserialized.selector, portable_spec.selector);
+}
+
+#[test]
+#[should_panic(expected = "only one default message allowed")]
+fn spec_contract_only_one_default_message_allowed() {
+        ContractSpec::new()
+        .constructors(vec![
+            ConstructorSpec::from_label("new")
+                .selector([94u8, 189u8, 136u8, 214u8])
+                .payable(true)
+                .args(vec![MessageParamSpec::new("init_value")
+                    .of_type(TypeSpec::with_name_segs::<i32, _>(
+                        vec!["i32"].into_iter().map(AsRef::as_ref),
+                    ))
+                    .done()])
+                .returns(ReturnTypeSpec::new(None))
+                .docs(Vec::new())
+                .done()
+        ])
+        .messages(vec![
+            MessageSpec::from_label("inc")
+                .selector([231u8, 208u8, 89u8, 15u8])
+                .mutates(true)
+                .payable(true)
+                .args(vec![MessageParamSpec::new("by")
+                    .of_type(TypeSpec::with_name_segs::<i32, _>(
+                        vec!["i32"].into_iter().map(AsRef::as_ref),
+                    ))
+                    .done()])
+                .returns(ReturnTypeSpec::new(None))
+                .default(true)
+                .done(),
+            MessageSpec::from_label("get")
+                .selector([37u8, 68u8, 74u8, 254u8])
+                .mutates(false)
+                .payable(false)
+                .args(Vec::new())
+                .returns(ReturnTypeSpec::new(TypeSpec::with_name_segs::<i32, _>(
+                    vec!["i32"].into_iter().map(AsRef::as_ref),
+                )))
+                .default(true)
+                .done(),
+        ])
+        .events(Vec::new())
+        .lang_error(TypeSpec::with_name_segs::<ink_primitives::LangError, _>(
+            ::core::iter::Iterator::map(
+                ::core::iter::IntoIterator::into_iter(["ink", "LangError"]),
+                ::core::convert::AsRef::as_ref,
+            ),
+        ))
+        .done();
+}
+
+#[test]
+#[should_panic(expected = "only one default constructor allowed")]
+fn spec_contract_only_one_default_constructor_allowed() {
+        ContractSpec::new()
+        .constructors(vec![
+            ConstructorSpec::from_label("new")
+                .selector([94u8, 189u8, 136u8, 214u8])
+                .payable(true)
+                .args(vec![MessageParamSpec::new("init_value")
+                    .of_type(TypeSpec::with_name_segs::<i32, _>(
+                        vec!["i32"].into_iter().map(AsRef::as_ref),
+                    ))
+                    .done()])
+                .returns(ReturnTypeSpec::new(None))
+                .docs(Vec::new())
+                .default(true)
+                .done(),
+            ConstructorSpec::from_label("default")
+                .selector([2u8, 34u8, 255u8, 24u8])
+                .payable(Default::default())
+                .args(Vec::new())
+                .returns(ReturnTypeSpec::new(None))
+                .docs(Vec::new())
+                .default(true)
+                .done()
+        ])
+        .messages(vec![
+            MessageSpec::from_label("inc")
+                .selector([231u8, 208u8, 89u8, 15u8])
+                .mutates(true)
+                .payable(true)
+                .args(vec![MessageParamSpec::new("by")
+                    .of_type(TypeSpec::with_name_segs::<i32, _>(
+                        vec!["i32"].into_iter().map(AsRef::as_ref),
+                    ))
+                    .done()])
+                .returns(ReturnTypeSpec::new(None))
+                .default(true)
+                .done()
+        ])
+        .events(Vec::new())
+        .lang_error(TypeSpec::with_name_segs::<ink_primitives::LangError, _>(
+            ::core::iter::Iterator::map(
+                ::core::iter::IntoIterator::into_iter(["ink", "LangError"]),
+                ::core::convert::AsRef::as_ref,
+            ),
+        ))
+        .done();
 }
 
 #[test]
@@ -75,6 +177,7 @@ fn spec_contract_json() {
                 .args(Vec::new())
                 .returns(ReturnTypeSpec::new(None))
                 .docs(Vec::new())
+                .default(true)
                 .done(),
             ConstructorSpec::from_label("result_new")
                 .selector([6u8, 3u8, 55u8, 123u8])
@@ -99,6 +202,7 @@ fn spec_contract_json() {
                     ))
                     .done()])
                 .returns(ReturnTypeSpec::new(None))
+                .default(true)
                 .done(),
             MessageSpec::from_label("get")
                 .selector([37u8, 68u8, 74u8, 254u8])
@@ -142,6 +246,7 @@ fn spec_contract_json() {
                         }
                     ],
                     "docs": [],
+                    "default": false,
                     "label": "new",
                     "payable": true,
                     "returnType": null,
@@ -150,6 +255,7 @@ fn spec_contract_json() {
                 {
                     "args": [],
                     "docs": [],
+                    "default": true,
                     "label": "default",
                     "payable": false,
                     "returnType": null,
@@ -158,6 +264,7 @@ fn spec_contract_json() {
                 {
                     "args": [],
                     "docs": [],
+                    "default": false,
                     "label": "result_new",
                     "payable": false,
                     "returnType": {
@@ -193,6 +300,7 @@ fn spec_contract_json() {
                             }
                         }
                     ],
+                    "default": true,
                     "docs": [],
                     "mutates": true,
                     "payable": true,
@@ -202,6 +310,7 @@ fn spec_contract_json() {
                 },
                 {
                     "args": [],
+                    "default": false,
                     "docs": [],
                     "mutates": false,
                     "payable": false,
@@ -247,7 +356,8 @@ fn trim_docs() {
             "returnType": null,
             "selector": "0x075bcd15",
             "args": [],
-            "docs": ["foobar"]
+            "docs": ["foobar"],
+            "default": false
         })
     );
     assert_eq!(deserialized.docs, compact_spec.docs);
@@ -295,7 +405,8 @@ fn trim_docs_with_code() {
                 "    \"Hello, World\"",
                 "}",
                 "```"
-            ]
+            ],
+            "default": false
         })
     );
     assert_eq!(deserialized.docs, compact_spec.docs);
@@ -382,7 +493,8 @@ fn construct_runtime_contract_spec() {
             "docs": [
                 "foo",
                 "bar"
-            ]
+            ],
+            "default": false
         }
     );
     assert_eq!(constructor_spec, expected_constructor_spec);
@@ -411,6 +523,7 @@ fn construct_runtime_contract_spec() {
                     "FooType"
                 ]
             },
+            "default": false,
             "docs": [
                 "foo",
                 "bar"

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -55,7 +55,7 @@ fn spec_constructor_selector_must_serialize_to_hex() {
 }
 
 #[test]
-#[should_panic(expected = "only one default message allowed")]
+#[should_panic(expected = "only one default message is allowed")]
 fn spec_contract_only_one_default_message_allowed() {
     ContractSpec::new()
         .constructors(vec![ConstructorSpec::from_label("new")
@@ -104,7 +104,7 @@ fn spec_contract_only_one_default_message_allowed() {
 }
 
 #[test]
-#[should_panic(expected = "only one default constructor allowed")]
+#[should_panic(expected = "only one default constructor is allowed")]
 fn spec_contract_only_one_default_constructor_allowed() {
     ContractSpec::new()
         .constructors(vec![

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -57,20 +57,18 @@ fn spec_constructor_selector_must_serialize_to_hex() {
 #[test]
 #[should_panic(expected = "only one default message allowed")]
 fn spec_contract_only_one_default_message_allowed() {
-        ContractSpec::new()
-        .constructors(vec![
-            ConstructorSpec::from_label("new")
-                .selector([94u8, 189u8, 136u8, 214u8])
-                .payable(true)
-                .args(vec![MessageParamSpec::new("init_value")
-                    .of_type(TypeSpec::with_name_segs::<i32, _>(
-                        vec!["i32"].into_iter().map(AsRef::as_ref),
-                    ))
-                    .done()])
-                .returns(ReturnTypeSpec::new(None))
-                .docs(Vec::new())
-                .done()
-        ])
+    ContractSpec::new()
+        .constructors(vec![ConstructorSpec::from_label("new")
+            .selector([94u8, 189u8, 136u8, 214u8])
+            .payable(true)
+            .args(vec![MessageParamSpec::new("init_value")
+                .of_type(TypeSpec::with_name_segs::<i32, _>(
+                    vec!["i32"].into_iter().map(AsRef::as_ref),
+                ))
+                .done()])
+            .returns(ReturnTypeSpec::new(None))
+            .docs(Vec::new())
+            .done()])
         .messages(vec![
             MessageSpec::from_label("inc")
                 .selector([231u8, 208u8, 89u8, 15u8])
@@ -108,7 +106,7 @@ fn spec_contract_only_one_default_message_allowed() {
 #[test]
 #[should_panic(expected = "only one default constructor allowed")]
 fn spec_contract_only_one_default_constructor_allowed() {
-        ContractSpec::new()
+    ContractSpec::new()
         .constructors(vec![
             ConstructorSpec::from_label("new")
                 .selector([94u8, 189u8, 136u8, 214u8])
@@ -129,22 +127,20 @@ fn spec_contract_only_one_default_constructor_allowed() {
                 .returns(ReturnTypeSpec::new(None))
                 .docs(Vec::new())
                 .default(true)
-                .done()
+                .done(),
         ])
-        .messages(vec![
-            MessageSpec::from_label("inc")
-                .selector([231u8, 208u8, 89u8, 15u8])
-                .mutates(true)
-                .payable(true)
-                .args(vec![MessageParamSpec::new("by")
-                    .of_type(TypeSpec::with_name_segs::<i32, _>(
-                        vec!["i32"].into_iter().map(AsRef::as_ref),
-                    ))
-                    .done()])
-                .returns(ReturnTypeSpec::new(None))
-                .default(true)
-                .done()
-        ])
+        .messages(vec![MessageSpec::from_label("inc")
+            .selector([231u8, 208u8, 89u8, 15u8])
+            .mutates(true)
+            .payable(true)
+            .args(vec![MessageParamSpec::new("by")
+                .of_type(TypeSpec::with_name_segs::<i32, _>(
+                    vec!["i32"].into_iter().map(AsRef::as_ref),
+                ))
+                .done()])
+            .returns(ReturnTypeSpec::new(None))
+            .default(true)
+            .done()])
         .events(Vec::new())
         .lang_error(TypeSpec::with_name_segs::<ink_primitives::LangError, _>(
             ::core::iter::Iterator::map(


### PR DESCRIPTION
Adds `default` attribute for constructors and messages. 
`default` attribute is reflected in metadata so consuming services can for example determine which constructor/message should be selected by default.

#1703 