### PR TITLE
`[ink_e2e]` replace `log` with `tracing`

### DIFF
--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -26,8 +26,8 @@ jsonrpsee = { version = "0.18.0", features = ["ws-client"] }
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.81" }
 tokio = { version = "1.18.2", features = ["rt-multi-thread"] }
-log = { version = "0.4" }
-env_logger = { version = "0.10" }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 subxt = "0.28.0"
 

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -23,8 +23,7 @@ ink_ir = { version = "4.2.0", path = "../../ink/ir" }
 cargo_metadata = "0.15.3"
 contract-build = "2.0.2"
 derive_more = "0.99.17"
-env_logger = "0.10.0"
-log = "0.4.17"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 serde_json = "1.0.89"
 syn = "2"
 proc-macro2 = "1"

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -98,7 +98,7 @@ impl InkE2ETest {
         if already_built_contracts.is_empty() {
             // Build all of them for the first time and initialize everything
             BUILD_ONCE.call_once(|| {
-                env_logger::init();
+                tracing_subscriber::fmt::init();
                 for manifest_path in contracts_to_build_and_import {
                     let dest_wasm = build_contract(&manifest_path);
                     let _ = already_built_contracts.insert(manifest_path, dest_wasm);
@@ -157,7 +157,7 @@ impl InkE2ETest {
                 log_info("setting up e2e test");
 
                 ::ink_e2e::INIT.call_once(|| {
-                    ::ink_e2e::env_logger::init();
+                    ::ink_e2e::tracing_subscriber::fmt::init();
                 });
 
                 log_info("creating new client");

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -39,7 +39,6 @@ pub use client::{
     UploadResult,
 };
 pub use default_accounts::*;
-pub use env_logger;
 pub use ink_e2e_macro::test;
 pub use node_proc::{
     TestNodeProcess,
@@ -52,6 +51,7 @@ pub use subxt::{
     tx::PairSigner,
 };
 pub use tokio;
+pub use tracing_subscriber;
 
 use pallet_contracts_primitives::{
     CodeUploadResult,
@@ -117,12 +117,12 @@ pub fn log_prefix() -> String {
 
 /// Writes `msg` to stdout.
 pub fn log_info(msg: &str) {
-    log::info!("[{}] {}", log_prefix(), msg);
+    tracing::info!("[{}] {}", log_prefix(), msg);
 }
 
 /// Writes `msg` to stderr.
 pub fn log_error(msg: &str) {
-    log::error!("[{}] {}", log_prefix(), msg);
+    tracing::error!("[{}] {}", log_prefix(), msg);
 }
 
 /// Get an ink! [`ink_primitives::AccountId`] for a given keyring account.

--- a/crates/e2e/src/node_proc.rs
+++ b/crates/e2e/src/node_proc.rs
@@ -60,10 +60,10 @@ where
 
     /// Attempt to kill the running substrate process.
     pub fn kill(&mut self) -> Result<(), String> {
-        log::info!("Killing node process {}", self.proc.id());
+        tracing::info!("Killing node process {}", self.proc.id());
         if let Err(err) = self.proc.kill() {
             let err = format!("Error killing node process {}: {}", self.proc.id(), err);
-            log::error!("{}", err);
+            tracing::error!("{}", err);
             return Err(err)
         }
         Ok(())
@@ -150,7 +150,7 @@ where
             }
             Err(err) => {
                 let err = format!("Failed to connect to node rpc at {ws_url}: {err}");
-                log::error!("{}", err);
+                tracing::error!("{}", err);
                 proc.kill().map_err(|e| {
                     format!("Error killing substrate process '{}': {}", proc.id(), e)
                 })?;

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -34,9 +34,6 @@ impl-serde = "0.4.0"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 serde_json = "1.0.81"
 
-log = "0.4"
-env_logger = "0.10"
-
 [features]
 default = ["std"]
 std = [


### PR DESCRIPTION
Align with usage of `tracing` in `cargo-contract`. This will allow us to see output of `cargo-contract` logs when running `RUST_LOG=debug cargo test --features e2e-tests`, which would be useful in troubleshooting issues such as https://github.com/paritytech/ink-examples/issues/20