### PR TITLE
Stabilize `call_runtime`

### DIFF
--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -72,9 +72,6 @@ std = [
     "blake2",
 ]
 
-# Enable direct call to a pallet dispatchable via `call_runtime()`.
-call-runtime = []
-
 # Enable contract debug messages via `debug_print!` and `debug_println!`.
 ink-debug = []
 

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -750,15 +750,9 @@ where
 /// - If the runtime doesn't allow for the contract unstable feature.
 /// - If the runtime doesn't allow for dispatching this call from a contract.
 ///
-/// # Note
-///
-/// The `call_runtime` host function is still part of `pallet-contracts`' unstable
-/// interface and thus can be changed at anytime.
-///
 /// # Panics
 ///
 /// Panics in the off-chain environment.
-#[cfg(feature = "call-runtime")]
 pub fn call_runtime<E, Call>(call: &Call) -> Result<()>
 where
     E: Environment,

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -515,7 +515,6 @@ pub trait TypedEnvBackend: EnvBackend {
     where
         E: Environment;
 
-    #[cfg(feature = "call-runtime")]
     fn call_runtime<E, Call>(&mut self, call: &Call) -> Result<()>
     where
         E: Environment,

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -543,7 +543,6 @@ impl TypedEnvBackend for EnvInstance {
         unimplemented!("off-chain environment does not support `own_code_hash`")
     }
 
-    #[cfg(feature = "call-runtime")]
     fn call_runtime<E, Call>(&mut self, _call: &Call) -> Result<()>
     where
         E: Environment,

--- a/crates/env/src/engine/on_chain/ext/riscv32.rs
+++ b/crates/env/src/engine/on_chain/ext/riscv32.rs
@@ -250,7 +250,6 @@ pub fn return_value(flags: ReturnFlags, return_value: &[u8]) -> ! {
     }
 }
 
-#[cfg(feature = "call-runtime")]
 pub fn call_runtime(call: &[u8]) -> Result {
     let ret_code = (Ptr32::from_slice(call), call.len() as u32)
         .using_encoded(|in_data| sys::call(FUNC_ID, Ptr32::from_slice(in_data)));

--- a/crates/env/src/engine/on_chain/ext/wasm32.rs
+++ b/crates/env/src/engine/on_chain/ext/wasm32.rs
@@ -153,7 +153,6 @@ mod sys {
             out_len_ptr: Ptr32Mut<u32>,
         ) -> ReturnCode;
 
-        #[cfg(feature = "call-runtime")]
         pub fn call_runtime(call_ptr: Ptr32<[u8]>, call_len: u32) -> ReturnCode;
     }
 
@@ -465,7 +464,6 @@ pub fn return_value(flags: ReturnFlags, return_value: &[u8]) -> ! {
     }
 }
 
-#[cfg(feature = "call-runtime")]
 pub fn call_runtime(call: &[u8]) -> Result {
     let ret_code =
         unsafe { sys::call_runtime(Ptr32::from_slice(call), call.len() as u32) };

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -578,7 +578,6 @@ impl TypedEnvBackend for EnvInstance {
         Ok(hash)
     }
 
-    #[cfg(feature = "call-runtime")]
     fn call_runtime<E, Call>(&mut self, call: &Call) -> Result<()>
     where
         E: Environment,

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -50,11 +50,6 @@ ink-debug = [
     "ink_env/ink-debug",
 ]
 
-# Enable direct call to a pallet dispatchable via `call_runtime()`.
-call-runtime = [
-    "ink_env/call-runtime",
-]
-
 show-codegen-docs = []
 
 # Disable the ink! provided global memory allocator.

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -1040,7 +1040,6 @@ where
         ink_env::set_code_hash2::<E>(code_hash)
     }
 
-    #[cfg(feature = "call-runtime")]
     pub fn call_runtime<Call: scale::Encode>(self, call: &Call) -> Result<()> {
         ink_env::call_runtime::<E, _>(call)
     }

--- a/integration-tests/call-runtime/Cargo.toml
+++ b/integration-tests/call-runtime/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../crates/ink", default-features = false, features = ["call-runtime"] }
+ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
@@ -37,7 +37,3 @@ std = [
 ]
 ink-as-dependency = []
 e2e-tests = []
-
-# Assumes that the node used in E2E testing allows using the `call-runtime` API, including triggering
-# `Balances::transfer` extrinsic.
-permissive-node = []

