### PR TITLE
:t-rex: fix e2e test, account for contract initial free balance

### DIFF
--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -70,7 +70,10 @@ pub mod e2e_call_runtime {
                 .call_dry_run(&ink_e2e::alice(), &get_balance, 0, None)
                 .await;
 
-            assert_eq!(get_balance_res.return_value(), pre_balance + transfer_amount);
+            assert_eq!(
+                get_balance_res.return_value(),
+                pre_balance + transfer_amount
+            );
 
             Ok(())
         }


### PR DESCRIPTION
Since https://github.com/paritytech/substrate/pull/13369, contracts now have an initial free balance which was causing this test to fail.