### PR TITLE
E2E: Add runtime Call

### DIFF
--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -777,7 +777,7 @@ where
     ) -> Result<ExtrinsicEvents<C>, Error<C, E>> {
         let tx_events = self
             .api
-            .runtime_call(&signer, pallet_name, call_name, call_data)
+            .runtime_call(signer, pallet_name, call_name, call_data)
             .await;
 
         for evt in tx_events.iter() {

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -768,16 +768,16 @@ where
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.
-    pub async fn runtime_call(
+    pub async fn runtime_call<'a>(
         &mut self,
         signer: &Signer<C>,
-        pallet_name: &'static str,
-        call_name: &'static str,
-        call_data: Vec<u8>,
+        pallet_name: &'a str,
+        call_name: &'a str,
+        call_data: Vec<Value>,
     ) -> Result<ExtrinsicEvents<C>, Error<C, E>> {
         let tx_events = self
             .api
-            .runtime_call(signer, pallet_name, call_name, call_data)
+            .runtime_call(&signer, pallet_name, call_name, call_data)
             .await;
 
         for evt in tx_events.iter() {

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -762,8 +762,8 @@ where
     /// The `call_data` is a `Vec<Value>`
     ///
     /// Note:
-    /// `pallet_name` must be in camel case ex: "Balances"
-    /// `call_name` must be snake case ex: "force_transfer"
+    /// `pallet_name` must be in camel case ex: `Balances`
+    /// `call_name` must be snake case ex: `force_transfer`
     /// `call_data` is a Vec<subxt::dynamic::Value> that holds a representation of
     /// some value
     ///

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -762,8 +762,8 @@ where
     /// The `call_data` is a `Vec<Value>`
     ///
     /// Note:
-    /// `pallet_name` must be in camel case ex: "System"
-    /// `call_name` must be snake case ex: "kill_prefix"
+    /// `pallet_name` must be in camel case ex: "Balances"
+    /// `call_name` must be snake case ex: "force_transfer"
     /// `call_data` is a Vec<subxt::dynamic::Value> that holds a representation of
     /// some value
     ///

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -759,7 +759,7 @@ where
     }
 
     /// Executes a runtime call `call_name` for the `pallet_name`.
-    /// The `call_data` is a Vec<Value>
+    /// The `call_data` is a `Vec<Value>`
     ///
     /// Note:
     /// `pallet_name` must be in camel case ex: "System"

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -764,7 +764,7 @@ where
     /// Note:
     /// `pallet_name` must be in camel case ex: "System"
     /// `call_name` must be snake case ex: "kill_prefix"
-    /// `call_data` must be a Vec of subxt::dynamic::Value that holds a representation of
+    /// `call_data` is a Vec<subxt::dynamic::Value> that holds a representation of
     /// some value
     ///
     /// Returns when the transaction is included in a block. The return value

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -764,7 +764,8 @@ where
     /// Note:
     /// `pallet_name` must be in camel case ex: "System"
     /// `call_name` must be snake case ex: "kill_prefix"
-    /// `call_data` must be a Vec of subxt::dynamic::Value that holds a representation of some value
+    /// `call_data` must be a Vec of subxt::dynamic::Value that holds a representation of
+    /// some value
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.
@@ -792,13 +793,12 @@ where
                     &metadata,
                 );
                 log_error(&format!("extrinsic for call failed: {dispatch_error:?}"));
-                return Err(Error::CallExtrinsic(dispatch_error));
+                return Err(Error::CallExtrinsic(dispatch_error))
             }
         }
 
         Ok(tx_events)
     }
-
 
     /// Executes a dry-run `call`.
     ///

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -762,10 +762,10 @@ where
     /// The `call_data` is a `Vec<Value>`
     ///
     /// Note:
-    /// `pallet_name` must be in camel case ex: `Balances`
-    /// `call_name` must be snake case ex: `force_transfer`
-    /// `call_data` is a Vec<subxt::dynamic::Value> that holds a representation of
-    /// some value
+    /// - `pallet_name` must be in camel case, for example `Balances`.
+    /// - `call_name` must be snake case, for example `force_transfer`.
+    /// - `call_data` is a `Vec<subxt::dynamic::Value>` that holds a representation of
+    ///    some value
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -765,7 +765,7 @@ where
     /// - `pallet_name` must be in camel case, for example `Balances`.
     /// - `call_name` must be snake case, for example `force_transfer`.
     /// - `call_data` is a `Vec<subxt::dynamic::Value>` that holds a representation of
