### PR TITLE
`call-runtime`: use `subxt`

### DIFF
--- a/integration-tests/call-runtime/Cargo.toml
+++ b/integration-tests/call-runtime/Cargo.toml
@@ -11,6 +11,9 @@ ink = { path = "../../crates/ink", default-features = false, features = ["call-r
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 
+subxt-macro = { git = "https://github.com/pmikolajczyk41/subxt", branch = "pmikolajczyk41/no-std-imports" }
+primitive-types = { version = "0.12.1", default-features = false }
+
 # Substrate
 #
 # We need to explicitly turn off some of the `sp-io` features, to avoid conflicts

--- a/integration-tests/call-runtime/README.md
+++ b/integration-tests/call-runtime/README.md
@@ -13,7 +13,6 @@ To integrate this example into Substrate you need to adjust pallet contracts con
     …
     // `Everything` or anything that will allow for the `Balances::transfer` extrinsic.
     type CallFilter = frame_support::traits::Everything; 
-    type UnsafeUnstableInterface = ConstBool<true>;
     …
   }
   ```


### PR DESCRIPTION
We tried harnessing `subxt` for the 'call_runtime' feature. Although we can remove the need of manually crafting call object, there are still some issues due to the subxt's design.

1. `subxt` macro assumes that `subxt` crate is available. This is fine for all standard usecases, where one uses full subxt power. However, in our case, we need only runtime types module, without any other `subxt` features. Especially, because full `subxt` is far from being no-std compatible and therefore it cannot be used in smart contracts context. For this, we can depend solely on `subxt_macro` crate, which is no-std compatible and provides only the required macro. Unfortunately, we still have to provide at least a dummy `subxt` module for primitive types and reexports.

2. Macro configuration is not trivial. Also, it still lacks possibility of picking only a subset of pallets.

3. Passing runtime metadata to the macro has to be done with a running node (`runtime_metadata_url`). Using `runtime_metadata_path` fails during contract building phase with `cargo contract` (`Failed IO for /tmp/cargo-contract_mB5KYC/metadata.scale, make sure that you are providing the correct file path for metadata: No such file or directory (os error 2)`).

4. `subxt` uses `std` library for `boxed`, `vec`, `string` etc. This fails for no-std context, where SC is built. Unfortunately, we find it very hard to remove all such dependencies (e.g. by pointing to the `alloc` crate). For now, we prepared a temporary version of `subxt` that works well in no-std context, but fails in a standard one.

5. `RuntimeCall` enum is not self-contained. It depends on a group of pallet-specific type families. This is not a problem for a standard usecase, where one uses full `subxt` power. However, in our case, this blocks putting `RuntimeCall` into a single place like `Environment` trait, so that any contract can conveniently build a call object. Instead, every contract has to have an access to the whole module with runtime types.

This is rather a call for discussion / current best effort for https://github.com/paritytech/ink/issues/1675.

---

Ad 4.
Problematic imports:
 - `::std::borrow`: easily convertible to `::core::borrow`, no further issues here
 - `::std::collections`: easily convertible to `::core::alloc::collections`, no further issues here
 - `::std::boxed`, `::std::vec`: could be taken from `sp_core::sp_std::` (available only under specific `subxt` feature) or somewhere where `alloc` is always available
 - `::std::string`: `alloc` needed in both std and no-std contexts; notice, that this cannot be feature-gated, because the crate, where the macro is used might not have `std` feature but not be no-std

---

cc: @athei @cmichi @jsdw