--- a/integration-tests/call-runtime/lib.rs
+++ b/integration-tests/call-runtime/lib.rs
@@ -82,8 +82,6 @@ mod runtime_call {
         ///
         /// Fails if:
         ///  - called in the off-chain environment
-        ///  - the chain doesn't allow `call-runtime` API (`UnsafeUnstableInterface` is
-        ///    turned off)
         ///  - the chain forbids contracts to call `Balances::transfer` (`CallFilter` is
         ///    too restrictive)
         ///  - after the transfer, `receiver` doesn't have at least existential deposit
@@ -133,7 +131,6 @@ mod runtime_call {
         const UNIT: Balance = 1_000_000_000_000;
 
         /// The contract will be given 1000 tokens during instantiation.
-        #[cfg(feature = "permissive-node")]
         const CONTRACT_BALANCE: Balance = 1_000 * UNIT;
 
         /// The receiver will get enough funds to have the required existential deposit.
@@ -145,14 +142,11 @@ mod runtime_call {
         /// empty account fails.
         ///
         /// Must not be zero, because such an operation would be a successful no-op.
-        #[cfg(feature = "permissive-node")]
         const INSUFFICIENT_TRANSFER_VALUE: Balance = 1;
 
         /// Positive case scenario:
-        ///  - `call_runtime` is enabled
         ///  - the call is valid
         ///  - the call execution succeeds
-        #[cfg(feature = "permissive-node")]
         #[ink_e2e::test]
         async fn transfer_with_call_runtime_works(
             mut client: Client<C, E>,
@@ -216,10 +210,8 @@ mod runtime_call {
         }
 
         /// Negative case scenario:
-        ///  - `call_runtime` is enabled
         ///  - the call is valid
         ///  - the call execution fails
-        #[cfg(feature = "permissive-node")]
         #[ink_e2e::test]
         async fn transfer_with_call_runtime_fails_when_execution_fails(
             mut client: Client<C, E>,
@@ -258,9 +250,7 @@ mod runtime_call {
         }
 
         /// Negative case scenario:
-        ///  - `call_runtime` is enabled
         ///  - the call is invalid
-        #[cfg(feature = "permissive-node")]
         #[ink_e2e::test]
         async fn transfer_with_call_runtime_fails_when_call_is_invalid(
             mut client: Client<C, E>,
@@ -289,37 +279,6 @@ mod runtime_call {
 
             // then
             assert!(call_res.is_err());
-
-            Ok(())
-        }
-
-        /// Negative case scenario:
-        ///  - `call_runtime` is disabled
-        #[cfg(not(feature = "permissive-node"))]
-        #[ink_e2e::test]
-        async fn call_runtime_fails_when_forbidden(
-            mut client: Client<C, E>,
-        ) -> E2EResult<()> {
-            // given
-            let constructor = RuntimeCallerRef::new();
-            let contract_acc_id = client
-                .instantiate("call-runtime", &ink_e2e::alice(), constructor, 0, None)
-                .await
-                .expect("instantiate failed")
-                .account_id;
-
-            let receiver: AccountId = default_accounts::<DefaultEnvironment>().bob;
-
-            let transfer_message = build_message::<RuntimeCallerRef>(contract_acc_id)
-                .call(|caller| caller.transfer_through_runtime(receiver, TRANSFER_VALUE));
-
-            // when
-            let call_res = client
-                .call(&ink_e2e::alice(), transfer_message, 0, None)
-                .await;
-
-            // then
-            assert!(matches!(call_res, Err(ink_e2e::Error::CallExtrinsic(_))));
 
             Ok(())
         }

--- a/integration-tests/custom-environment/Cargo.toml
+++ b/integration-tests/custom-environment/Cargo.toml
@@ -26,6 +26,3 @@ std = [
 ]
 ink-as-dependency = []
 e2e-tests = []
-
-# Assumes that the node used in E2E testing allows for at least 6 event topics.
-permissive-node = []

--- a/integration-tests/custom-environment/lib.rs
+++ b/integration-tests/custom-environment/lib.rs
@@ -96,7 +96,6 @@ mod runtime_call {
 
         type E2EResult<T> = Result<T, Box<dyn std::error::Error>>;
 
-        #[cfg(feature = "permissive-node")]
         #[ink_e2e::test(environment = crate::EnvironmentWithManyTopics)]
         async fn calling_custom_environment_works(
             mut client: Client<C, E>,
@@ -129,42 +128,6 @@ mod runtime_call {
 
             // then
             call_res.contains_event("Contracts", "ContractEmitted");
-
-            Ok(())
-        }
-
-        #[cfg(not(feature = "permissive-node"))]
-        #[ink_e2e::test(environment = crate::EnvironmentWithManyTopics)]
-        async fn calling_custom_environment_fails_if_incompatible_with_node(
-            mut client: Client<C, E>,
-        ) -> E2EResult<()> {
-            // given
-            let constructor = TopicsRef::new();
-            let contract_acc_id = client
-                .instantiate(
-                    "custom-environment",
-                    &ink_e2e::alice(),
-                    constructor,
-                    0,
-                    None,
-                )
-                .await
-                .expect("instantiate failed")
-                .account_id;
-
-            let message =
-                MessageBuilder::<crate::EnvironmentWithManyTopics, TopicsRef>::from_account_id(
-                    contract_acc_id,
-                )
-                    .call(|caller| caller.trigger());
-
-            // when
-            let call_res = client
-                .call_dry_run(&ink_e2e::alice(), &message, 0, None)
-                .await;
-
-            // then
-            assert!(call_res.is_err());
 
             Ok(())
         }


### PR DESCRIPTION
This host function is now [stabilized](https://github.com/paritytech/substrate/pull/13901) in the pallet. 

So we remove the feature flag and comments stating it's unstable.