-    ///    some value
+    ///    some value.
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -758,6 +758,48 @@ where
         })
     }
 
+    /// Executes a runtime call `call_name` for the `pallet_name`.
+    /// The `call_data` is the call data bytes.
+    ///
+    /// Note:
+    /// `pallet_name` must be in camel case ex: "System"
+    /// `call_name` must be snake case ex: "kill_prefix"
+    /// `call_data` scale encoded call.
+    ///
+    /// Returns when the transaction is included in a block. The return value
+    /// contains all events that are associated with this transaction.
+    pub async fn runtime_call(
+        &mut self,
+        signer: &Signer<C>,
+        pallet_name: &'static str,
+        call_name: &'static str,
+        call_data: Vec<u8>,
+    ) -> Result<ExtrinsicEvents<C>, Error<C, E>> {
+        let tx_events = self
+            .api
+            .runtime_call(signer, pallet_name, call_name, call_data)
+            .await;
+
+        for evt in tx_events.iter() {
+            let evt = evt.unwrap_or_else(|err| {
+                panic!("unable to unwrap event: {err:?}");
+            });
+
+            if is_extrinsic_failed_event(&evt) {
+                let metadata = self.api.client.metadata();
+                let dispatch_error = subxt::error::DispatchError::decode_from(
+                    evt.field_bytes(),
+                    &metadata,
+                );
+                log_error(&format!("extrinsic for call failed: {dispatch_error:?}"));
+                return Err(Error::CallExtrinsic(dispatch_error));
+            }
+        }
+
+        Ok(tx_events)
+    }
+
+
     /// Executes a dry-run `call`.
     ///
     /// Returns the result of the dry run, together with the decoded return value of the

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -759,12 +759,12 @@ where
     }
 
     /// Executes a runtime call `call_name` for the `pallet_name`.
-    /// The `call_data` is the call data bytes.
+    /// The `call_data` is a Vec<Value>
     ///
     /// Note:
     /// `pallet_name` must be in camel case ex: "System"
     /// `call_name` must be snake case ex: "kill_prefix"
-    /// `call_data` scale encoded call.
+    /// `call_data` must be a Vec of subxt::dynamic::Value that holds a representation of some value
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -423,7 +423,8 @@ where
     }
 
     /// Submit an extrinsic `call_name` for the `pallet_name`.
-    /// The `call_data` is the call data bytes.
+    /// The `call_data` is a Vec<subxt::dynamic::Value> that holds a representation of
+    /// some value
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -427,18 +427,14 @@ where
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.
-    pub async fn runtime_call<'a >(
+    pub async fn runtime_call<'a>(
         &self,
         signer: &Signer<C>,
         pallet_name: &'a str,
         call_name: &'a str,
         call_data: Vec<subxt::dynamic::Value>,
     ) -> ExtrinsicEvents<C> {
-        let call = subxt::dynamic::tx(
-            pallet_name,
-            call_name,
-            call_data,
-        );
+        let call = subxt::dynamic::tx(pallet_name, call_name, call_data);
 
         self.submit_extrinsic(&call, signer).await
     }

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -423,8 +423,8 @@ where
     }
 
     /// Submit an extrinsic `call_name` for the `pallet_name`.
-    /// The `call_data` is a `Vec<subxt::dynamic::Value>` that holds a representation of
-    /// some value
+    /// The `call_data` is a `Vec<subxt::dynamic::Value>` that holds
+    /// a representation of some value.
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -423,7 +423,7 @@ where
     }
 
     /// Submit an extrinsic `call_name` for the `pallet_name`.
-    /// The `call_data` is a Vec<subxt::dynamic::Value> that holds a representation of
+    /// The `call_data` is a `Vec<subxt::dynamic::Value>` that holds a representation of
     /// some value
     ///
     /// Returns when the transaction is included in a block. The return value

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -421,4 +421,27 @@ where
 
         self.submit_extrinsic(&call, signer).await
     }
