### PR TITLE
Persist `Environment` in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Persist `Environment` in metadata - [#1741](https://github.com/paritytech/ink/pull/1741)
+
 ### Changed
 - Upgraded `syn` to version `2` - [#1731](https://github.com/paritytech/ink/pull/1731)
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -16,7 +16,6 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "4.1.0", path = "../metadata", default-features = false, features = ["derive"], optional = true }
 ink_allocator = { version = "4.1.0", path = "../allocator", default-features = false }
 ink_storage_traits = { version = "4.1.0", path = "../storage/traits", default-features = false }
 ink_prelude = { version = "4.1.0", path = "../prelude", default-features = false }
@@ -56,7 +55,6 @@ ink = { path = "../ink" }
 [features]
 default = ["std"]
 std = [
-    "ink_metadata/std",
     "ink_allocator/std",
     "ink_prelude/std",
     "ink_primitives/std",

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -177,6 +177,7 @@ pub trait Environment {
 }
 
 /// Placeholder for chains that have no defined chain extension.
+#[cfg_attr(feature = "std", derive(TypeInfo))]
 pub enum NoChainExtension {}
 
 /// The fundamental types of the default configuration.

--- a/crates/ink/codegen/src/generator/chain_extension.rs
+++ b/crates/ink/codegen/src/generator/chain_extension.rs
@@ -133,6 +133,9 @@ impl GenerateCode for ChainExtension<'_> {
         let instance_ident = format_ident!("__ink_{}Instance", ident);
         quote_spanned!(span =>
             #(#attrs)*
+            #[cfg_attr(feature = "std", derive(
+                ::scale_info::TypeInfo,
+            ))]
             pub enum #ident {}
 
             const _: () = {

--- a/crates/ink/codegen/src/generator/env.rs
+++ b/crates/ink/codegen/src/generator/env.rs
@@ -39,6 +39,8 @@ impl GenerateCode for Env<'_> {
             type Hash = <<#storage_ident as ::ink::env::ContractEnv>::Env as ::ink::env::Environment>::Hash;
             type Timestamp = <<#storage_ident as ::ink::env::ContractEnv>::Env as ::ink::env::Environment>::Timestamp;
             type BlockNumber = <<#storage_ident as ::ink::env::ContractEnv>::Env as ::ink::env::Environment>::BlockNumber;
+            type ChainExtension = <<#storage_ident as ::ink::env::ContractEnv>::Env as ::ink::env::Environment>::ChainExtension;
+            const MAX_EVENT_TOPICS: usize = <<#storage_ident as ::ink::env::ContractEnv>::Env as ::ink::env::Environment>::MAX_EVENT_TOPICS;
         }
     }
 }

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -86,6 +86,7 @@ impl Metadata<'_> {
         let constructors = self.generate_constructors();
         let messages = self.generate_messages();
         let events = self.generate_events();
+        let env = self.contract.config().env();
         let docs = self
             .contract
             .module()

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -28,7 +28,10 @@ use quote::{
     quote,
     quote_spanned,
 };
-use syn::spanned::Spanned as _;
+use syn::{
+    parse_quote,
+    spanned::Spanned as _,
+};
 
 /// Generates code to generate the metadata of the contract.
 #[derive(From)]
@@ -86,7 +89,6 @@ impl Metadata<'_> {
         let constructors = self.generate_constructors();
         let messages = self.generate_messages();
         let events = self.generate_events();
-        let env = self.contract.config().env();
         let docs = self
             .contract
             .module()
@@ -97,6 +99,7 @@ impl Metadata<'_> {
             ::ink::LangError
         };
         let error = Self::generate_type_spec(&error_ty);
+        let environment = self.generate_environment();
         quote! {
             ::ink::metadata::ContractSpec::new()
                 .constructors([
@@ -113,6 +116,9 @@ impl Metadata<'_> {
                 ])
                 .lang_error(
                      #error
+                )
+                .environment(
+                    #environment
                 )
                 .done()
         }
@@ -407,6 +413,35 @@ impl Metadata<'_> {
                     .done()
             )
         })
