### PR TITLE
Added PR report cron job

### DIFF
--- a/.github/scripts/combine-pr.py
+++ b/.github/scripts/combine-pr.py
@@ -1,0 +1,59 @@
+import uuid
+import json
+import glob
+import sys
+import os
+
+
+def set_output(name, value):
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+        print(f'{name}={value}', file=fh)
+
+
+def set_multiline_output(name, value):
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+        delimiter = uuid.uuid1()
+        print(f'{name}<<{delimiter}', file=fh)
+        print(value, file=fh)
+        print(delimiter, file=fh)
+
+
+if len(sys.argv) > 1:
+    limit = int(sys.argv[1])
+else:
+    limit = 999
+
+result = []
+for f in glob.glob("outputs/*.json"):
+    with open(f, "r") as infile:
+        result += json.load(infile)
+
+sorted_data = sorted(result, key=lambda x: x['daysStale'])
+sorted_data.reverse()
+
+count = len(sorted_data)
+
+set_output("COUNT", count)
+
+if count < 1:
+    set_output("MESSAGE", "")
+    exit()
+
+sliced_list = sorted_data[:limit]
+
+formated_list = []
+for i, data in enumerate(sliced_list):
+    message = str(
+        f' {i + 1}. [{data["title"]}]({data["url"]}) | {data["daysStale"]} days with no reviews')
+    formated_list.append(message)
+
+with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as fh:
+    print(f'## There are {count} stale PRs', file=fh)
+    for message in formated_list:
+        print(f'{message}', file=fh)
+
+message = "\n".join(formated_list)
+
+set_multiline_output("MESSAGE", message)
+
+set_output("data", json.dumps(formated_list))

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -10,6 +10,7 @@ jobs:
   fetch-issues:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 3
       matrix:
         # List of repositories to fetch the issues
         repo:

--- a/.github/workflows/pr-notifier.yml
+++ b/.github/workflows/pr-notifier.yml
@@ -1,0 +1,102 @@
+name: Find stale PRs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * 4"
+
+jobs:
+  fetch-issues:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 3
+      matrix:
+        # List of repositories to fetch the issues
+        repo:
+          - ink
+          - cargo-contract
+          - substrate-contracts-node
+          - contracts-ui
+          - ink-docs
+          - smart-bench
+          - ink-waterfall
+          - ink-playground
+          - nft-marketplace-demo
+          - pallet-contracts-xcm
+          - link
+          - ink-examples
+          - useink
+          - awesome-ink
+          - squink-splash-beginner
+          - squink-splash-advanced
+          - ink-workshop
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.ISSUE_TRACKER_APP_ID }}
+          private_key: ${{ secrets.ISSUE_TRACKER_APP_KEY }}
+      - run: mkdir outputs
+      - name: Fetch PRs from ${{ matrix.repo }}
+        id: pr
+        uses: paritytech/stale-pr-finder@main
+        with:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          repo: ${{ matrix.repo }}
+          # only fetch PRs that don't have any reviews
+          noReviews: true
+          # from today onwards. Increase this number to set how much time without interaction must pass for the issue to be analyzed
+          days-stale: 0
+          fileOutput: outputs/${{ matrix.repo }}.json
+      - uses: actions/upload-artifact@v3
+        with:
+          name: outputs
+          path: outputs/*.json
+
+  message:
+    runs-on: ubuntu-latest
+    needs: fetch-issues
+    steps:
+      - uses: actions/checkout@v3
+      - name: Load outputs
+        uses: actions/download-artifact@v3
+        with:
+          name: outputs
+          path: outputs
+      - name: Run combine script
+        id: pr
+        run: python ./.github/scripts/combine-pr.py $LIMIT
+        shell: bash
+        env:
+          # How many PRs to show in the message
+          LIMIT: 8
+      - name: send message
+        if: ${{ steps.pr.outputs.MESSAGE != '' }}
+        uses: s3krit/matrix-message-action@v0.0.3
+        with:
+          room_id: "!EBuECvRavzBxijipBi:parity.io"
+          access_token: ${{ secrets.STALE_MATRIX_ACCESS_TOKEN }}
+          # Remember to keep at least one empty line between paragraphs
+          message: |
+            ## Good morning, team 🥐!
+            This weekly digest contains the longest unreviewed pull requests from repositories which the Smart Contracts ☂️ owns ([list](https://www.notion.so/paritytechnologies/What-belongs-to-our-umbrella-b9a80b72fedc47d6b35224a15bdec64c)).
+
+            ${{ steps.pr.outputs.MESSAGE }}
+
+            Unfortunately there are more stale PRs. The above list is limited to 8 entries. Find all the stale PRs [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          server: "m.parity.io"
+      - name: send message for no PRs found
+        if: ${{ steps.pr.outputs.MESSAGE == '' }}
+        uses: s3krit/matrix-message-action@v0.0.3
+        with:
+          room_id: "!EBuECvRavzBxijipBi:parity.io"
+          access_token: ${{ secrets.STALE_MATRIX_ACCESS_TOKEN }}
+          # Remember to keep at least one empty line between paragraphs
+          message: |
+            ## Good morning, team 🥐!
+
+            We have no Pull Requests waiting for reviews.
+
+            **Good job everyone!**
+          server: "m.parity.io"


### PR DESCRIPTION
This PR opens a cron job that uses the [paritytech/stale-pr-finder](https://github.com/paritytech/stale-pr-finder) action.

It will run every Tuesday at 7AM UTC (9 AM Germany)

You can also manually run this action by going to https://github.com/paritytech/ink/actions/workflows/pr-notifier.yml

It will fetch PRs from the repositories:
- ink
- cargo-contract
- substrate-contracts-node
- contracts-ui
- ink-docs
- smart-bench
- ink-waterfall
- ink-playground
- nft-marketplace-demo
- pallet-contracts-xcm
- link
- ink-examples

It will only fetch PRs that don't have any reviews (comments don't count).

It will organize them by oldest, and fetch only the first 8 issues and will format them with the format:
`- [(title)]((url)) | (daysStale) days with no review`

In the case that there a no PRs found, it will post the message:
> We have no Pull Requests waiting for reviews.
>
> **Good job everyone!**

I have added a lot of comments to the `yml` file so it is easy to configure if you need to add an extra repository

---

I also created a python script to combine and produce the output because I was having problems with `jq`.

First of all, the `jq` command was becoming way to long and impossible to understand, and second, the length of the array is so long that GitHub fails to use it as a variable, so by having a file that handles all of it in it, we overcome that issue.

And I belive it's more readable than a `jq` bash command:
```bash
jq -r '. | sort_by(.daysStale) | reverse[:8]| to_entries | .[] | "\(.key). [\(.value.title)](\(.value.url)) | \(.value.daysStale) days with no reviews"'
```

So, everything the python script does is:
1. combines all of the jsons in `outputs/*.json`
2. orders all the outputs based on the parameter `daysStale`
3. reverses the list
4. counts the amount of elements and generates an output
5. limits the list to the given number (15 in this PR)
6. formats the strings with the given template (the for loop above)
7. pushes the result as a summary and an output for another github action to use

---

I also limited stale-issues-finder to work with a top of 3 parallel jobs.

This will help with the case where too many jobs are running at the same time and timing out the GitHub API