### PR TITLE
`[ink_e2e]` update `Determinism` enum to match Substrate definition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -365,7 +365,7 @@ codecov:
 
 #### stage:                        examples
 
-.examples-test:
+examples-test:
   stage:                           examples
   <<:                              *docker-env
   <<:                              *test-refs

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -124,10 +124,11 @@ pub struct Transfer<E: Environment, C: subxt::Config> {
 )]
 #[encode_as_type(crate_path = "subxt::ext::scale_encode")]
 pub enum Determinism {
-    /// The execution should be deterministic and hence no indeterministic instructions are
-    /// allowed.
+    /// The execution should be deterministic and hence no indeterministic instructions
+    /// are allowed.
     ///
-    /// Dispatchables always use this mode in order to make on-chain execution deterministic.
+    /// Dispatchables always use this mode in order to make on-chain execution
+    /// deterministic.
     Enforced,
     /// Allow calling or uploading an indeterministic code.
     ///

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -124,12 +124,11 @@ pub struct Transfer<E: Environment, C: subxt::Config> {
 )]
 #[encode_as_type(crate_path = "subxt::ext::scale_encode")]
 pub enum Determinism {
-    /// The execution should be deterministic and hence no indeterministic instructions
-    /// are allowed.
+    /// The execution should be deterministic and hence no indeterministic instructions are
+    /// allowed.
     ///
-    /// Dispatchables always use this mode in order to make on-chain execution
-    /// deterministic.
-    Deterministic,
+    /// Dispatchables always use this mode in order to make on-chain execution deterministic.
+    Enforced,
     /// Allow calling or uploading an indeterministic code.
     ///
     /// This is only possible when calling into `pallet-contracts` directly via
@@ -138,7 +137,7 @@ pub enum Determinism {
     /// # Note
     ///
     /// **Never** use this mode for on-chain execution.
-    AllowIndeterminism,
+    Relaxed,
 }
 
 /// A raw call to `pallet-contracts`'s `upload`.
@@ -372,7 +371,7 @@ where
             origin: subxt::tx::Signer::account_id(signer).clone(),
             code,
             storage_deposit_limit,
-            determinism: Determinism::Deterministic,
+            determinism: Determinism::Enforced,
         };
         let func = "ContractsApi_upload_code";
         let params = rpc_params![func, Bytes(scale::Encode::encode(&call_request))];
@@ -404,7 +403,7 @@ where
             UploadCode::<E> {
                 code,
                 storage_deposit_limit,
-                determinism: Determinism::Deterministic,
+                determinism: Determinism::Enforced,
             },
         )
         .unvalidated();

--- a/integration-tests/multi-contract-caller/accumulator/lib.rs
+++ b/integration-tests/multi-contract-caller/accumulator/lib.rs
@@ -15,7 +15,7 @@ pub mod accumulator {
 
     impl Accumulator {
         /// Initializes the value to the initial value.
-        #[ink(constructor)]
+        #[ink(constructor, payable)]
         pub fn new(init_value: i32) -> Self {
             Self { value: init_value }
         }

--- a/integration-tests/multi-contract-caller/adder/lib.rs
+++ b/integration-tests/multi-contract-caller/adder/lib.rs
@@ -18,7 +18,7 @@ mod adder {
 
     impl Adder {
         /// Creates a new `adder` from the given `accumulator`.
-        #[ink(constructor)]
+        #[ink(constructor, payable)]
         pub fn new(accumulator: AccumulatorRef) -> Self {
             Self { accumulator }
         }

--- a/integration-tests/multi-contract-caller/lib.rs
+++ b/integration-tests/multi-contract-caller/lib.rs
@@ -50,7 +50,7 @@ mod multi_contract_caller {
     impl MultiContractCaller {
         /// Instantiate a `multi_contract_caller` contract with the given sub-contract
         /// codes.
-        #[ink(constructor)]
+        #[ink(constructor, payable)]
         pub fn new(
             init_value: i32,
             version: u32,
@@ -155,7 +155,7 @@ mod multi_contract_caller {
                     "multi_contract_caller",
                     &ink_e2e::alice(),
                     constructor,
-                    0,
+                    10_000_000_000_000,
                     None,
                 )
                 .await

--- a/integration-tests/multi-contract-caller/subber/lib.rs
+++ b/integration-tests/multi-contract-caller/subber/lib.rs
@@ -18,7 +18,7 @@ mod subber {
 
     impl Subber {
         /// Creates a new `subber` from the given `accumulator`.
-        #[ink(constructor)]
+        #[ink(constructor, payable)]
         pub fn new(accumulator: AccumulatorRef) -> Self {
             Self { accumulator }
         }


### PR DESCRIPTION
- update Determinism enum to match Substrate definition (should fix `call-builder` e2e tests)
- also fixes `multi_contract_caller` to take account of new account deposits