### PR TITLE
Make `set_contract_storage` fallible

### DIFF
--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -63,7 +63,7 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
                     return Err(format_err_spanned!(
                         arg,
                         "expected a string literal for `additional_contracts` ink! E2E test configuration argument",
-                    ))
+                    ));
                 }
             } else if arg.name.is_ident("environment") {
                 if let Some((_, ast)) = environment {
@@ -75,7 +75,7 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
                     return Err(format_err_spanned!(
                         arg,
                         "expected a path for `environment` ink! E2E test configuration argument",
-                    ))
+                    ));
                 }
             } else {
                 return Err(format_err_spanned!(

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -192,7 +192,7 @@ where
 ///
 /// - If the encode length of value exceeds the configured maximum value length of a
 ///   storage entry.
-pub fn set_contract_storage<K, V>(key: &K, value: &V) -> Option<u32>
+pub fn set_contract_storage<K, V>(key: &K, value: &V) -> Result<Option<u32>>
 where
     K: scale::Encode,
     V: Storable,

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -172,7 +172,7 @@ pub trait EnvBackend {
     /// Writes the value to the contract storage under the given storage key.
     ///
     /// Returns the size of the pre-existing value at the specified key if any.
-    fn set_contract_storage<K, V>(&mut self, key: &K, value: &V) -> Option<u32>
+    fn set_contract_storage<K, V>(&mut self, key: &K, value: &V) -> Result<Option<u32>>
     where
         K: scale::Encode,
         V: Storable;

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -186,14 +186,17 @@ impl EnvInstance {
 }
 
 impl EnvBackend for EnvInstance {
-    fn set_contract_storage<K, V>(&mut self, key: &K, value: &V) -> Option<u32>
+    fn set_contract_storage<K, V>(&mut self, key: &K, value: &V) -> Result<Option<u32>>
     where
         K: scale::Encode,
         V: Storable,
     {
         let mut v = vec![];
+        if value.size_hint() > 9600 {
+            return Err(Error::Unknown)
+        }
         Storable::encode(value, &mut v);
-        self.engine.set_storage(&key.encode(), &v[..])
+        Ok(self.engine.set_storage(&key.encode(), &v[..]))
     }
 
     fn get_contract_storage<K, R>(&mut self, key: &K) -> Result<Option<R>>

--- a/crates/env/src/engine/on_chain/buffer.rs
+++ b/crates/env/src/engine/on_chain/buffer.rs
@@ -212,4 +212,9 @@ impl<'a> ScopedBuffer<'a> {
         debug_assert!(!self.buffer.is_empty());
         self.buffer
     }
+
+    /// Return the length of the internal buffer.
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
 }

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -212,15 +212,18 @@ impl EnvInstance {
 }
 
 impl EnvBackend for EnvInstance {
-    fn set_contract_storage<K, V>(&mut self, key: &K, value: &V) -> Option<u32>
+    fn set_contract_storage<K, V>(&mut self, key: &K, value: &V) -> Result<Option<u32>>
     where
         K: scale::Encode,
         V: Storable,
     {
         let mut buffer = self.scoped_buffer();
         let key = buffer.take_encoded(key);
+        if value.size_hint() > buffer.len() {
+            return Err(Error::Unknown)
+        }
         let value = buffer.take_storable_encoded(value);
-        ext::set_storage(key, value)
+        Ok(ext::set_storage(key, value))
     }
 
     fn get_contract_storage<K, R>(&mut self, key: &K) -> Result<Option<R>>

--- a/crates/ink/codegen/src/generator/dispatch.rs
+++ b/crates/ink/codegen/src/generator/dispatch.rs
@@ -585,7 +585,7 @@ impl Dispatch<'_> {
                         ::ink::env::set_contract_storage::<::ink::primitives::Key, #storage_ident>(
                             &<#storage_ident as ::ink::storage::traits::StorageKey>::KEY,
                             contract,
-                        );
+                        ).unwrap(); // TODO (unwrapping here should roughly be the same as is)
                     }
 
                     ::ink::env::return_value::<
@@ -838,7 +838,7 @@ impl Dispatch<'_> {
                         ::ink::env::set_contract_storage::<::ink::primitives::Key, #storage_ident>(
                             &<#storage_ident as ::ink::storage::traits::StorageKey>::KEY,
                             &contract,
-                        );
+                        ).unwrap(); // TODO (unwrapping here should roughly be the same as is)
                     }
                 }
 

