### PR TITLE
Upgrade `scale-info` to `2.5` 

### DIFF
--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -40,7 +40,7 @@ sp-weights = "14.0.0"
 
 [dev-dependencies]
 # Required for the doctest of `MessageBuilder::call`
-scale-info = { version = "2.3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -48,7 +48,7 @@ secp256k1 = { version = "0.27.0", features = ["recovery", "global-context"], opt
 #
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside the off-chain environment!
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink = { path = "../ink" }

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -32,7 +32,7 @@ ink_metadata = { path = "../metadata", default-features = false }
 
 trybuild = { version = "1.0.60", features = ["diff"] }
 # Required for the doctest of `env_access::EnvAccess::instantiate_contract`
-scale-info = { version = "2.3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5", default-features = false, features = ["derive"] }
 
 [features]
 default = ["std"]

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -31,7 +31,7 @@ ink = { path = ".." }
 ink_metadata = { path = "../../metadata" }
 ink_prelude = { path = "../../prelude" }
 ink_storage = { path = "../../storage" }
-scale-info = { version = "2.3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5", default-features = false, features = ["derive"] }
 
 [lib]
 name = "ink_macro"

--- a/crates/ink/tests/return_type_metadata.rs
+++ b/crates/ink/tests/return_type_metadata.rs
@@ -66,21 +66,21 @@ mod tests {
     ) -> (&'a Type<PortableForm>, &'a Type<PortableForm>) {
         assert_eq!(
             "Result",
-            format!("{}", ty.path()),
+            format!("{}", ty.path),
             "Message return type should be a Result"
         );
-        match ty.type_def() {
+        match &ty.type_def {
             TypeDef::Variant(variant) => {
-                assert_eq!(2, variant.variants().len());
-                let ok_variant = &variant.variants()[0];
-                let ok_field = &ok_variant.fields()[0];
-                let ok_ty = resolve_type(metadata, ok_field.ty().id());
-                assert_eq!("Ok", ok_variant.name());
+                assert_eq!(2, variant.variants.len());
+                let ok_variant = &variant.variants[0];
+                let ok_field = &ok_variant.fields[0];
+                let ok_ty = resolve_type(metadata, ok_field.ty.id);
+                assert_eq!("Ok", ok_variant.name);
 
-                let err_variant = &variant.variants()[1];
-                let err_field = &err_variant.fields()[0];
-                let err_ty = resolve_type(metadata, err_field.ty().id());
-                assert_eq!("Err", err_variant.name());
+                let err_variant = &variant.variants[1];
+                let err_field = &err_variant.fields[0];
+                let err_ty = resolve_type(metadata, err_field.ty.id);
+                assert_eq!("Err", err_variant.name);
 
                 (ok_ty, err_ty)
             }
@@ -107,10 +107,10 @@ mod tests {
         assert_eq!("TraitDefinition::get_value", message.label());
 
         let type_spec = message.return_type().opt_type().unwrap();
-        let ty = resolve_type(&metadata, type_spec.ty().id());
+        let ty = resolve_type(&metadata, type_spec.ty().id);
         let (ok_ty, _) = extract_result(&metadata, ty);
 
-        assert_eq!(&TypeDef::Primitive(TypeDefPrimitive::U32), ok_ty.type_def());
+        assert_eq!(TypeDef::Primitive(TypeDefPrimitive::U32), ok_ty.type_def);
     }
 
     #[test]
@@ -125,19 +125,19 @@ mod tests {
             format!("{}", type_spec.display_name())
         );
 
-        let outer_result_ty = resolve_type(&metadata, type_spec.ty().id());
+        let outer_result_ty = resolve_type(&metadata, type_spec.ty().id);
         let (outer_ok_ty, outer_err_ty) = extract_result(&metadata, outer_result_ty);
         let (inner_ok_ty, _) = extract_result(&metadata, outer_ok_ty);
 
         assert_eq!(
-            format!("{}", outer_err_ty.path()),
+            format!("{}", outer_err_ty.path),
             "ink_primitives::LangError"
         );
 
         let unit_ty = TypeDef::Tuple(TypeDefTuple::new_portable(vec![]));
         assert_eq!(
-            &unit_ty,
-            inner_ok_ty.type_def(),
+            unit_ty,
+            inner_ok_ty.type_def,
             "Ok variant should be a unit `()` type"
         );
     }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -21,7 +21,7 @@ ink_primitives = { version = "4.1.0", path = "../primitives/", default-features 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.4.0"
 derive_more = { version = "0.99", default-features = false, features = ["from"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive", "serde", "decode"] }
+scale-info = { version = "2.5", default-features = false, features = ["derive", "serde", "decode"] }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -18,7 +18,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 ink_prelude = { version = "4.1.0", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", features = ["const_xxh32"] }
 
 [features]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -23,7 +23,7 @@ ink_prelude = { version = "4.1.0", path = "../prelude/", default-features = fals
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 cfg-if = "1.0"
 array-init = { version = "2.0", default-features = false }
 

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -19,7 +19,7 @@ ink_metadata = { version = "4.1.0", path = "../../metadata", default-features = 
 ink_primitives = { version = "4.1.0", path = "../../primitives", default-features = false }
 ink_prelude = { version = "4.1.0", path = "../../prelude", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 paste = "1.0"

--- a/integration-tests/basic_contract_caller/Cargo.toml
+++ b/integration-tests/basic_contract_caller/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 # Note: We **need** to specify the `ink-as-dependency` feature.
 #

--- a/integration-tests/basic_contract_caller/other_contract/Cargo.toml
+++ b/integration-tests/basic_contract_caller/other_contract/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/call-runtime/Cargo.toml
+++ b/integration-tests/call-runtime/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false, features = ["call-runtime"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 # Substrate
 #

--- a/integration-tests/conditional-compilation/Cargo.toml
+++ b/integration-tests/conditional-compilation/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/contract-terminate/Cargo.toml
+++ b/integration-tests/contract-terminate/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/contract-transfer/Cargo.toml
+++ b/integration-tests/contract-transfer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/custom-environment/Cargo.toml
+++ b/integration-tests/custom-environment/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/custom_allocator/Cargo.toml
+++ b/integration-tests/custom_allocator/Cargo.toml
@@ -14,7 +14,7 @@ ink = { path = "../../crates/ink", default-features = false, features = ["no-all
 dlmalloc = {version = "0.2", default-features = false, features = ["global"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/dns/Cargo.toml
+++ b/integration-tests/dns/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/erc1155/Cargo.toml
+++ b/integration-tests/erc1155/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/erc20/Cargo.toml
+++ b/integration-tests/erc20/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/erc721/Cargo.toml
+++ b/integration-tests/erc721/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/flipper/Cargo.toml
+++ b/integration-tests/flipper/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/incrementer/Cargo.toml
+++ b/integration-tests/incrementer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 constructors_return_value = { path = "../constructors-return-value", default-features = false, features = ["ink-as-dependency"] }
 integration_flipper = { path = "../integration-flipper", default-features = false, features = ["ink-as-dependency"] }

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }

--- a/integration-tests/mapping_integration_tests/Cargo.toml
+++ b/integration-tests/mapping_integration_tests/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/mother/Cargo.toml
+++ b/integration-tests/mother/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+wildcard_complement_message { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/multi_contract_caller/Cargo.toml
+++ b/integration-tests/multi_contract_caller/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 adder = { path = "adder", default-features = false, features = ["ink-as-dependency"] }
 subber = { path = "subber", default-features = false, features = ["ink-as-dependency"] }

--- a/integration-tests/multi_contract_caller/accumulator/Cargo.toml
+++ b/integration-tests/multi_contract_caller/accumulator/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/multi_contract_caller/adder/Cargo.toml
+++ b/integration-tests/multi_contract_caller/adder/Cargo.toml
@@ -10,7 +10,7 @@ ink = { path = "../../../crates/ink", default-features = false }
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/multi_contract_caller/subber/Cargo.toml
+++ b/integration-tests/multi_contract_caller/subber/Cargo.toml
@@ -10,7 +10,7 @@ ink = { path = "../../../crates/ink", default-features = false }
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/multisig/Cargo.toml
+++ b/integration-tests/multisig/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/payment-channel/Cargo.toml
+++ b/integration-tests/payment-channel/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 hex-literal = { version = "0.3" }

--- a/integration-tests/psp22-extension/Cargo.toml
+++ b/integration-tests/psp22-extension/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/rand-extension/Cargo.toml
+++ b/integration-tests/rand-extension/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/set_code_hash/Cargo.toml
+++ b/integration-tests/set_code_hash/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/set_code_hash/updated_incrementer/Cargo.toml
+++ b/integration-tests/set_code_hash/updated_incrementer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/trait-dyn-cross-contract-calls/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 dyn-traits = { path = "./traits", default-features = false }
 

--- a/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 dyn-traits = { path = "../../traits", default-features = false }
 

--- a/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/trait-erc20/Cargo.toml
+++ b/integration-tests/trait-erc20/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/trait-flipper/Cargo.toml
+++ b/integration-tests/trait-flipper/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/trait-incrementer/Cargo.toml
+++ b/integration-tests/trait-incrementer/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 traits = { path = "./traits", default-features = false }
 
 [lib]

--- a/integration-tests/trait-incrementer/traits/Cargo.toml
+++ b/integration-tests/trait-incrementer/traits/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "traits"

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -34,7 +34,7 @@ ink_metadata = { path = "../crates/metadata", default-features = false }
 ink_primitives = { path = "../crates/primitives", default-features = false }
 ink_storage = { path = "../crates/storage", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5", default-features = false, features = ["derive"] }
 
 # For the moment we have to include the tests as examples and
 # then use `dylint_testing::ui_test_examples`.


### PR DESCRIPTION
And fix deprecation warnings by using public fields.