### PR TITLE
Created cron job to show stale issues

### DIFF
--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -39,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           repo: ${{ matrix.repo }}
           # Users to ignore if they are authors. They are separated by commas
-          ignoreAuthors: ascjones,HCastano,Robbepop,athei,agryaznov,SkymanOne,xermicus,statictype,DoubleOTheven,cmichi,safina12
+          ignoreAuthors: ascjones,HCastano,Robbepop,athei,agryaznov,SkymanOne,xermicus,statictype,DoubleOTheven,cmichi,safina12,lean-apple,juangirini,pgherveou
           # only fetch issues that don't have any replies
           noComments: true
           # from today onwards. Increase this number to set how much time without interaction must pass for the issue to be analyzed

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -1,0 +1,99 @@
+name: Find stale issues
+
+on:
+  workflow_dispatch:
+  schedule:
+      # UTC Time
+    - cron: "0 7 * * 4"
+
+jobs:
+  fetch-issues:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # List of repositories to fetch the issues
+        repo:
+          - ink
+          - cargo-contract
+          - substrate-contracts-node
+          - contracts-ui
+          - ink-docs
+          - smart-bench
+          - ink-waterfall
+          - ink-playground
+          - nft-marketplace-demo
+          - pallet-contracts-xcm
+          - link
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.ISSUE_TRACKER_APP_ID }}
+          private_key: ${{ secrets.ISSUE_TRACKER_APP_KEY }}
+      - name: Fetch issues from ${{ matrix.repo }}
+        id: issue
+        uses: paritytech/stale-issues-finder@main
+        with:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          repo: ${{ matrix.repo }}
+          # Users to ignore if they are authors. They are separated by commas
+          ignoreAuthors: ascjones,HCastano,Robbepop,athei,agryaznov,SkymanOne,xermicus,statictype,DoubleOTheven,cmichi,safina12
+          # only fetch issues that don't have any replies
+          noComments: true
+          # from today onwards. Increase this number to set how much time without interaction must pass for the issue to be analyzed
+          days-stale: 0
+      - run: mkdir outputs
+      - name: Write repo data
+        run: echo "$DATA" > "$FILE"
+        env:
+          DATA: ${{ steps.issue.outputs.data }}
+          FILE: outputs/${{ matrix.repo }}.json
+      - uses: actions/upload-artifact@v3
+        with:
+          name: outputs
+          path: outputs/*.json
+
+  message:
+    runs-on: ubuntu-latest
+    needs: fetch-issues
+    steps:
+      - name: Load outputs
+        uses: actions/download-artifact@v3
+        with:
+          name: outputs
+          path: outputs
+      - name: Combine outputs
+        id: issues
+        run: |
+          COMBINED=$(jq -s 'reduce .[] as $x ([]; . + $x)' outputs/*.json | tr '\n' ' ')
+          echo "ISSUES=$COMBINED" >> $GITHUB_OUTPUT
+      - name: Filter to the oldest 30 issues
+        id: message
+        # Modify the number in [:8] to change how many issues should be shown
+        run: |
+          MESSAGE=$(echo $COMBINED | jq -r '. | sort_by(.daysStale) | reverse[:8]| .[] | "- [\(.title)](\(.url)) | \(.daysStale) days with no reply"')
+          delimiter="$(openssl rand -hex 8)"
+          echo "MESSAGE<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo "$MESSAGE" >> "${GITHUB_OUTPUT}"
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+        env:
+          COMBINED: ${{ steps.issues.outputs.ISSUES }}
+      - name: send message
+        uses: s3krit/matrix-message-action@v0.0.3
+        with:
+          room_id: "!EBuECvRavzBxijipBi:parity.io"
+          access_token: ${{ secrets.STALE_MATRIX_ACCESS_TOKEN }}
+          # Remember to keep at least one empty line between paragraphs
+          message: |
+            ## Good morning, team 🥞!
+            This weekly digest lists GitHub issues without any reply that were created by non-team members.
+
+            This weekly digest lists GitHub issues without any reply that were created by non-team members. 
+            
+            The list is an aggregation of repositories which the Smart Contracts ☂️ owns ([list](https://www.notion.so/paritytechnologies/What-belongs-to-our-umbrella-b9a80b72fedc47d6b35224a15bdec64c)).
+
+            ${{ steps.message.outputs.MESSAGE }}
+
+            Find all the stale issues [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          server: "m.parity.io"

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -67,18 +67,28 @@ jobs:
         id: issues
         run: |
           COMBINED=$(jq -s 'reduce .[] as $x ([]; . + $x)' outputs/*.json | tr '\n' ' ')
+          COUNT=$(echo $COMBINED | jq length)
+          echo "# There are $COUNT stale issues" >> $GITHUB_STEP_SUMMARY
           echo "ISSUES=$COMBINED" >> $GITHUB_OUTPUT
-      - name: Filter to the oldest 30 issues
+          echo "COUNT=$COUNT" >> $GITHUB_OUTPUT
+      - name: Filter to the oldest issues
         id: message
-        # Modify the number in [:8] to change how many issues should be shown
+        # Modify the number in reverse[:8] to change how many issues should be shown
         run: |
-          MESSAGE=$(echo $COMBINED | jq -r '. | sort_by(.daysStale) | reverse[:8]| .[] | "- [\(.title)](\(.url)) | \(.daysStale) days with no reply"')
-          delimiter="$(openssl rand -hex 8)"
-          echo "MESSAGE<<${delimiter}" >> "${GITHUB_OUTPUT}"
-          echo "$MESSAGE" >> "${GITHUB_OUTPUT}"
-          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+          if [ $COUNT = "0" ]; then
+            echo "MESSAGE=$EMPTY_MESSAGE" >> $GITHUB_OUTPUT
+          else
+            MESSAGE=$(echo $COMBINED | jq -r '. | sort_by(.daysStale) | reverse[:8]| .[] | "- [\(.title)](\(.url)) | \(.daysStale) days with no reply"')
+            delimiter="$(openssl rand -hex 8)"
+            echo "MESSAGE<<${delimiter}" >> "${GITHUB_OUTPUT}"
+            echo "$MESSAGE" >> "${GITHUB_OUTPUT}"
+            echo "${delimiter}" >> "${GITHUB_OUTPUT}"
+          fi
         env:
           COMBINED: ${{ steps.issues.outputs.ISSUES }}
+          COUNT: ${{ steps.issues.outputs.COUNT }}
+          # This is the message that will be shown when there are no 
+          EMPTY_MESSAGE: "No stale issues! Good job!"
       - name: send message
         uses: s3krit/matrix-message-action@v0.0.3
         with:

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -99,8 +99,6 @@ jobs:
           message: |
             ## Good morning, team 🥞!
             This weekly digest lists GitHub issues without any reply that were created by non-team members.
-
-            This weekly digest lists GitHub issues without any reply that were created by non-team members. 
             
             The list is an aggregation of repositories which the Smart Contracts ☂️ owns ([list](https://www.notion.so/paritytechnologies/What-belongs-to-our-umbrella-b9a80b72fedc47d6b35224a15bdec64c)).
 

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -24,6 +24,7 @@ jobs:
           - nft-marketplace-demo
           - pallet-contracts-xcm
           - link
+          - ink-examples
     steps:
       - name: Generate token
         id: generate_token


### PR DESCRIPTION
This PR opens a cron job that uses the [paritytech/stale-issues-finder](https://github.com/paritytech/stale-issues-finder) action.

It will run every Thursday at 7AM UTC (9 AM Germany)

You can also manually run this action by going to https://github.com/paritytech/ink/actions/workflows/issue-notifier.yml

It will fetch issues from the repositories:
- ink
- cargo-contract
- substrate-contracts-node
- contracts-ui
- ink-docs
- smart-bench
- ink-waterfall
- ink-playground
- nft-marketplace-demo
- pallet-contracts-xcm
- link
- ink-examples

It will ignore issues created by:
 - ascjones
 - HCastano
 - Robbepop
 - athei
 - agryaznov
 - SkymanOne
 - xermicus
 - statictype
 - DoubleOTheven
 - cmichi
 - safina12
 - lean-apple
 - juangirini
 - pgherveou

It will only fetch issues that don't have any comments.

It will organize them by oldest, and fetch only the first 8 issues and will format them with the format:
`- [(title)]((url)) | (daysStale) days with no reply`

In the case that there a no issues found, it will post the message:
> No stale issues! Good job!

I have added a lot of comments to the `yml` file so it is easy to configure if you need to add an extra author, or modify a repository.

This PR is blocked by paritytech/internal_it#204 so please do not merge it until it is running.