### PR TITLE
Automatically export preludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Upgraded `syn` to version `2` - [#1731](https://github.com/paritytech/ink/pull/1731)
+- Automatically export preludes - [#1737](https://github.com/paritytech/ink/pull/1737)
 
 ## Version 4.1.0
 

--- a/crates/ink/codegen/src/generator/contract.rs
+++ b/crates/ink/codegen/src/generator/contract.rs
@@ -53,7 +53,7 @@ impl GenerateCode for Contract<'_> {
         quote! {
             #( #attrs )*
             #vis mod #ident {
-                use ink::prelude::{borrow::*, boxed::*, format, string::*, vec::*};
+                use ink::prelude::{borrow::*, boxed::*, format, string::*, vec::*, vec};
                 #env
                 #storage
                 #events

--- a/crates/ink/codegen/src/generator/contract.rs
+++ b/crates/ink/codegen/src/generator/contract.rs
@@ -53,7 +53,7 @@ impl GenerateCode for Contract<'_> {
         quote! {
             #( #attrs )*
             #vis mod #ident {
-                use ::ink::prelude::{borrow::*, boxed::*, format, string::*, vec::*};
+                use ::ink::prelude::*;
                 #env
                 #storage
                 #events

--- a/crates/ink/codegen/src/generator/contract.rs
+++ b/crates/ink/codegen/src/generator/contract.rs
@@ -53,7 +53,7 @@ impl GenerateCode for Contract<'_> {
         quote! {
             #( #attrs )*
             #vis mod #ident {
-                use ink::prelude::{borrow::*, boxed::*, format, string::*, vec::*, vec};
+                use ::ink::prelude::{borrow::*, boxed::*, format, string::*, vec::*, vec};
                 #env
                 #storage
                 #events

--- a/crates/ink/codegen/src/generator/contract.rs
+++ b/crates/ink/codegen/src/generator/contract.rs
@@ -53,6 +53,7 @@ impl GenerateCode for Contract<'_> {
         quote! {
             #( #attrs )*
             #vis mod #ident {
+                use ink::prelude::{borrow::*, boxed::*, format, string::*, vec::*};
                 #env
                 #storage
                 #events

--- a/crates/ink/codegen/src/generator/contract.rs
+++ b/crates/ink/codegen/src/generator/contract.rs
@@ -53,7 +53,7 @@ impl GenerateCode for Contract<'_> {
         quote! {
             #( #attrs )*
             #vis mod #ident {
-                use ::ink::prelude::{borrow::*, boxed::*, format, string::*, vec::*, vec};
+                use ::ink::prelude::{borrow::*, boxed::*, format, string::*, vec::*};
                 #env
                 #storage
                 #events

--- a/crates/prelude/src/lib.rs
+++ b/crates/prelude/src/lib.rs
@@ -38,7 +38,11 @@ cfg_if! {
             boxed,
             format,
             string,
+            string::String,
+            string::ToString,
             vec,
+            vec::Vec,
+            vec::IntoIter,
         };
 
         /// Collection types.
@@ -59,7 +63,11 @@ cfg_if! {
             boxed,
             format,
             string,
+            string::String,
+            string::ToString,
             vec,
+            vec::Vec,
+            vec::IntoIter,
         };
 
         /// Collection types.


### PR DESCRIPTION
We've seen a number of questions related to inability to use structures like `Vec` and `String` in smart contract. This is because we require those data types to be explicitly imported from the ink! prelude. 

This PR automatically imports default crates that contain macros and data structures that are present in a typical rust program by default.