### PR TITLE
Update subxt version

### DIFF
--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -29,14 +29,16 @@ tokio = { version = "1.18.2", features = ["rt-multi-thread"] }
 log = { version = "0.4" }
 env_logger = { version = "0.10" }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-subxt = "0.27.0"
+scale-decode = { version = "0.5.0", default-features = false, features = ["derive"] }
+scale-encode = { version = "0.1.0", default-features = false, features = ["derive"] }
+subxt = "0.28.0"
 
 # Substrate
-pallet-contracts-primitives = "18.0.0"
-sp-core = "16.0.0"
-sp-keyring = "18.0.0"
-sp-runtime = "18.0.0"
-sp-weights = "14.0.0"
+pallet-contracts-primitives = "23.0.0"
+sp-core = "20.0.0"
+sp-keyring = "23.0.0"
+sp-runtime = "23.0.0"
+sp-weights = "19.0.0"
 
 [dev-dependencies]
 # Required for the doctest of `MessageBuilder::call`

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -29,8 +29,6 @@ tokio = { version = "1.18.2", features = ["rt-multi-thread"] }
 log = { version = "0.4" }
 env_logger = { version = "0.10" }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-scale-decode = { version = "0.5.0", default-features = false, features = ["derive"] }
-scale-encode = { version = "0.1.0", default-features = false, features = ["derive"] }
 subxt = "0.28.0"
 
 # Substrate

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -43,10 +43,14 @@ use subxt::{
     blocks::ExtrinsicEvents,
     config::ExtrinsicParams,
     events::EventDetails,
-    ext::scale_value::{
-        Composite,
-        Value,
-        ValueDef,
+    ext::{
+        scale_decode,
+        scale_encode,
+        scale_value::{
+            Composite,
+            Value,
+            ValueDef,
+        },
     },
     tx::PairSigner,
 };
@@ -323,7 +327,8 @@ where
     scale_decode::DecodeAsType,
     scale_encode::EncodeAsType,
 )]
-#[decode_as_type(trait_bounds = "")]
+#[decode_as_type(trait_bounds = "", crate_path = "subxt::ext::scale_decode")]
+#[encode_as_type(crate_path = "subxt::ext::scale_encode")]
 struct ContractInstantiatedEvent<E: Environment> {
     /// Account id of the deployer.
     pub deployer: E::AccountId,
@@ -347,7 +352,8 @@ where
     scale_decode::DecodeAsType,
     scale_encode::EncodeAsType,
 )]
-#[decode_as_type(trait_bounds = "")]
+#[decode_as_type(trait_bounds = "", crate_path = "subxt::ext::scale_decode")]
+#[encode_as_type(crate_path = "subxt::ext::scale_encode")]
 struct CodeStoredEvent<E: Environment> {
     /// Hash under which the contract code was stored.
     pub code_hash: E::Hash,

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -31,6 +31,7 @@ use ink_env::Environment;
 use ink_primitives::MessageResult;
 use pallet_contracts_primitives::ExecReturnValue;
 use sp_core::Pair;
+#[cfg(feature = "std")]
 use std::{
     collections::BTreeMap,
     fmt::Debug,

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -322,7 +322,7 @@ where
     scale_decode::DecodeAsType,
     scale_encode::EncodeAsType,
 )]
-#[decode_as_type(trait_bounds = "E::AccountId: scale_decode::DecodeAsType")]
+#[decode_as_type(trait_bounds = "")]
 struct ContractInstantiatedEvent<E: Environment> {
     /// Account id of the deployer.
     pub deployer: E::AccountId,
@@ -346,7 +346,7 @@ where
     scale_decode::DecodeAsType,
     scale_encode::EncodeAsType,
 )]
-#[decode_as_type(trait_bounds = "E::Hash: scale_decode::DecodeAsType")]
+#[decode_as_type(trait_bounds = "")]
 struct CodeStoredEvent<E: Environment> {
     /// Hash under which the contract code was stored.
     pub code_hash: E::Hash,

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -309,6 +309,7 @@ where
             Error::CallDryRun(_) => f.write_str("CallDryRun"),
             Error::CallExtrinsic(_) => f.write_str("CallExtrinsic"),
             Error::Balance(msg) => write!(f, "Balance: {msg}"),
+            Error::Decoding(err) => write!(f, "Decoding: {err}"),
         }
     }
 }
