### PR TITLE
Clarify unit as bytes for `size` getter of mapping

### DIFF
--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -175,7 +175,7 @@ where
             .unwrap_or_else(|error| panic!("Failed to take value in Mapping: {error:?}"))
     }
 
-    /// Get the size of a value stored at `key` in the contract storage.
+    /// Get the size in bytes of a value stored at `key` in the contract storage.
     ///
     /// Returns `None` if no `value` exists at the given `key`.
     #[inline]


### PR DESCRIPTION
Closes #1686 🫡