--- a/crates/ink/ir/src/ir/item_mod.rs
+++ b/crates/ink/ir/src/ir/item_mod.rs
@@ -263,7 +263,7 @@ impl ItemMod {
                         .into_combine(format_err!(
                             overlap.span(),
                             "first ink! message with overlapping wildcard selector here",
-                        )))
+                        )));
                     }
                 }
             }
@@ -283,7 +283,7 @@ impl ItemMod {
                             .into_combine(format_err!(
                             overlap.span(),
                             "first ink! constructor with overlapping wildcard selector here",
-                        )))
+                        )));
                     }
                 }
             }

--- a/crates/ink/ir/src/ir/trait_def/item/mod.rs
+++ b/crates/ink/ir/src/ir/trait_def/item/mod.rs
@@ -384,7 +384,7 @@ impl InkItemTrait {
                 ).into_combine(format_err_spanned!(
                     duplicate_selector,
                     "first ink! trait constructor or message with same selector found here",
-                )))
+                )));
             }
             assert!(
                 duplicate_ident.is_none(),

--- a/crates/ink/macro/src/storage/tests/storable.rs
+++ b/crates/ink/macro/src/storage/tests/storable.rs
@@ -33,6 +33,17 @@ fn unit_struct_works() {
                 impl ::ink::storage::traits::Storable for UnitStruct {
                     #[inline(always)]
                     #[allow(non_camel_case_types)]
+                    #[allow(unused_mut)]
+                    fn size_hint(&self) -> ::core::primitive::usize {
+                        let mut size_hint = 0;
+                        match self {
+                            UnitStruct => {}
+                        }
+                        size_hint
+                    }
+
+                    #[inline(always)]
+                    #[allow(non_camel_case_types)]
                     fn decode<__ink_I: ::scale::Input>(__input: &mut __ink_I) -> ::core::result::Result<Self, ::scale::Error> {
                         ::core::result::Result::Ok(UnitStruct)
                     }
@@ -63,6 +74,27 @@ fn struct_works() {
         expands to {
             const _: () = {
                 impl ::ink::storage::traits::Storable for NamedFields {
+                    #[inline (always)]
+                    #[allow (non_camel_case_types)]
+                    #[allow(unused_mut)]
+                    fn size_hint(&self) -> ::core::primitive::usize {
+                        let mut size_hint = 0;
+                        match self {
+                            NamedFields { a : __binding_0 , b : __binding_1 , d : __binding_2 , } => {
+                                {
+                                    size_hint += ::ink::storage:: traits:: Storable:: size_hint(__binding_0);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_1);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_2);
+                                }
+                            }
+                        }
+                        size_hint
+                    }
+
                     #[inline(always)]
                     #[allow(non_camel_case_types)]
                     fn decode<__ink_I: ::scale::Input>(__input: &mut __ink_I) -> ::core::result::Result<Self, ::scale::Error> {
@@ -125,6 +157,20 @@ fn one_variant_enum_works() {
                 impl ::ink::storage::traits::Storable for OneVariantEnum {
                     #[inline(always)]
                     #[allow(non_camel_case_types)]
+                    #[allow(unused_mut)]
+                    fn size_hint (&self) -> ::core::primitive::usize {
+                        let mut size_hint = 0;
+                        match self {
+                            OneVariantEnum::A => {
+                                {
+                                    size_hint += <::core::primitive::u8 as ::ink::storage::traits::Storable>::size_hint(&0u8);
+                                }
+                            }
+                        }
+                        size_hint
+                    }
+                    #[inline(always)]
+                    #[allow(non_camel_case_types)]
                     fn decode<__ink_I: ::scale::Input>(__input: &mut __ink_I) -> ::core::result::Result<Self, ::scale::Error> {
                         ::core::result::Result::Ok(
                             match <::core::primitive::u8 as ::ink::storage::traits::Storable>::decode(__input)?
@@ -168,6 +214,43 @@ fn enum_works() {
         expands to {
             const _: () = {
                 impl ::ink::storage::traits::Storable for MixedEnum {
+                    #[inline(always)]
+                    #[allow(non_camel_case_types)]
+                    #[allow(unused_mut)]
+                    fn size_hint (&self) -> ::core::primitive::usize{
+                        let mut size_hint = 0;
+                        match self {
+                            MixedEnum::A => {
+                                {
+                                    size_hint += <::core::primitive::u8 as ::ink::storage::traits::Storable>::size_hint(&0u8);
+                                }
+                            }
+                            MixedEnum::B(__binding_0, __binding_1,) => {
+                                {
+                                    size_hint += <::core::primitive::u8 as ::ink::storage::traits::Storable>::size_hint(&1u8);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_0);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_1);
+                                }
+                            }
+                            MixedEnum::C { a: __binding_0, b: __binding_1, } => {
+                                {
+                                    size_hint += <::core::primitive::u8 as ::ink::storage::traits::Storable>::size_hint(&2u8);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_0);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_1);
+                                }
+                            }
+                        }
+                        size_hint
+                    }
+
                     #[inline(always)]
                     #[allow(non_camel_case_types)]
                     fn decode<__ink_I: ::scale::Input>(__input: &mut __ink_I) -> ::core::result::Result<Self, ::scale::Error> {
@@ -274,6 +357,23 @@ fn generic_struct_works() {
                 {
                     #[inline(always)]
                     #[allow(non_camel_case_types)]
+                    #[allow(unused_mut)]
+                    fn size_hint(&self) -> ::core::primitive::usize {
+                        let mut size_hint = 0;
+                        match self {
+                            GenericStruct { a : __binding_0 , b : __binding_1 , } => {
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_0);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_1);
+                                }
+                            }
+                        }
+                        size_hint
+                    }
+                    #[inline(always)]
+                    #[allow(non_camel_case_types)]
                     fn decode<__ink_I: ::scale::Input>(__input: &mut __ink_I) -> ::core::result::Result<Self, ::scale::Error> {
                         ::core::result::Result::Ok(
                             GenericStruct {
@@ -332,6 +432,38 @@ fn generic_enum_works() {
                     T1: ::ink::storage::traits::Storable,
                     T2: ::ink::storage::traits::Storable
                 {
+                    #[inline(always)]
+                    #[allow(non_camel_case_types)]
+                    #[allow(unused_mut)]
+                    fn size_hint(&self) -> ::core::primitive::usize {
+                        let mut size_hint = 0;
+                        match self {
+                            GenericEnum::Tuple (__binding_0, __binding_1,) => {
+                                {
+                                    size_hint += <::core::primitive:: u8 as::ink::storage::traits::Storable>::size_hint(&0u8);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_0);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_1);
+                                }
+                            }
+                            GenericEnum::Named { a: __binding_0, b: __binding_1,} => {
+                                {
+                                    size_hint += <::core::primitive::u8 as::ink::storage::traits::Storable>::size_hint(&1u8);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_0);
+                                }
+                                {
+                                    size_hint += ::ink::storage::traits::Storable::size_hint(__binding_1);
+                                }
+                            }
+                        }
+                        size_hint
+                    }
+
                     #[inline(always)]
                     #[allow(non_camel_case_types)]
                     fn decode<__ink_I: ::scale::Input>(__input: &mut __ink_I) -> ::core::result::Result<Self, ::scale::Error> {

--- a/crates/ink/tests/ui/storage_item/pass/argument_derive_false.rs
+++ b/crates/ink/tests/ui/storage_item/pass/argument_derive_false.rs
@@ -1,8 +1,5 @@
 use ink::storage::traits::Storable;
-use ink::storage::traits::{
-    ManualKey,
-    StorageKey,
-};
+use ink::storage::traits::{ManualKey, StorageKey};
 
 #[ink::storage_item(derive = false)]
 #[derive(Default)]
@@ -14,6 +11,10 @@ struct Contract<KEY: StorageKey = ManualKey<123>> {
 
 // Disabling of deriving allow to implement the trait manually
 impl<KEY: StorageKey> Storable for Contract<KEY> {
+    fn size_hint(&self) -> usize {
+        0
+    }
+
     fn encode<T: scale::Output + ?Sized>(&self, _dest: &mut T) {}
 
     fn decode<I: scale::Input>(_input: &mut I) -> Result<Self, scale::Error> {

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -136,7 +136,7 @@ where
     ///
     /// Returns the size in bytes of the pre-existing value at the specified key if any.
     #[inline]
-    pub fn insert<Q, R>(&mut self, key: Q, value: &R) -> Option<u32>
+    pub fn insert<Q, R>(&mut self, key: Q, value: &R) -> ink_env::Result<Option<u32>>
     where
         Q: scale::EncodeLike<K>,
         R: Storable + scale::EncodeLike<V>,
@@ -213,6 +213,11 @@ where
     KeyType: StorageKey,
 {
     #[inline]
+    fn size_hint(&self) -> usize {
+        0
+    }
+
+    #[inline]
     fn encode<T: Output + ?Sized>(&self, _dest: &mut T) {}
 
     #[inline]
@@ -272,7 +277,7 @@ mod tests {
     fn insert_and_get_work() {
         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
             let mut mapping: Mapping<u8, _> = Mapping::new();
-            mapping.insert(1, &2);
+            mapping.insert(1, &2).expect("buffer can hold an u8");
             assert_eq!(mapping.get(1), Some(2));
 
             Ok(())
@@ -284,7 +289,7 @@ mod tests {
     fn insert_and_get_work_for_two_mapping_with_same_manual_key() {
         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
             let mut mapping: Mapping<u8, u8, ManualKey<123>> = Mapping::new();
-            mapping.insert(1, &2);
+            mapping.insert(1, &2).expect("buffer can hold an u8");
 
             let mapping2: Mapping<u8, u8, ManualKey<123>> = Mapping::new();
             assert_eq!(mapping2.get(1), Some(2));
@@ -309,7 +314,7 @@ mod tests {
     fn insert_and_take_work() {
         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
             let mut mapping: Mapping<u8, _> = Mapping::new();
-            mapping.insert(1, &2);
+            mapping.insert(1, &2).expect("buffer can hold an u8");
             assert_eq!(mapping.take(1), Some(2));
             assert!(mapping.get(1).is_none());
 
@@ -335,7 +340,7 @@ mod tests {
             // Given
             let mut mapping: Mapping<u8, u8> = Mapping::new();
 
-            mapping.insert(1, &2);
+            mapping.insert(1, &2).expect("buffer can hold an u8");
             assert_eq!(mapping.get(1), Some(2));
 
             // When

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -143,8 +143,8 @@ where
     }
 
     /// Writes the given `value` to the contract storage.
-    pub fn set(&mut self, value: &V) {
-        ink_env::set_contract_storage::<Key, V>(&KeyType::KEY, value);
+    pub fn set(&mut self, value: &V) -> ink_env::Result<Option<u32>> {
+        ink_env::set_contract_storage::<Key, V>(&KeyType::KEY, value)
     }
 }
 
@@ -168,6 +168,11 @@ impl<V, KeyType> Storable for Lazy<V, KeyType>
 where
     KeyType: StorageKey,
 {
+    #[inline(always)]
+    fn size_hint(&self) -> usize {
+        0
+    }
+
     #[inline(always)]
     fn encode<T: Output + ?Sized>(&self, _dest: &mut T) {}
 
@@ -226,7 +231,7 @@ mod tests {
     fn set_and_get_work() {
         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
             let mut storage: Lazy<u8> = Lazy::new();
-            storage.set(&2);
+            storage.set(&2).expect("buffer can hold an u8");
             assert_eq!(storage.get(), Some(2));
 
             Ok(())
@@ -238,7 +243,7 @@ mod tests {
     fn set_and_get_work_for_two_lazy_with_same_manual_key() {
         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
             let mut storage: Lazy<u8, ManualKey<123>> = Lazy::new();
-            storage.set(&2);
+            storage.set(&2).expect("buffer can hold an u8");
 
             let storage2: Lazy<u8, ManualKey<123>> = Lazy::new();
             assert_eq!(storage2.get(), Some(2));

--- a/crates/storage/traits/src/storage.rs
+++ b/crates/storage/traits/src/storage.rs
@@ -20,6 +20,8 @@ use ink_primitives::Key;
 /// [`scale::Codec`] are storable by default and transferable between contracts.
 /// But not each storable type is transferable.
 pub trait Storable: Sized {
+    fn size_hint(&self) -> usize;
+
     /// Convert self to a slice and append it to the destination.
     fn encode<T: scale::Output + ?Sized>(&self, dest: &mut T);
 
@@ -33,6 +35,11 @@ impl<P> Storable for P
 where
     P: scale::Codec,
 {
+    #[inline]
+    fn size_hint(&self) -> usize {
+        scale::Encode::size_hint(&self)
+    }
+
     #[inline]
     fn encode<T: scale::Output + ?Sized>(&self, dest: &mut T) {
         scale::Encode::encode_to(self, dest)


### PR DESCRIPTION
Related issue #1682

This is a very naive approach to the problem: If `set_contract_storage` can fail because the data does no longer fit into the encoding buffer, contract authors can account for that possibility. I don't think we need this for decoding because I don't see how something would fit in the buffer while encoding but no longer while decoding it.

A less invasive way would be to just add a `try_set` method to `Lazy`, but I thought this might be useful to have generally available. We also could introduce `try_set_contract_storage` into the API instead so we don't break the existing API. WDYT? Was there was an explicit reason `set_contract_storage` does not return a `Result`?

This is an early WIP. Todo:
- [ ] Don't use `Error::Unknown`, might need a new one
- [ ] Adapt integration tests
- [ ] In the dispatch it just unwraps the result, however now that we have a `Result` we could as well do something about it other than panic
- [ ] Implement tests
- [ ] Probably many more