@@ -742,7 +743,7 @@ where
         let tx_events = self
             .api
             .call(
-                sp_runtime::MultiAddress::Id(message.account_id().clone()),
+                subxt::utils::MultiAddress::Id(message.account_id().clone()),
                 value,
                 dry_run.exec_result.gas_required,
                 storage_deposit_limit,

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -572,7 +572,7 @@ where
             .api
             .instantiate_with_code(
                 value,
-                dry_run.gas_required,
+                dry_run.gas_required.into(),
                 storage_deposit_limit,
                 code,
                 data.clone(),
@@ -752,7 +752,7 @@ where
             .call(
                 subxt::utils::MultiAddress::Id(message.account_id().clone()),
                 value,
-                dry_run.exec_result.gas_required,
+                dry_run.exec_result.gas_required.into(),
                 storage_deposit_limit,
                 message.exec_input().to_vec(),
                 signer,

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -32,6 +32,7 @@ use sp_weights::Weight;
 use subxt::{
     blocks::ExtrinsicEvents,
     config::ExtrinsicParams,
+    ext::scale_encode,
     rpc_params,
     utils::MultiAddress,
     OnlineClient,
@@ -39,7 +40,7 @@ use subxt::{
 
 /// A raw call to `pallet-contracts`'s `instantiate_with_code`.
 #[derive(Debug, scale::Encode, scale::Decode, scale_encode::EncodeAsType)]
-#[encode_as_type(trait_bounds = "")]
+#[encode_as_type(trait_bounds = "", crate_path = "subxt::ext::scale_encode")]
 pub struct InstantiateWithCode<E: Environment> {
     #[codec(compact)]
     value: E::Balance,
@@ -52,7 +53,7 @@ pub struct InstantiateWithCode<E: Environment> {
 
 /// A raw call to `pallet-contracts`'s `call`.
 #[derive(Debug, scale::Decode, scale::Encode, scale_encode::EncodeAsType)]
-#[encode_as_type(trait_bounds = "")]
+#[encode_as_type(trait_bounds = "", crate_path = "subxt::ext::scale_encode")]
 pub struct Call<E: Environment> {
     dest: MultiAddress<E::AccountId, ()>,
     #[codec(compact)]
@@ -64,7 +65,7 @@ pub struct Call<E: Environment> {
 
 /// A raw call to `pallet-contracts`'s `call`.
 #[derive(Debug, scale::Decode, scale::Encode, scale_encode::EncodeAsType)]
-#[encode_as_type(trait_bounds = "")]
+#[encode_as_type(trait_bounds = "", crate_path = "subxt::ext::scale_encode")]
 pub struct Transfer<E: Environment, C: subxt::Config> {
     dest: subxt::utils::Static<C::Address>,
     #[codec(compact)]
@@ -82,6 +83,7 @@ pub struct Transfer<E: Environment, C: subxt::Config> {
     scale::Encode,
     scale_encode::EncodeAsType,
 )]
+#[encode_as_type(crate_path = "subxt::ext::scale_encode")]
 pub enum Determinism {
     /// The execution should be deterministic and hence no indeterministic instructions
     /// are allowed.
@@ -102,7 +104,7 @@ pub enum Determinism {
 
 /// A raw call to `pallet-contracts`'s `upload`.
 #[derive(Debug, scale::Encode, scale::Decode, scale_encode::EncodeAsType)]
-#[encode_as_type(trait_bounds = "")]
+#[encode_as_type(trait_bounds = "", crate_path = "subxt::ext::scale_encode")]
 pub struct UploadCode<E: Environment> {
     code: Vec<u8>,
     storage_deposit_limit: Option<E::Balance>,
@@ -195,14 +197,13 @@ where
         dest: C::AccountId,
         value: E::Balance,
     ) -> Result<(), subxt::Error> {
-        let call = subxt::tx::Payload::new_static(
+        let call = subxt::tx::Payload::new(
             "Balances",
             "transfer",
             Transfer::<E, C> {
                 dest: subxt::utils::Static(dest.into()),
                 value,
             },
-            Default::default(),
         )
         .unvalidated();
 
@@ -304,18 +305,17 @@ where
         salt: Vec<u8>,
         signer: &Signer<C>,
     ) -> ExtrinsicEvents<C> {
-        let call = subxt::tx::Payload::new_static(
+        let call = subxt::tx::Payload::new(
             "Contracts",
             "instantiate_with_code",
             InstantiateWithCode::<E> {
                 value,
-                gas_limit: subxt::utils::Static(gas_limit),
+                gas_limit: gas_limit.into(),
                 storage_deposit_limit,
                 code,
                 data,
                 salt,
             },
-            Default::default(),
         )
         .unvalidated();
 
@@ -359,7 +359,7 @@ where
         code: Vec<u8>,
         storage_deposit_limit: Option<E::Balance>,
     ) -> ExtrinsicEvents<C> {
-        let call = subxt::tx::Payload::new_static(
+        let call = subxt::tx::Payload::new(
             "Contracts",
             "upload_code",
             UploadCode::<E> {
@@ -367,7 +367,6 @@ where
                 storage_deposit_limit,
                 determinism: Determinism::Deterministic,
             },
-            Default::default(),
         )
         .unvalidated();
 
@@ -417,17 +416,16 @@ where
         data: Vec<u8>,
         signer: &Signer<C>,
     ) -> ExtrinsicEvents<C> {
-        let call = subxt::tx::Payload::new_static(
+        let call = subxt::tx::Payload::new(
             "Contracts",
             "call",
             Call::<E> {
                 dest: contract,
                 value,
-                gas_limit: subxt::utils::Static(gas_limit),
+                gas_limit: gas_limit.into(),
                 storage_deposit_limit,
                 data,
             },
-            Default::default(),
         )
         .unvalidated();
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -23,6 +23,8 @@ ink_prelude = { version = "4.1.0", path = "../prelude", default-features = false
 ink_primitives = { version = "4.1.0", path = "../primitives", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
+scale-decode = { version = "0.5.0", default-features = false }
+scale-encode = { version = "0.1.0", default-features = false }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 num-traits = { version = "0.2", default-features = false, features = ["i128"] }
 cfg-if = "1.0"

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -23,8 +23,6 @@ ink_prelude = { version = "4.1.0", path = "../prelude", default-features = false
 ink_primitives = { version = "4.1.0", path = "../primitives", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-scale-decode = { version = "0.5.0", default-features = false }
-scale-encode = { version = "0.1.0", default-features = false }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 num-traits = { version = "0.2", default-features = false, features = ["i128"] }
 cfg-if = "1.0"
@@ -50,6 +48,8 @@ secp256k1 = { version = "0.27.0", features = ["recovery", "global-context"], opt
 #
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside the off-chain environment!
+scale-decode = { version = "0.5.0", default-features = false, optional = true }
+scale-encode = { version = "0.1.0", default-features = false, optional = true }
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
@@ -65,6 +65,8 @@ std = [
     "ink_storage_traits/std",
     "ink_engine/std",
     "scale/std",
+    "scale-decode",
+    "scale-encode",
     "scale-info/std",
     "secp256k1",
     "num-traits/std",

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -106,6 +106,15 @@ pub trait AccountIdGuard {}
 /// used in the [`DefaultEnvironment`].
 impl AccountIdGuard for AccountId {}
 
+#[cfg(feature = "std")]
+pub trait CodecAsType: scale_decode::DecodeAsType + scale_encode::EncodeAsType {}
+#[cfg(feature = "std")]
+impl<T: scale_decode::DecodeAsType + scale_encode::EncodeAsType> CodecAsType for T {}
+#[cfg(not(feature = "std"))]
+pub trait CodecAsType {}
+#[cfg(not(feature = "std"))]
+impl<T> CodecAsType for T {}
+
 /// The environmental types usable by contracts defined with ink!.
 pub trait Environment {
     /// The maximum number of supported event topics provided by the runtime.
@@ -117,8 +126,7 @@ pub trait Environment {
     /// The account id type.
     type AccountId: 'static
         + scale::Codec
-        + scale_decode::DecodeAsType
-        + scale_encode::EncodeAsType
+        + CodecAsType
         + Clone
         + PartialEq
         + Eq
@@ -129,8 +137,7 @@ pub trait Environment {
     /// The type of balances.
     type Balance: 'static
         + scale::Codec
-        + scale_decode::DecodeAsType
-        + scale_encode::EncodeAsType
+        + CodecAsType
         + Copy
         + Clone
         + PartialEq
@@ -141,8 +148,7 @@ pub trait Environment {
     /// The type of hash.
     type Hash: 'static
         + scale::Codec
-        + scale_decode::DecodeAsType
-        + scale_encode::EncodeAsType
+        + CodecAsType
         + Copy
         + Clone
         + Clear
@@ -155,8 +161,7 @@ pub trait Environment {
     /// The type of a timestamp.
     type Timestamp: 'static
         + scale::Codec
-        + scale_decode::DecodeAsType
-        + scale_encode::EncodeAsType
+        + CodecAsType
         + Copy
         + Clone
         + PartialEq
@@ -167,8 +172,7 @@ pub trait Environment {
     /// The type of block number.
     type BlockNumber: 'static
         + scale::Codec
-        + scale_decode::DecodeAsType
-        + scale_encode::EncodeAsType
+        + CodecAsType
         + Copy
         + Clone
         + PartialEq

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -106,14 +106,15 @@ pub trait AccountIdGuard {}
 /// used in the [`DefaultEnvironment`].
 impl AccountIdGuard for AccountId {}
 
-#[cfg(feature = "std")]
-pub trait CodecAsType: scale_decode::DecodeAsType + scale_encode::EncodeAsType {}
-#[cfg(feature = "std")]
-impl<T: scale_decode::DecodeAsType + scale_encode::EncodeAsType> CodecAsType for T {}
-#[cfg(not(feature = "std"))]
-pub trait CodecAsType {}
-#[cfg(not(feature = "std"))]
-impl<T> CodecAsType for T {}
+cfg_if::cfg_if! {
+    if #[cfg(feature = "std")] {
+        pub trait CodecAsType: scale_decode::DecodeAsType + scale_encode::EncodeAsType {}
+        impl<T: scale_decode::DecodeAsType + scale_encode::EncodeAsType> CodecAsType for T {}
+    } else {
+        pub trait CodecAsType {}
+        impl<T> CodecAsType for T {}
+    }
+}
 
 /// The environmental types usable by contracts defined with ink!.
 pub trait Environment {

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -117,6 +117,8 @@ pub trait Environment {
     /// The account id type.
     type AccountId: 'static
         + scale::Codec
+        + scale_decode::DecodeAsType
+        + scale_encode::EncodeAsType
         + Clone
         + PartialEq
         + Eq
@@ -127,6 +129,8 @@ pub trait Environment {
     /// The type of balances.
     type Balance: 'static
         + scale::Codec
+        + scale_decode::DecodeAsType
+        + scale_encode::EncodeAsType
         + Copy
         + Clone
         + PartialEq
@@ -137,6 +141,8 @@ pub trait Environment {
     /// The type of hash.
     type Hash: 'static
         + scale::Codec
+        + scale_decode::DecodeAsType
+        + scale_encode::EncodeAsType
         + Copy
         + Clone
         + Clear
@@ -149,6 +155,8 @@ pub trait Environment {
     /// The type of a timestamp.
     type Timestamp: 'static
         + scale::Codec
+        + scale_decode::DecodeAsType
+        + scale_encode::EncodeAsType
         + Copy
         + Clone
         + PartialEq
@@ -159,6 +167,8 @@ pub trait Environment {
     /// The type of block number.
     type BlockNumber: 'static
         + scale::Codec
+        + scale_decode::DecodeAsType
+        + scale_encode::EncodeAsType
         + Copy
         + Clone
         + PartialEq

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -18,8 +18,8 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 ink_prelude = { version = "4.1.0", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-scale-decode = { version = "0.5.0", default-features = false, features = ["derive"] }
-scale-encode = { version = "0.1.0", default-features = false, features = ["derive"] }
+scale-decode = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
+scale-encode = { version = "0.1.0", default-features = false, features = ["derive"], optional = true }
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", features = ["const_xxh32"] }
 
@@ -28,5 +28,7 @@ default = ["std"]
 std = [
     "ink_prelude/std",
     "scale/std",
+    "scale-decode",
+    "scale-encode",
     "scale-info/std",
 ]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -18,6 +18,8 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 ink_prelude = { version = "4.1.0", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
+scale-decode = { version = "0.5.0", default-features = false, features = ["derive"] }
+scale-encode = { version = "0.1.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", features = ["const_xxh32"] }
 

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -24,6 +24,7 @@ use scale_encode::EncodeAsType;
 use scale_info::TypeInfo;
 
 #[allow(clippy::all)]
+#[allow(unused)]
 use std;
 
 /// The default environment `AccountId` type.

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -18,14 +18,12 @@ use scale::{
     Decode,
     Encode,
 };
-use scale_decode::DecodeAsType;
-use scale_encode::EncodeAsType;
 #[cfg(feature = "std")]
-use scale_info::TypeInfo;
-
-#[allow(clippy::all)]
-#[allow(unused)]
-use std;
+use {
+    scale_decode::DecodeAsType,
+    scale_encode::EncodeAsType,
+    scale_info::TypeInfo,
+};
 
 /// The default environment `AccountId` type.
 ///
@@ -34,21 +32,9 @@ use std;
 /// This is a mirror of the `AccountId` type used in the default configuration
 /// of PALLET contracts.
 #[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Decode,
-    Encode,
-    DecodeAsType,
-    EncodeAsType,
-    From,
+    Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Decode, Encode, From,
 )]
-#[cfg_attr(feature = "std", derive(TypeInfo))]
+#[cfg_attr(feature = "std", derive(TypeInfo, DecodeAsType, EncodeAsType))]
 pub struct AccountId([u8; 32]);
 
 impl AsRef<[u8; 32]> for AccountId {
@@ -105,12 +91,10 @@ impl<'a> TryFrom<&'a [u8]> for AccountId {
     Hash,
     Decode,
     Encode,
-    DecodeAsType,
-    EncodeAsType,
     From,
     Default,
 )]
-#[cfg_attr(feature = "std", derive(TypeInfo))]
+#[cfg_attr(feature = "std", derive(TypeInfo, DecodeAsType, EncodeAsType))]
 pub struct Hash([u8; 32]);
 
 impl<'a> TryFrom<&'a [u8]> for Hash {

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -15,6 +15,7 @@
 use core::array::TryFromSliceError;
 use derive_more::From;
 use scale::{
+    alloc::vec::Vec,
     Decode,
     Encode,
 };

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -15,7 +15,6 @@
 use core::array::TryFromSliceError;
 use derive_more::From;
 use scale::{
-    alloc::vec::Vec,
     Decode,
     Encode,
 };
@@ -23,6 +22,9 @@ use scale_decode::DecodeAsType;
 use scale_encode::EncodeAsType;
 #[cfg(feature = "std")]
 use scale_info::TypeInfo;
+
+#[allow(unused_imports)]
+use std;
 
 /// The default environment `AccountId` type.
 ///

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -23,7 +23,7 @@ use scale_encode::EncodeAsType;
 #[cfg(feature = "std")]
 use scale_info::TypeInfo;
 
-#[allow(unused_imports)]
+#[allow(clippy::all)]
 use std;
 
 /// The default environment `AccountId` type.

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -18,6 +18,8 @@ use scale::{
     Decode,
     Encode,
 };
+use scale_decode::DecodeAsType;
+use scale_encode::EncodeAsType;
 #[cfg(feature = "std")]
 use scale_info::TypeInfo;
 
@@ -28,7 +30,19 @@ use scale_info::TypeInfo;
 /// This is a mirror of the `AccountId` type used in the default configuration
 /// of PALLET contracts.
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Encode, Decode, From,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Decode,
+    Encode,
+    DecodeAsType,
+    EncodeAsType,
+    From,
 )]
 #[cfg_attr(feature = "std", derive(TypeInfo))]
 pub struct AccountId([u8; 32]);
@@ -85,8 +99,10 @@ impl<'a> TryFrom<&'a [u8]> for AccountId {
     Ord,
     PartialOrd,
     Hash,
-    Encode,
     Decode,
+    Encode,
+    DecodeAsType,
+    EncodeAsType,
     From,
     Default,
 )]

--- a/integration-tests/call-runtime/Cargo.toml
+++ b/integration-tests/call-runtime/Cargo.toml
@@ -17,8 +17,8 @@ scale-info = { version = "2.5", default-features = false, features = ["derive"],
 # (especially for global allocator).
 #
 # See also: https://substrate.stackexchange.com/questions/4733/error-when-compiling-a-contract-using-the-xcm-chain-extension.
-sp-io = { version = "18.0.0", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
-sp-runtime = { version = "19.0.0", default-features = false }
+sp-io = { version = "22.0.0", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-runtime = { version = "23.0.0", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -13,7 +13,7 @@ scale-info = { version = "2.5", default-features = false, features = ["derive"],
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }
-subxt = { version = "0.27.1", default-features = false }
+subxt = { version = "0.28.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -21,8 +21,10 @@ pub mod e2e_call_runtime {
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
         use super::*;
-        use ink_e2e::build_message;
-        use subxt::dynamic::Value;
+        use ink_e2e::{
+            build_message,
+            subxt::dynamic::Value,
+        };
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 


### PR DESCRIPTION
We bump `subxt` to `0.28.0` version. Main changes are due to new `scale_en/decode` crates used by `subxt` (check https://github.com/paritytech/subxt/pull/842).