+    }
+
+    fn generate_environment(&self) -> TokenStream2 {
+        let span = self.contract.module().span();
+
+        let account_id: syn::Type = parse_quote!(AccountId);
+        let balance: syn::Type = parse_quote!(Balance);
+        let hash: syn::Type = parse_quote!(Hash);
+        let timestamp: syn::Type = parse_quote!(Timestamp);
+        let block_number: syn::Type = parse_quote!(BlockNumber);
+        let chain_extension: syn::Type = parse_quote!(ChainExtension);
+
+        let account_id = Self::generate_type_spec(&account_id);
+        let balance = Self::generate_type_spec(&balance);
+        let hash = Self::generate_type_spec(&hash);
+        let timestamp = Self::generate_type_spec(&timestamp);
+        let block_number = Self::generate_type_spec(&block_number);
+        let chain_extension = Self::generate_type_spec(&chain_extension);
+        quote_spanned!(span=>
+            ::ink::metadata::EnvironmentSpec::new()
+                .account_id(#account_id)
+                .balance(#balance)
+                .hash(#hash)
+                .timestamp(#timestamp)
+                .block_number(#block_number)
+                .chain_extension(#chain_extension)
+                .max_event_topics(MAX_EVENT_TOPICS)
+                .done()
+        )
     }
 }
 

--- a/crates/ink/src/lib.rs
+++ b/crates/ink/src/lib.rs
@@ -36,6 +36,8 @@ pub use ink_env as env;
 pub use ink_metadata as metadata;
 pub use ink_prelude as prelude;
 pub use ink_primitives as primitives;
+#[cfg(feature = "std")]
+pub use metadata::TypeInfo;
 
 pub mod storage {
     pub mod traits {

--- a/crates/ink/tests/return_type_metadata.rs
+++ b/crates/ink/tests/return_type_metadata.rs
@@ -66,21 +66,21 @@ mod tests {
     ) -> (&'a Type<PortableForm>, &'a Type<PortableForm>) {
         assert_eq!(
             "Result",
-            format!("{}", ty.path()),
+            format!("{}", ty.path),
             "Message return type should be a Result"
         );
-        match ty.type_def() {
+        match &ty.type_def {
             TypeDef::Variant(variant) => {
-                assert_eq!(2, variant.variants().len());
-                let ok_variant = &variant.variants()[0];
-                let ok_field = &ok_variant.fields()[0];
-                let ok_ty = resolve_type(metadata, ok_field.ty().id());
-                assert_eq!("Ok", ok_variant.name());
+                assert_eq!(2, variant.variants.len());
+                let ok_variant = &variant.variants[0];
+                let ok_field = &ok_variant.fields[0];
+                let ok_ty = resolve_type(metadata, ok_field.ty.id);
+                assert_eq!("Ok", ok_variant.name);
 
-                let err_variant = &variant.variants()[1];
-                let err_field = &err_variant.fields()[0];
-                let err_ty = resolve_type(metadata, err_field.ty().id());
-                assert_eq!("Err", err_variant.name());
+                let err_variant = &variant.variants[1];
+                let err_field = &err_variant.fields[0];
+                let err_ty = resolve_type(metadata, err_field.ty.id);
+                assert_eq!("Err", err_variant.name);
 
                 (ok_ty, err_ty)
             }
@@ -107,10 +107,10 @@ mod tests {
         assert_eq!("TraitDefinition::get_value", message.label());
 
         let type_spec = message.return_type().opt_type().unwrap();
-        let ty = resolve_type(&metadata, type_spec.ty().id());
+        let ty = resolve_type(&metadata, type_spec.ty().id);
         let (ok_ty, _) = extract_result(&metadata, ty);
 
-        assert_eq!(&TypeDef::Primitive(TypeDefPrimitive::U32), ok_ty.type_def());
+        assert_eq!(&TypeDef::Primitive(TypeDefPrimitive::U32), &ok_ty.type_def);
     }
 
     #[test]
@@ -125,19 +125,18 @@ mod tests {
             format!("{}", type_spec.display_name())
         );
 
-        let outer_result_ty = resolve_type(&metadata, type_spec.ty().id());
+        let outer_result_ty = resolve_type(&metadata, type_spec.ty().id);
         let (outer_ok_ty, outer_err_ty) = extract_result(&metadata, outer_result_ty);
         let (inner_ok_ty, _) = extract_result(&metadata, outer_ok_ty);
 
         assert_eq!(
-            format!("{}", outer_err_ty.path()),
+            format!("{}", outer_err_ty.path),
             "ink_primitives::LangError"
         );
 
         let unit_ty = TypeDef::Tuple(TypeDefTuple::new_portable(vec![]));
         assert_eq!(
-            &unit_ty,
-            inner_ok_ty.type_def(),
+            &unit_ty, &inner_ok_ty.type_def,
             "Ok variant should be a unit `()` type"
         );
     }

--- a/crates/ink/tests/return_type_metadata.rs
+++ b/crates/ink/tests/return_type_metadata.rs
@@ -110,7 +110,7 @@ mod tests {
         let ty = resolve_type(&metadata, type_spec.ty().id);
         let (ok_ty, _) = extract_result(&metadata, ty);
 
-        assert_eq!(&TypeDef::Primitive(TypeDefPrimitive::U32), &ok_ty.type_def);
+        assert_eq!(TypeDef::Primitive(TypeDefPrimitive::U32), ok_ty.type_def);
     }
 
     #[test]

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -53,6 +53,7 @@ pub use self::specs::{
 
 use impl_serde::serialize as serde_hex;
 
+pub use scale_info::TypeInfo;
 #[cfg(feature = "derive")]
 use scale_info::{
     form::PortableForm,

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -36,6 +36,8 @@ pub use self::specs::{
     ContractSpec,
     ContractSpecBuilder,
     DisplayName,
+    EnvironmentSpec,
+    EnvironmentSpecBuilder,
     EventParamSpec,
     EventParamSpecBuilder,
     EventSpec,

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -1340,7 +1340,7 @@ where
     }
 }
 
-/// Describes a contract message.
+/// Describes a contract environment.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(
     serialize = "F::Type: Serialize, F::String: Serialize",
@@ -1399,24 +1399,31 @@ where
     F: Form,
     TypeSpec<F>: Default,
 {
+    /// Returns the `AccountId` type of the environment.
     pub fn account_id(&self) -> &TypeSpec<F> {
         &self.account_id
     }
+    /// Returns the `Balance` type of the environment.
     pub fn balance(&self) -> &TypeSpec<F> {
         &self.balance
     }
+    /// Returns the `Hash` type of the environment.
     pub fn hash(&self) -> &TypeSpec<F> {
         &self.hash
     }
+    /// Returns the `Timestamp` type of the environment.
     pub fn timestamp(&self) -> &TypeSpec<F> {
         &self.timestamp
     }
+    /// Returns the `BlockNumber` type of the environment.
     pub fn block_number(&self) -> &TypeSpec<F> {
         &self.block_number
     }
+    /// Returns the `ChainExtension` type of the environment.
     pub fn chain_extension(&self) -> &TypeSpec<F> {
         &self.chain_extension
     }
+    /// Returns the `MAX_EVENT_TOPICS` value of the environment.
     pub fn max_event_topics(&self) -> usize {
         self.max_event_topics
     }
@@ -1466,6 +1473,7 @@ where
     TypeSpec<F>: Default,
     EnvironmentSpec<F>: Default,
 {
+    /// Sets the `AccountId` type of the environment.
     pub fn account_id(
         self,
         account_id: TypeSpec<F>,
@@ -1487,6 +1495,7 @@ where
     TypeSpec<F>: Default,
     EnvironmentSpec<F>: Default,
 {
+    /// Sets the `Balance` type of the environment.
     pub fn balance(
         self,
         balance: TypeSpec<F>,
@@ -1508,6 +1517,7 @@ where
     TypeSpec<F>: Default,
     EnvironmentSpec<F>: Default,
 {
+    /// Sets the `Hash` type of the environment.
     pub fn hash(
         self,
         hash: TypeSpec<F>,
@@ -1526,6 +1536,7 @@ where
     TypeSpec<F>: Default,
     EnvironmentSpec<F>: Default,
 {
+    /// Sets the `Timestamp` type of the environment.
     pub fn timestamp(
         self,
         timestamp: TypeSpec<F>,
@@ -1547,6 +1558,7 @@ where
     TypeSpec<F>: Default,
     EnvironmentSpec<F>: Default,
 {
+    /// Sets the `BlockNumber` type of the environment.
     pub fn block_number(
         self,
         block_number: TypeSpec<F>,
@@ -1568,6 +1580,7 @@ where
     TypeSpec<F>: Default,
     EnvironmentSpec<F>: Default,
 {
+    /// Sets the `ChainExtension` type of the environment.
     pub fn chain_extension(
         self,
         chain_extension: TypeSpec<F>,
@@ -1589,6 +1602,7 @@ where
     TypeSpec<F>: Default,
     EnvironmentSpec<F>: Default,
 {
+    /// Sets the `MAX_EVENT_TOPICS` value of the environment.
     pub fn max_event_topics(
         self,
         max_event_topics: usize,
@@ -1619,6 +1633,7 @@ where
     TypeSpec<F>: Default,
     EnvironmentSpec<F>: Default,
 {
+    /// Finished constructing the `EnvironmentSpec` object.
     pub fn done(self) -> EnvironmentSpec<F> {
         self.spec
     }

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -14,33 +14,15 @@
 
 #![allow(clippy::new_ret_no_self)]
 
-use crate::{
-    serde_hex,
-    utils::trim_extra_whitespace,
-};
+use crate::{serde_hex, utils::trim_extra_whitespace};
 #[cfg(not(feature = "std"))]
-use alloc::{
-    format,
-    vec,
-    vec::Vec,
-};
+use alloc::{format, vec, vec::Vec};
 use core::marker::PhantomData;
 use scale_info::{
-    form::{
-        Form,
-        MetaForm,
-        PortableForm,
-    },
-    meta_type,
-    IntoPortable,
-    Registry,
-    TypeInfo,
+    form::{Form, MetaForm, PortableForm},
+    meta_type, IntoPortable, Registry, TypeInfo,
 };
-use serde::{
-    de::DeserializeOwned,
-    Deserialize,
-    Serialize,
-};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// Describes a contract.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -516,6 +498,18 @@ mod state {
     pub struct IsPayable;
     /// Type state for the message return type.
     pub struct Returns;
+    /// Type state for the `AccountId` type of the environment.
+    pub struct AccountId;
+     /// Type state for the `Balance` type of the environment.
+    pub struct Balance;
+     /// Type state for the `Timestampt` type of the environment.
+    pub struct Timestamp;
+     /// Type state for the BlockNumber` type of the environment.
+    pub struct BlockNumber;
+     /// Type state for the `ChainExtension` type of the environment.
+    pub struct ChainExtension;
+     /// Type state for the max number of topics specified in the environment.
+    pub struct MaxEventTopics;
 }
 
 impl<F> MessageSpec<F>
@@ -1298,3 +1292,59 @@ where
         self.spec
     }
 }
+
+/// Describes a contract message.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "F::Type: Serialize, F::String: Serialize",
+    deserialize = "F::Type: DeserializeOwned, F::String: DeserializeOwned"
+))]
+#[serde(rename_all = "camelCase")]
+pub struct EnvironmentSpec<F: Form = MetaForm> {
+    account_id: TypeSpec<F>,
+    balance: TypeSpec<F>,
+    hash: TypeSpec<F>,
+    timestamp: TypeSpec<F>,
+    block_number: TypeSpec<F>,
+    chain_extension: TypeSpec<F>,
+    max_event_topics: usize,
+}
+
+impl<F> EnvironmentSpec<F>
+where
+    F: Form,
+{
+    pub fn account_id(&self) -> &TypeSpec<F> {
+        &self.account_id
+    }
+
+    pub fn balance(&self) -> &TypeSpec<F> {
+        &self.balance
+    }
+    pub fn hash(&self) -> &TypeSpec<F> {
+        &self.hash
+    }
+    pub fn timestamp(&self) -> &TypeSpec<F> {
+        &self.timestamp
+    }
+    pub fn block_number(&self) -> &TypeSpec<F> {
+        &self.block_number
+    }
+    pub fn chain_extension(&self) -> &TypeSpec<F> {
+        &self.chain_extension
+    }
+    pub fn max_event_topics(&self) -> usize {
+        self.max_event_topics
+    }
+}
+
+/// An environment specification builder.
+#[must_use]
+pub struct EnvironmentSpecBuilder<F>
+where
+    F: Form,
+{
+    spec: EnvironmentSpec<F>,
+}
+
+

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -122,7 +122,7 @@ where
     pub fn lang_error(&self) -> &TypeSpec<F> {
         &self.lang_error
     }
-    // Returns The environment types of the contract specification.
+    // Returns the environment types of the contract specification.
     pub fn environment(&self) -> &EnvironmentSpec<F> {
         &self.environment
     }

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -62,6 +62,7 @@ where
     docs: Vec<F::String>,
     /// The language specific error type.
     lang_error: TypeSpec<F>,
+    /// The environment types of the contract specification.
     environment: EnvironmentSpec<F>,
 }
 
@@ -121,7 +122,7 @@ where
     pub fn lang_error(&self) -> &TypeSpec<F> {
         &self.lang_error
     }
-
+    // Returns The environment types of the contract specification.
     pub fn environment(&self) -> &EnvironmentSpec<F> {
         &self.environment
     }
@@ -226,7 +227,7 @@ where
         }
     }
 
-    /// sets the environment types of the contract specification.
+    /// Sets the environment types of the contract specification.
     pub fn environment(self, environment: EnvironmentSpec<F>) -> Self {
         Self {
             spec: ContractSpec {

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -551,7 +551,7 @@ mod state {
     pub struct Hash;
     /// Type state for the `Timestamp` type of the environment.
     pub struct Timestamp;
-    /// Type state for the BlockNumber` type of the environment.
+    /// Type state for the `BlockNumber` type of the environment.
     pub struct BlockNumber;
     /// Type state for the `ChainExtension` type of the environment.
     pub struct ChainExtension;

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -55,6 +55,17 @@ fn spec_constructor_selector_must_serialize_to_hex() {
 
 #[test]
 fn spec_contract_json() {
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum NoChainExtension {}
+
+    type AccountId = ink_primitives::AccountId;
+    type Balance = u64;
+    type Hash = ink_primitives::Hash;
+    type Timestamp = u64;
+    type BlockNumber = u128;
+    type ChainExtension = NoChainExtension;
+    const MAX_EVENT_TOPICS: usize = 4;
+
     // given
     let contract: ContractSpec = ContractSpec::new()
         .constructors(vec![
@@ -117,6 +128,47 @@ fn spec_contract_json() {
                 ::core::convert::AsRef::as_ref,
             ),
         ))
+        .environment(
+            EnvironmentSpec::new()
+                .account_id(TypeSpec::with_name_segs::<AccountId, _>(
+                    ::core::iter::Iterator::map(
+                        ::core::iter::IntoIterator::into_iter(["AccountId"]),
+                        ::core::convert::AsRef::as_ref,
+                    ),
+                ))
+                .balance(TypeSpec::with_name_segs::<Balance, _>(
+                    ::core::iter::Iterator::map(
+                        ::core::iter::IntoIterator::into_iter(["Balance"]),
+                        ::core::convert::AsRef::as_ref,
+                    ),
+                ))
+                .hash(TypeSpec::with_name_segs::<Hash, _>(
+                    ::core::iter::Iterator::map(
+                        ::core::iter::IntoIterator::into_iter(["Hash"]),
+                        ::core::convert::AsRef::as_ref,
+                    ),
+                ))
+                .timestamp(TypeSpec::with_name_segs::<Timestamp, _>(
+                    ::core::iter::Iterator::map(
+                        ::core::iter::IntoIterator::into_iter(["Timestamp"]),
+                        ::core::convert::AsRef::as_ref,
+                    ),
+                ))
+                .block_number(TypeSpec::with_name_segs::<BlockNumber, _>(
+                    ::core::iter::Iterator::map(
+                        ::core::iter::IntoIterator::into_iter(["BlockNumber"]),
+                        ::core::convert::AsRef::as_ref,
+                    ),
+                ))
+                .chain_extension(TypeSpec::with_name_segs::<ChainExtension, _>(
+                    ::core::iter::Iterator::map(
+                        ::core::iter::IntoIterator::into_iter(["ChainExtension"]),
+                        ::core::convert::AsRef::as_ref,
+                    ),
+                ))
+                .max_event_topics(MAX_EVENT_TOPICS)
+                .done(),
+        )
         .done();
 
     let mut registry = Registry::new();
@@ -172,6 +224,45 @@ fn spec_contract_json() {
                 }
             ],
             "docs": [],
+            "environment":  {
+                "accountId":  {
+                    "displayName":  [
+                        "AccountId",
+                    ],
+                    "type": 4,
+                },
+                "balance":  {
+                    "displayName":  [
+                        "Balance",
+                    ],
+                    "type": 7,
+                },
+                "blockNumber":  {
+                    "displayName":  [
+                        "BlockNumber",
+                    ],
+                    "type": 9,
+                },
+                "chainExtension":  {
+                    "displayName":  [
+                        "ChainExtension",
+                    ],
+                    "type": 10,
+                },
+                "hash":  {
+                    "displayName":  [
+                        "Hash",
+                    ],
+                    "type": 8,
+                },
+                "maxEventTopics": 4,
+                "timestamp":  {
+                    "displayName":  [
+                        "Timestamp",
+                    ],
+                    "type": 7,
+                },
+            },
             "events": [],
             "lang_error": {
               "displayName": [


### PR DESCRIPTION
This PR closes #1695 by adding a field `environment` to `metadata.json` which contains the info about the types of the contract's environment.