+
+    /// Submit an extrinsic `call_name` for the `pallet_name`.
+    /// The `call_data` is the call data bytes.
+    ///
+    /// Returns when the transaction is included in a block. The return value
+    /// contains all events that are associated with this transaction.
+    pub async fn runtime_call(
+        &self,
+        signer: &Signer<C>,
+        pallet_name: &'static str,
+        call_name: &'static str,
+        call_data: Vec<u8>,
+    ) -> ExtrinsicEvents<C> {
+        let call = tx::StaticTxPayload::new(
+            pallet_name,
+            call_name,
+            call_data,
+            Default::default(),
+        )
+            .unvalidated();
+
+        self.submit_extrinsic(&call, signer).await
+    }
 }

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -427,20 +427,18 @@ where
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.
-    pub async fn runtime_call(
+    pub async fn runtime_call<'a >(
         &self,
         signer: &Signer<C>,
-        pallet_name: &'static str,
-        call_name: &'static str,
-        call_data: Vec<u8>,
+        pallet_name: &'a str,
+        call_name: &'a str,
+        call_data: Vec<subxt::dynamic::Value>,
     ) -> ExtrinsicEvents<C> {
-        let call = tx::StaticTxPayload::new(
+        let call = subxt::dynamic::tx(
             pallet_name,
             call_name,
             call_data,
-            Default::default(),
-        )
-            .unvalidated();
+        );
 
         self.submit_extrinsic(&call, signer).await
     }

--- a/integration-tests/e2e-call-runtime/.gitignore
+++ b/integration-tests/e2e-call-runtime/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "e2e_call_runtime"
+version = "4.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { path = "../../crates/ink", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
+
+[dev-dependencies]
+ink_e2e = { path = "../../crates/e2e" }
+subxt = { version = "0.27.1", default-features = false }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -37,8 +37,9 @@ pub mod e2e_call_runtime {
 
             // when
             let call_data = vec![
-                // A value representing a MultiAddress<AccountId32, _>. We want the "Id" variant, and that
-                // will ultimately contain the bytes for our destination address
+                // A value representing a MultiAddress<AccountId32, _>. We want the "Id"
+                // variant, and that will ultimately contain the bytes
+                // for our destination address
                 Value::unnamed_variant("Id", [Value::from_bytes(&contract_acc_id)]),
                 // A value representing the amount we'd like to transfer.
                 Value::u128(100_000_000_000u128),

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -49,7 +49,7 @@ pub mod e2e_call_runtime {
             client
                 .runtime_call(&ink_e2e::alice(), "Balances", "transfer", call_data)
                 .await
-                .expect("system remark call failed");
+                .expect("runtime call failed");
 
             // then
             let get_balance = build_message::<ContractRef>(contract_acc_id.clone())

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -3,6 +3,7 @@
 #[ink::contract]
 pub mod e2e_call_runtime {
     #[ink(storage)]
+    #[derive(Default)]
     pub struct Contract {}
 
     impl Contract {

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -38,7 +38,7 @@ pub mod e2e_call_runtime {
 
             // when
             let call_data = vec![
-                // A value representing a MultiAddress<AccountId32, _>. We want the "Id"
+                // A value representing a `MultiAddress<AccountId32, _>`. We want the "Id"
                 // variant, and that will ultimately contain the bytes
                 // for our destination address
                 Value::unnamed_variant("Id", [Value::from_bytes(&contract_acc_id)]),

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -1,0 +1,68 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+pub mod e2e_call_runtime {
+    #[ink(storage)]
+    pub struct Contract {}
+
+    impl Contract {
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn get_contract_balance(&self) -> Balance {
+            self.env().balance()
+        }
+    }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use super::*;
+        use ink_e2e::build_message;
+        use subxt::dynamic::Value;
+
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn call_runtime_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let constructor = ContractRef::new();
+            let contract_acc_id = client
+                .instantiate("e2e_call_runtime", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            // when
+            let call_data = vec![
+                // A value representing a MultiAddress<AccountId32, _>. We want the "Id" variant, and that
+                // will ultimately contain the bytes for our destination address
+                Value::unnamed_variant("Id", [Value::from_bytes(&contract_acc_id)]),
+                // A value representing the amount we'd like to transfer.
+                Value::u128(100_000_000_000u128),
+            ];
+
+            // Send funds from Alice to the contract using Balances::transfer
+            client
+                .runtime_call(&ink_e2e::alice(), "Balances", "transfer", call_data)
+                .await
+                .expect("system remark call failed");
+
+            // then
+            let get_balance = build_message::<ContractRef>(contract_acc_id.clone())
+                .call(|contract| contract.get_contract_balance());
+            let get_balance_res = client
+                .call_dry_run(&ink_e2e::alice(), &get_balance, 0, None)
+                .await;
+
+            assert!(matches!(
+                get_balance_res.return_value(),
+                100_000_000_000u128
+            ));
+
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
Added `runtime_call` to E2E in order to call any pallet call form the testing environment.
It is needed to test specific use cases (especially for chain-extensions e2e tests).