### PR TITLE
`[ink_e2e]` improve call API, remove `build_message` + callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Schema generation - [#1765](https://github.com/paritytech/ink/pull/1765)
 
+### Changed
+- E2E: improve call API, remove `build_message` + callback - [#1782](https://github.com/paritytech/ink/pull/1782)
+
 ## Version 4.2.0
 
 ### Added

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro = true
 [dependencies]
 ink_ir = { version = "4.2.0", path = "../../ink/ir" }
 cargo_metadata = "0.15.3"
-contract-build = "3.0.0"
+contract-build = "2.0.2"
 derive_more = "0.99.17"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 serde_json = "1.0.89"

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro = true
 [dependencies]
 ink_ir = { version = "4.2.0", path = "../../ink/ir" }
 cargo_metadata = "0.15.3"
-contract-build = "2.0.2"
+contract-build = "3.0.0"
 derive_more = "0.99.17"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 serde_json = "1.0.89"

--- a/crates/e2e/src/builders.rs
+++ b/crates/e2e/src/builders.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ink::codegen::TraitCallBuilder;
 use ink_env::{
     call::{
         utils::{
@@ -20,11 +19,8 @@ use ink_env::{
             Set,
             Unset,
         },
-        Call,
-        CallBuilder,
         CreateBuilder,
         ExecutionInput,
-        FromAccountId,
     },
     Environment,
 };
@@ -58,132 +54,4 @@ where
         .params()
         .exec_input()
         .encode()
-}
-
-/// Captures the encoded input for an `ink!` message call, together with the account id of
-/// the contract being called.
-#[derive(Debug, Clone)]
-pub struct Message<E: Environment, RetType> {
-    account_id: E::AccountId,
-    exec_input: Vec<u8>,
-    _return_type: std::marker::PhantomData<RetType>,
-}
-
-impl<E, RetType> Message<E, RetType>
-where
-    E: Environment,
-{
-    /// Create a new message from the given account id and encoded message data.
-    pub fn new(account_id: E::AccountId, exec_input: Vec<u8>) -> Self {
-        Self {
-            account_id,
-            exec_input,
-            _return_type: Default::default(),
-        }
-    }
-
-    /// The account id of the contract being called to invoke the message.
-    pub fn account_id(&self) -> &E::AccountId {
-        &self.account_id
-    }
-
-    /// The encoded message data, comprised of the selector and the message arguments.
-    pub fn exec_input(&self) -> &[u8] {
-        &self.exec_input
-    }
-}
-
-/// Convenience method for building messages for the default environment.
-///
-/// # Note
-///
-/// This is hardcoded to [`ink_env::DefaultEnvironment`] so the user does not have to
-/// specify this generic parameter, which currently is hardcoded in the E2E testing suite.
-pub fn build_message<Ref>(
-    account_id: <ink_env::DefaultEnvironment as Environment>::AccountId,
-) -> MessageBuilder<ink_env::DefaultEnvironment, Ref>
-where
-    Ref: TraitCallBuilder + FromAccountId<ink_env::DefaultEnvironment>,
-{
-    MessageBuilder::from_account_id(account_id)
-}
-
-/// Build messages using a contract ref.
-pub struct MessageBuilder<E: Environment, Ref> {
-    account_id: E::AccountId,
-    contract_ref: Ref,
-}
-
-impl<E, Ref> MessageBuilder<E, Ref>
-where
-    E: Environment,
-    Ref: TraitCallBuilder + FromAccountId<E>,
-{
-    /// Create a new [`MessageBuilder`] to invoke a message on the given contract.
-    pub fn from_account_id(account_id: E::AccountId) -> Self {
-        let contract_ref = <Ref as FromAccountId<E>>::from_account_id(account_id.clone());
-        Self {
-            account_id,
-            contract_ref,
-        }
-    }
-
-    /// Build an encoded call for a message from a [`CallBuilder`] instance returned from
-    /// a contract ref method.
-    ///
-    /// This utilizes the generated message inherent methods on the contract ref
-    /// implementation, which returns a [`CallBuilder`] initialized with the selector
-    /// and message arguments.
-    ///
-    /// # Example
-    /// ```
-    /// # #[ink::contract]
-    /// # pub mod my_contract {
-    /// #
-    /// #     #[ink(storage)]
-    /// #     pub struct MyContract { }
-    /// #
-    /// #     impl MyContract {
-    /// #         #[ink(constructor)]
-    /// #         pub fn new() -> Self {
-    /// #             Self {}
-    /// #         }
-    /// #
-    /// #         #[ink(message)]
-    /// #         pub fn message(&self) {}
-    /// #     }
-    /// # }
-    /// #
-    /// # fn message_builder_doc_test() {
-    /// #     use my_contract::MyContractRef;
-    /// #     let contract_acc_id = ink_primitives::AccountId::from([0x00; 32]);
-    /// ink_e2e::MessageBuilder::<ink::env::DefaultEnvironment, MyContractRef>::from_account_id(
-    ///     contract_acc_id,
-    /// )
-    /// .call(|contract| contract.message());
-    /// # }
-    /// ```
-
-    pub fn call<F, Args, RetType>(mut self, mut message: F) -> Message<E, RetType>
-    where
-        F: FnMut(
-            &mut <Ref as TraitCallBuilder>::Builder,
-        ) -> CallBuilder<
-            E,
-            Set<Call<E>>,
-            Set<ExecutionInput<Args>>,
-            Set<ReturnType<RetType>>,
-        >,
-        Args: scale::Encode,
-        RetType: scale::Decode,
-    {
-        let call_builder = <Ref as TraitCallBuilder>::call_mut(&mut self.contract_ref);
-        let builder = message(call_builder);
-        let exec_input = builder.params().exec_input().encode();
-        Message {
-            account_id: self.account_id.clone(),
-            exec_input,
-            _return_type: Default::default(),
-        }
-    }
 }

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -829,7 +829,7 @@ where
                 let dispatch_error =
                     subxt::error::DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(Error::Decoding)?;
-                log_error(&format!("extrinsic for call failed: {dispatch_error:?}"));
+                log_error(&format!("extrinsic for call failed: {dispatch_error}"));
                 return Err(Error::CallExtrinsic(dispatch_error))
             }
         }

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -66,7 +66,8 @@ use subxt::{
     tx::PairSigner,
 };
 
-type CallBuilder<E, Args, RetType> = ink_env::call::CallBuilder<
+/// Represents an initialized contract message builder.
+pub type CallBuilderFinal<E, Args, RetType> = ink_env::call::CallBuilder<
     E,
     Set<Call<E>>,
     Set<ExecutionInput<Args>>,
@@ -773,14 +774,14 @@ where
     pub async fn call<Args, RetType>(
         &mut self,
         signer: &Signer<C>,
-        message: &CallBuilder<E, Args, RetType>,
+        message: &CallBuilderFinal<E, Args, RetType>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
     ) -> Result<CallResult<C, E, RetType>, Error<C, E>>
     where
         Args: scale::Encode,
         RetType: scale::Decode,
-        CallBuilder<E, Args, RetType>: Clone,
+        CallBuilderFinal<E, Args, RetType>: Clone,
     {
         let account_id = message.clone().params().callee().clone();
         let exec_input = scale::Encode::encode(message.clone().params().exec_input());
@@ -874,14 +875,14 @@ where
     pub async fn call_dry_run<Args, RetType>(
         &mut self,
         signer: &Signer<C>,
-        message: &CallBuilder<E, Args, RetType>,
+        message: &CallBuilderFinal<E, Args, RetType>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
     ) -> CallDryRunResult<E, RetType>
     where
         Args: scale::Encode,
         RetType: scale::Decode,
-        CallBuilder<E, Args, RetType>: Clone,
+        CallBuilderFinal<E, Args, RetType>: Clone,
     {
         let dest = message.clone().params().callee().clone();
         let exec_input = scale::Encode::encode(message.clone().params().exec_input());

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -496,7 +496,7 @@ where
     /// Calling this function multiple times is idempotent, the contract is
     /// newly instantiated each time using a unique salt. No existing contract
     /// instance is reused!
-    pub async fn instantiate<Contract, ContractRef, Args, R>(
+    pub async fn instantiate<Contract, Args, R>(
         &mut self,
         contract_name: &str,
         signer: &Signer<C>,

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -72,12 +72,12 @@ use subxt::{
 pub struct InstantiationResult<
     C: subxt::Config,
     E: Environment,
-    Contract: ContractCallBuilder,
+    CallBuilder,
 > {
     /// The account id at which the contract was instantiated.
     pub account_id: E::AccountId,
     /// Call builder for constructing calls,
-    pub call_builder: <Contract as ContractCallBuilder>::Type,
+    pub call_builder: CallBuilder,
     /// The result of the dry run, contains debug messages
     /// if there were any.
     pub dry_run: ContractInstantiateResult<C::AccountId, E::Balance>,
@@ -85,13 +85,12 @@ pub struct InstantiationResult<
     pub events: ExtrinsicEvents<C>,
 }
 
-impl<C, E, Contract> InstantiationResult<C, E, Contract>
+impl<C, E, CallBuilder> InstantiationResult<C, E, CallBuilder>
 where
     C: subxt::Config,
     E: Environment,
-    Contract: ContractCallBuilder,
 {
-    pub fn call(&mut self) -> &mut <Contract as ContractCallBuilder>::Type {
+    pub fn call(&mut self) -> &mut CallBuilder {
         &mut self.call_builder
     }
 }
@@ -508,7 +507,7 @@ where
         >,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> Result<InstantiationResult<C, E, Contract>, Error<C, E>>
+    ) -> Result<InstantiationResult<C, E, <Contract as ContractCallBuilder>::Type>, Error<C, E>>
     where
         Contract: ContractCallBuilder + ContractReference,
         <Contract as ContractCallBuilder>::Type: FromAccountId<E>,
@@ -516,7 +515,7 @@ where
     {
         let code = self.load_code(contract_name);
         let ret = self
-            .exec_instantiate(signer, code, constructor, value, storage_deposit_limit)
+            .exec_instantiate::<Contract, Args, R>(signer, code, constructor, value, storage_deposit_limit)
             .await?;
         log_info(&format!("instantiated contract at {:?}", ret.account_id));
         Ok(ret)
@@ -583,7 +582,7 @@ where
         >,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> Result<InstantiationResult<C, E, Contract>, Error<C, E>>
+    ) -> Result<InstantiationResult<C, E, <Contract as ContractCallBuilder>::Type>, Error<C, E>>
     where
         Contract: ContractCallBuilder + ContractReference,
         <Contract as ContractCallBuilder>::Type: FromAccountId<E>,

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -642,7 +642,7 @@ where
                     subxt::error::DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(Error::Decoding)?;
                 log_error(&format!(
-                    "extrinsic for instantiate failed: {dispatch_error:?}"
+                    "extrinsic for instantiate failed: {dispatch_error}"
                 ));
                 return Err(Error::InstantiateExtrinsic(dispatch_error))
             }
@@ -734,7 +734,7 @@ where
                     subxt::error::DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(Error::Decoding)?;
 
-                log_error(&format!("extrinsic for upload failed: {dispatch_error:?}"));
+                log_error(&format!("extrinsic for upload failed: {dispatch_error}"));
                 return Err(Error::UploadExtrinsic(dispatch_error))
             }
         }
@@ -859,7 +859,7 @@ where
                     subxt::error::DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(Error::Decoding)?;
 
-                log_error(&format!("extrinsic for call failed: {dispatch_error:?}"));
+                log_error(&format!("extrinsic for call failed: {dispatch_error}"));
                 return Err(Error::CallExtrinsic(dispatch_error))
             }
         }

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -16,7 +16,6 @@ use super::{
     builders::{
         constructor_exec_input,
         CreateBuilderPartial,
-        Message,
     },
     log_error,
     log_info,
@@ -27,7 +26,21 @@ use super::{
     ContractsApi,
     Signer,
 };
-use ink_env::Environment;
+use ink::codegen::ContractCallBuilder;
+use ink_env::{
+    call::{
+        utils::{
+            ReturnType,
+            Set,
+        },
+        Call,
+        CallBuilder,
+        ExecutionInput,
+        FromAccountId,
+    },
+    ContractReference,
+    Environment,
+};
 use ink_primitives::MessageResult;
 use pallet_contracts_primitives::ExecReturnValue;
 use sp_core::Pair;
@@ -56,14 +69,31 @@ use subxt::{
 };
 
 /// Result of a contract instantiation.
-pub struct InstantiationResult<C: subxt::Config, E: Environment> {
+pub struct InstantiationResult<
+    C: subxt::Config,
+    E: Environment,
+    Contract: ContractCallBuilder,
+> {
     /// The account id at which the contract was instantiated.
     pub account_id: E::AccountId,
+    /// Call builder for constructing calls,
+    pub call_builder: <Contract as ContractCallBuilder>::Type,
     /// The result of the dry run, contains debug messages
     /// if there were any.
     pub dry_run: ContractInstantiateResult<C::AccountId, E::Balance>,
     /// Events that happened with the contract instantiation.
     pub events: ExtrinsicEvents<C>,
+}
+
+impl<C, E, Contract> InstantiationResult<C, E, Contract>
+where
+    C: subxt::Config,
+    E: Environment,
+    Contract: ContractCallBuilder,
+{
+    pub fn call(&mut self) -> &mut <Contract as ContractCallBuilder>::Type {
+        &mut self.call_builder
+    }
 }
 
 /// Result of a contract upload.
@@ -97,13 +127,14 @@ where
 
 /// We implement a custom `Debug` here, as to avoid requiring the trait
 /// bound `Debug` for `E`.
-impl<C, E> core::fmt::Debug for InstantiationResult<C, E>
+impl<C, E, Contract> core::fmt::Debug for InstantiationResult<C, E, Contract>
 where
     C: subxt::Config,
     C::AccountId: Debug,
     E: Environment,
     <E as Environment>::AccountId: Debug,
     <E as Environment>::Balance: Debug,
+    Contract: ContractCallBuilder,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("InstantiationResult")
@@ -465,15 +496,22 @@ where
     /// Calling this function multiple times is idempotent, the contract is
     /// newly instantiated each time using a unique salt. No existing contract
     /// instance is reused!
-    pub async fn instantiate<ContractRef, Args, R>(
+    pub async fn instantiate<Contract, ContractRef, Args, R>(
         &mut self,
         contract_name: &str,
         signer: &Signer<C>,
-        constructor: CreateBuilderPartial<E, ContractRef, Args, R>,
+        constructor: CreateBuilderPartial<
+            E,
+            <Contract as ContractReference>::Type,
+            Args,
+            R,
+        >,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> Result<InstantiationResult<C, E>, Error<C, E>>
+    ) -> Result<InstantiationResult<C, E, Contract>, Error<C, E>>
     where
+        Contract: ContractCallBuilder + ContractReference,
+        <Contract as ContractCallBuilder>::Type: FromAccountId<E>,
         Args: scale::Encode,
     {
         let code = self.load_code(contract_name);
@@ -485,11 +523,11 @@ where
     }
 
     /// Dry run contract instantiation using the given constructor.
-    pub async fn instantiate_dry_run<ContractRef, Args, R>(
+    pub async fn instantiate_dry_run<Contract, Args, R>(
         &mut self,
         contract_name: &str,
         signer: &Signer<C>,
-        constructor: CreateBuilderPartial<E, ContractRef, Args, R>,
+        constructor: CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
     ) -> ContractInstantiateResult<C::AccountId, E::Balance>
@@ -533,15 +571,22 @@ where
     }
 
     /// Executes an `instantiate_with_code` call and captures the resulting events.
-    async fn exec_instantiate<ContractRef, Args, R>(
+    async fn exec_instantiate<Contract, Args, R>(
         &mut self,
         signer: &Signer<C>,
         code: Vec<u8>,
-        constructor: CreateBuilderPartial<E, ContractRef, Args, R>,
+        constructor: CreateBuilderPartial<
+            E,
+            <Contract as ContractReference>::Type,
+            Args,
+            R,
+        >,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> Result<InstantiationResult<C, E>, Error<C, E>>
+    ) -> Result<InstantiationResult<C, E, Contract>, Error<C, E>>
     where
+        Contract: ContractCallBuilder + ContractReference,
+        <Contract as ContractCallBuilder>::Type: FromAccountId<E>,
         Args: scale::Encode,
     {
         let salt = Self::salt();
@@ -613,12 +658,17 @@ where
                 return Err(Error::InstantiateExtrinsic(dispatch_error))
             }
         }
+        let account_id = account_id.expect("cannot extract `account_id` from events");
+        let call_builder = <<Contract as ContractCallBuilder>::Type as FromAccountId<
+            E,
+        >>::from_account_id(account_id.clone());
 
         Ok(InstantiationResult {
             dry_run,
+            call_builder,
             // The `account_id` must exist at this point. If the instantiation fails
             // the dry-run must already return that.
-            account_id: account_id.expect("cannot extract `account_id` from events"),
+            account_id,
             events: tx_events,
         })
     }
@@ -729,19 +779,29 @@ where
     ///
     /// Returns when the transaction is included in a block. The return value
     /// contains all events that are associated with this transaction.
-    pub async fn call<RetType>(
+    pub async fn call<Args, RetType>(
         &mut self,
         signer: &Signer<C>,
-        message: Message<E, RetType>,
+        message: &CallBuilder<
+            E,
+            Set<Call<E>>,
+            Set<ExecutionInput<Args>>,
+            Set<ReturnType<RetType>>,
+        >,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
     ) -> Result<CallResult<C, E, RetType>, Error<C, E>>
     where
+        Args: scale::Encode,
         RetType: scale::Decode,
+        CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<Args>>, Set<ReturnType<RetType>>>:
+            Clone,
     {
-        log_info(&format!("call: {:02X?}", message.exec_input()));
+        let account_id = message.clone().params().callee().clone();
+        let exec_input = scale::Encode::encode(message.clone().params().exec_input());
+        log_info(&format!("call: {:02X?}", exec_input));
 
-        let dry_run = self.call_dry_run(signer, &message, value, None).await;
+        let dry_run = self.call_dry_run(signer, message, value, None).await;
 
         if dry_run.exec_result.result.is_err() {
             return Err(Error::CallDryRun(dry_run.exec_result))
@@ -750,11 +810,11 @@ where
         let tx_events = self
             .api
             .call(
-                subxt::utils::MultiAddress::Id(message.account_id().clone()),
+                subxt::utils::MultiAddress::Id(account_id.clone()),
                 value,
                 dry_run.exec_result.gas_required.into(),
                 storage_deposit_limit,
-                message.exec_input().to_vec(),
+                exec_input,
                 signer,
             )
             .await;
@@ -826,21 +886,33 @@ where
     ///
     /// Returns the result of the dry run, together with the decoded return value of the
     /// invoked message.
-    pub async fn call_dry_run<RetType>(
+    pub async fn call_dry_run<Args, RetType>(
         &mut self,
         signer: &Signer<C>,
-        message: &Message<E, RetType>,
+        message: &CallBuilder<
+            E,
+            Set<Call<E>>,
+            Set<ExecutionInput<Args>>,
+            Set<ReturnType<RetType>>,
+        >,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
     ) -> CallDryRunResult<E, RetType>
     where
+        Args: scale::Encode,
         RetType: scale::Decode,
+        CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<Args>>, Set<ReturnType<RetType>>>:
+            Clone,
     {
+        let dest = message.clone().params().callee().clone();
+        let exec_input = scale::Encode::encode(message.clone().params().exec_input());
+
         let exec_result = self
             .api
-            .call_dry_run(
+            .call_dry_run::<RetType>(
                 Signer::account_id(signer).clone(),
-                message,
+                dest,
+                exec_input,
                 value,
                 storage_deposit_limit,
             )

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -26,6 +26,7 @@ mod node_proc;
 mod xts;
 
 pub use client::{
+    CallBuilderFinal,
     CallDryRunResult,
     CallResult,
     Client,

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -25,11 +25,6 @@ mod default_accounts;
 mod node_proc;
 mod xts;
 
-pub use builders::{
-    build_message,
-    Message,
-    MessageBuilder,
-};
 pub use client::{
     CallDryRunResult,
     CallResult,

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -412,7 +412,7 @@ where
     }
 
     /// Dry runs a call of the contract at `contract` with the given parameters.
-    pub async fn call_dry_run<RetType>(
+    pub async fn call_dry_run(
         &self,
         origin: C::AccountId,
         dest: E::AccountId,

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use super::{
-    builders::Message,
     log_info,
     sr25519,
     ContractExecResult,
@@ -416,17 +415,18 @@ where
     pub async fn call_dry_run<RetType>(
         &self,
         origin: C::AccountId,
-        message: &Message<E, RetType>,
+        dest: E::AccountId,
+        input_data: Vec<u8>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
     ) -> ContractExecResult<E::Balance> {
         let call_request = RpcCallRequest::<C, E> {
             origin,
-            dest: message.account_id().clone(),
+            dest,
             value,
             gas_limit: None,
             storage_deposit_limit,
-            input_data: message.exec_input().to_vec(),
+            input_data,
         };
         let func = "ContractsApi_call";
         let params = rpc_params![func, Bytes(scale::Encode::encode(&call_request))];

--- a/crates/env/src/call/call_builder.rs
+++ b/crates/env/src/call/call_builder.rs
@@ -332,6 +332,7 @@ where
 
 /// The default call type for cross-contract calls. Performs a cross-contract call to
 /// `callee` with gas limit `gas_limit`, transferring `transferred_value` of currency.
+#[derive(Clone)]
 pub struct Call<E: Environment> {
     callee: E::AccountId,
     gas_limit: Gas,
@@ -392,6 +393,7 @@ impl<E: Environment> DelegateCall<E> {
 }
 
 /// Builds up a cross contract call.
+#[derive(Clone)]
 pub struct CallBuilder<E, CallType, Args, RetType>
 where
     E: Environment,

--- a/crates/env/src/call/execution_input.rs
+++ b/crates/env/src/call/execution_input.rs
@@ -15,7 +15,7 @@
 use crate::call::Selector;
 
 /// The input data for a smart contract execution.
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct ExecutionInput<Args> {
     /// The selector for the smart contract execution.
     selector: Selector,
@@ -80,7 +80,7 @@ impl<Args> ExecutionInput<Args> {
 /// arguments. The potentially heap allocating encoding is done right at the end
 /// where we can leverage the static environmental buffer instead of allocating
 /// heap memory.
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct ArgumentList<Head, Rest> {
     /// The first argument of the argument list.
     head: Head,
@@ -92,7 +92,7 @@ pub struct ArgumentList<Head, Rest> {
 pub type ArgsList<Head, Rest> = ArgumentList<Argument<Head>, Rest>;
 
 /// A single argument and its reference to a known value.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Argument<T> {
     /// The reference to the known value.
     ///
@@ -109,7 +109,7 @@ impl<T> Argument<T> {
 }
 
 /// The end of an argument list.
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct ArgumentListEnd;
 
 /// An empty argument list.

--- a/integration-tests/call-runtime/lib.rs
+++ b/integration-tests/call-runtime/lib.rs
@@ -124,7 +124,6 @@ mod runtime_call {
             },
             primitives::AccountId,
         };
-        use ink_e2e::build_message;
 
         type E2EResult<T> = Result<T, Box<dyn std::error::Error>>;
 
@@ -159,7 +158,7 @@ mod runtime_call {
         ) -> E2EResult<()> {
             // given
             let constructor = RuntimeCallerRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate(
                     "call-runtime",
                     &ink_e2e::alice(),
@@ -168,8 +167,8 @@ mod runtime_call {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<RuntimeCaller>();
 
             let receiver: AccountId = default_accounts::<DefaultEnvironment>().bob;
 
@@ -183,11 +182,11 @@ mod runtime_call {
                 .expect("Failed to get account balance");
 
             // when
-            let transfer_message = build_message::<RuntimeCallerRef>(contract_acc_id)
-                .call(|caller| caller.transfer_through_runtime(receiver, TRANSFER_VALUE));
+            let transfer_message =
+                call.transfer_through_runtime(receiver, TRANSFER_VALUE);
 
             let call_res = client
-                .call(&ink_e2e::alice(), transfer_message, 0, None)
+                .call(&ink_e2e::alice(), &transfer_message, 0, None)
                 .await
                 .expect("call failed");
 
@@ -226,7 +225,7 @@ mod runtime_call {
         ) -> E2EResult<()> {
             // given
             let constructor = RuntimeCallerRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate(
                     "call-runtime",
                     &ink_e2e::alice(),
@@ -235,16 +234,14 @@ mod runtime_call {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<RuntimeCaller>();
 
             let receiver: AccountId = default_accounts::<DefaultEnvironment>().bob;
 
             // when
-            let transfer_message = build_message::<RuntimeCallerRef>(contract_acc_id)
-                .call(|caller| {
-                    caller.transfer_through_runtime(receiver, INSUFFICIENT_TRANSFER_VALUE)
-                });
+            let transfer_message =
+                call.transfer_through_runtime(receiver, INSUFFICIENT_TRANSFER_VALUE);
 
             let call_res = client
                 .call_dry_run(&ink_e2e::alice(), &transfer_message, 0, None)
@@ -267,7 +264,7 @@ mod runtime_call {
         ) -> E2EResult<()> {
             // given
             let constructor = RuntimeCallerRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate(
                     "call-runtime",
                     &ink_e2e::alice(),
@@ -276,12 +273,11 @@ mod runtime_call {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<RuntimeCaller>();
 
             // when
-            let transfer_message = build_message::<RuntimeCallerRef>(contract_acc_id)
-                .call(|caller| caller.call_nonexistent_extrinsic());
+            let transfer_message = call.call_nonexistent_extrinsic();
 
             let call_res = client
                 .call_dry_run(&ink_e2e::alice(), &transfer_message, 0, None)
@@ -302,20 +298,20 @@ mod runtime_call {
         ) -> E2EResult<()> {
             // given
             let constructor = RuntimeCallerRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate("call-runtime", &ink_e2e::alice(), constructor, 0, None)
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<RuntimeCaller>();
 
             let receiver: AccountId = default_accounts::<DefaultEnvironment>().bob;
 
-            let transfer_message = build_message::<RuntimeCallerRef>(contract_acc_id)
-                .call(|caller| caller.transfer_through_runtime(receiver, TRANSFER_VALUE));
+            let transfer_message =
+                call.transfer_through_runtime(receiver, TRANSFER_VALUE);
 
             // when
             let call_res = client
-                .call(&ink_e2e::alice(), transfer_message, 0, None)
+                .call(&ink_e2e::alice(), &transfer_message, 0, None)
                 .await;
 
             // then

--- a/integration-tests/contract-terminate/lib.rs
+++ b/integration-tests/contract-terminate/lib.rs
@@ -55,7 +55,7 @@ pub mod just_terminates {
 
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
-        use super::JustTerminateRef;
+        use super::*;
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
@@ -64,7 +64,7 @@ pub mod just_terminates {
         ) -> E2EResult<()> {
             // given
             let constructor = JustTerminateRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate(
                     "contract_terminate",
                     &ink_e2e::alice(),
@@ -73,15 +73,13 @@ pub mod just_terminates {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<JustTerminate>();
 
             // when
-            let terminate_me =
-                ink_e2e::build_message::<JustTerminateRef>(contract_acc_id)
-                    .call(|contract| contract.terminate_me());
+            let terminate_me = call.terminate_me();
             let call_res = client
-                .call(&ink_e2e::alice(), terminate_me, 0, None)
+                .call(&ink_e2e::alice(), &terminate_me, 0, None)
                 .await
                 .expect("terminate_me messages failed");
 

--- a/integration-tests/contract-transfer/lib.rs
+++ b/integration-tests/contract-transfer/lib.rs
@@ -190,7 +190,7 @@ pub mod give_me {
         ) -> E2EResult<()> {
             // given
             let constructor = GiveMeRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate(
                     "contract_transfer",
                     &ink_e2e::alice(),
@@ -199,14 +199,13 @@ pub mod give_me {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<GiveMe>();
 
             // when
-            let transfer = ink_e2e::build_message::<GiveMeRef>(contract_acc_id)
-                .call(|contract| contract.give_me(120));
+            let transfer = call.give_me(120);
 
-            let call_res = client.call(&ink_e2e::bob(), transfer, 10, None).await;
+            let call_res = client.call(&ink_e2e::bob(), &transfer, 10, None).await;
 
             // then
             if let Err(ink_e2e::Error::CallDryRun(dry_run)) = call_res {
@@ -224,7 +223,7 @@ pub mod give_me {
         ) -> E2EResult<()> {
             // given
             let constructor = GiveMeRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate(
                     "contract_transfer",
                     &ink_e2e::bob(),
@@ -233,19 +232,19 @@ pub mod give_me {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<GiveMe>();
+
             let balance_before: Balance = client
-                .balance(contract_acc_id.clone())
+                .balance(contract.account_id.clone())
                 .await
                 .expect("getting balance failed");
 
             // when
-            let transfer = ink_e2e::build_message::<GiveMeRef>(contract_acc_id)
-                .call(|contract| contract.give_me(120));
+            let transfer = call.give_me(120);
 
             let call_res = client
-                .call(&ink_e2e::eve(), transfer, 0, None)
+                .call(&ink_e2e::eve(), &transfer, 0, None)
                 .await
                 .expect("call failed");
 
@@ -253,7 +252,7 @@ pub mod give_me {
             assert!(call_res.debug_message().contains("requested value: 120\n"));
 
             let balance_after: Balance = client
-                .balance(contract_acc_id)
+                .balance(contract.account_id.clone())
                 .await
                 .expect("getting balance failed");
             assert_eq!(balance_before - balance_after, 120);

--- a/integration-tests/custom-environment/lib.rs
+++ b/integration-tests/custom-environment/lib.rs
@@ -92,8 +92,6 @@ mod runtime_call {
     mod e2e_tests {
         use super::*;
 
-        use ink_e2e::MessageBuilder;
-
         type E2EResult<T> = Result<T, Box<dyn std::error::Error>>;
 
         #[cfg(feature = "permissive-node")]
@@ -103,7 +101,7 @@ mod runtime_call {
         ) -> E2EResult<()> {
             // given
             let constructor = TopicsRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate(
                     "custom-environment",
                     &ink_e2e::alice(),
@@ -112,18 +110,14 @@ mod runtime_call {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let call = contract.call::<Topics>();
 
             // when
-            let message =
-                MessageBuilder::<crate::EnvironmentWithManyTopics, TopicsRef>::from_account_id(
-                    contract_acc_id,
-                )
-                .call(|caller| caller.trigger());
+            let message = call.trigger();
 
             let call_res = client
-                .call(&ink_e2e::alice(), message, 0, None)
+                .call(&ink_e2e::alice(), &message, 0, None)
                 .await
                 .expect("call failed");
 
@@ -140,7 +134,7 @@ mod runtime_call {
         ) -> E2EResult<()> {
             // given
             let constructor = TopicsRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate(
                     "custom-environment",
                     &ink_e2e::alice(),
@@ -149,14 +143,10 @@ mod runtime_call {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<Topics>();
 
-            let message =
-                MessageBuilder::<crate::EnvironmentWithManyTopics, TopicsRef>::from_account_id(
-                    contract_acc_id,
-                )
-                    .call(|caller| caller.trigger());
+            let message = call.trigger();
 
             // when
             let call_res = client

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -21,10 +21,7 @@ pub mod e2e_call_runtime {
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
         use super::*;
-        use ink_e2e::{
-            build_message,
-            subxt::dynamic::Value,
-        };
+        use ink_e2e::subxt::dynamic::Value;
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -32,11 +29,11 @@ pub mod e2e_call_runtime {
         async fn call_runtime_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
             // given
             let constructor = ContractRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate("e2e_call_runtime", &ink_e2e::alice(), constructor, 0, None)
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let call = contract.call::<Contract>();
 
             let transfer_amount = 100_000_000_000u128;
 
@@ -45,13 +42,12 @@ pub mod e2e_call_runtime {
                 // A value representing a `MultiAddress<AccountId32, _>`. We want the
                 // "Id" variant, and that will ultimately contain the
                 // bytes for our destination address
-                Value::unnamed_variant("Id", [Value::from_bytes(&contract_acc_id)]),
+                Value::unnamed_variant("Id", [Value::from_bytes(&contract.account_id)]),
                 // A value representing the amount we'd like to transfer.
                 Value::u128(transfer_amount),
             ];
 
-            let get_balance = build_message::<ContractRef>(contract_acc_id.clone())
-                .call(|contract| contract.get_contract_balance());
+            let get_balance = call.get_contract_balance();
             let pre_balance = client
                 .call_dry_run(&ink_e2e::alice(), &get_balance, 0, None)
                 .await
@@ -64,8 +60,7 @@ pub mod e2e_call_runtime {
                 .expect("runtime call failed");
 
             // then
-            let get_balance = build_message::<ContractRef>(contract_acc_id.clone())
-                .call(|contract| contract.get_contract_balance());
+            let get_balance = call.get_contract_balance();
             let get_balance_res = client
                 .call_dry_run(&ink_e2e::alice(), &get_balance, 0, None)
                 .await;

--- a/integration-tests/erc20/lib.rs
+++ b/integration-tests/erc20/lib.rs
@@ -597,6 +597,7 @@ mod erc20 {
             let charlie_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Charlie);
 
             let amount = 500_000_000u128;
+            // tx
             let transfer_from =
                 call.transfer_from(bob_account.clone(), charlie_account.clone(), amount);
             let transfer_from_result = client

--- a/integration-tests/erc20/lib.rs
+++ b/integration-tests/erc20/lib.rs
@@ -544,27 +544,27 @@ mod erc20 {
             // given
             let total_supply = 1_000_000_000;
             let constructor = Erc20Ref::new(total_supply);
-            let mut erc20 = client
-                // todo: would be nice to not require type param hint here.
-                .instantiate::<Erc20, _, _>("erc20", &ink_e2e::alice(), constructor, 0, None)
+            let erc20 = client
+                .instantiate("erc20", &ink_e2e::alice(), constructor, 0, None)
                 .await
                 .expect("instantiate failed");
+            let mut call = erc20.call::<Erc20>();
 
             // when
-            let total_supply_msg = erc20.call().total_supply();
+            let total_supply_msg = call.total_supply();
             let total_supply_res = client
                 .call_dry_run(&ink_e2e::bob(), &total_supply_msg, 0, None)
                 .await;
 
             let bob_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Bob);
             let transfer_to_bob = 500_000_000u128;
-            let transfer = erc20.call().transfer(bob_account.clone(), transfer_to_bob);
+            let transfer = call.transfer(bob_account.clone(), transfer_to_bob);
             let _transfer_res = client
                 .call(&ink_e2e::alice(), &transfer, 0, None)
                 .await
                 .expect("transfer failed");
 
-            let balance_of = erc20.call().balance_of(bob_account);
+            let balance_of = call.balance_of(bob_account);
             let balance_of_res = client
                 .call_dry_run(&ink_e2e::alice(), &balance_of, 0, None)
                 .await;
@@ -585,16 +585,11 @@ mod erc20 {
             // given
             let total_supply = 1_000_000_000;
             let constructor = Erc20Ref::new(total_supply);
-            let mut erc20 = client
-                .instantiate::<Erc20, _, _>(
-                    "erc20",
-                    &ink_e2e::bob(),
-                    constructor,
-                    0,
-                    None,
-                )
+            let erc20 = client
+                .instantiate("erc20", &ink_e2e::bob(), constructor, 0, None)
                 .await
                 .expect("instantiate failed");
+            let mut call = erc20.call::<Erc20>();
 
             // when
 
@@ -602,11 +597,8 @@ mod erc20 {
             let charlie_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Charlie);
 
             let amount = 500_000_000u128;
-            let transfer_from = erc20.call().transfer_from(
-                bob_account.clone(),
-                charlie_account.clone(),
-                amount,
-            );
+            let transfer_from =
+                call.transfer_from(bob_account.clone(), charlie_account.clone(), amount);
             let transfer_from_result = client
                 .call(&ink_e2e::charlie(), &transfer_from, 0, None)
                 .await;
@@ -618,16 +610,14 @@ mod erc20 {
 
             // Bob approves Charlie to transfer up to amount on his behalf
             let approved_value = 1_000u128;
-            let approve_call = erc20
-                .call()
-                .approve(charlie_account.clone(), approved_value);
+            let approve_call = call.approve(charlie_account.clone(), approved_value);
             client
                 .call(&ink_e2e::bob(), &approve_call, 0, None)
                 .await
                 .expect("approve failed");
 
             // `transfer_from` the approved amount
-            let transfer_from = erc20.call().transfer_from(
+            let transfer_from = call.transfer_from(
                 bob_account.clone(),
                 charlie_account.clone(),
                 approved_value,
@@ -640,17 +630,14 @@ mod erc20 {
                 "approved transfer_from should succeed"
             );
 
-            let balance_of = erc20.call().balance_of(bob_account);
+            let balance_of = call.balance_of(bob_account);
             let balance_of_res = client
                 .call_dry_run(&ink_e2e::alice(), &balance_of, 0, None)
                 .await;
 
             // `transfer_from` again, this time exceeding the approved amount
-            let transfer_from = erc20.call().transfer_from(
-                bob_account.clone(),
-                charlie_account.clone(),
-                1,
-            );
+            let transfer_from =
+                call.transfer_from(bob_account.clone(), charlie_account.clone(), 1);
             let transfer_from_result = client
                 .call(&ink_e2e::charlie(), &transfer_from, 0, None)
                 .await;

--- a/integration-tests/flipper/lib.rs
+++ b/integration-tests/flipper/lib.rs
@@ -55,7 +55,6 @@ pub mod flipper {
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
         use super::*;
-        use ink_e2e::build_message;
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -63,28 +62,25 @@ pub mod flipper {
         async fn it_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
             // given
             let constructor = FlipperRef::new(false);
-            let contract_acc_id = client
+            let contract = client
                 .instantiate("flipper", &ink_e2e::alice(), constructor, 0, None)
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<Flipper>();
 
-            let get = build_message::<FlipperRef>(contract_acc_id.clone())
-                .call(|flipper| flipper.get());
+            let get = call.get();
             let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
             assert!(matches!(get_res.return_value(), false));
 
             // when
-            let flip = build_message::<FlipperRef>(contract_acc_id.clone())
-                .call(|flipper| flipper.flip());
+            let flip = call.flip();
             let _flip_res = client
-                .call(&ink_e2e::bob(), flip, 0, None)
+                .call(&ink_e2e::bob(), &flip, 0, None)
                 .await
                 .expect("flip failed");
 
             // then
-            let get = build_message::<FlipperRef>(contract_acc_id.clone())
-                .call(|flipper| flipper.get());
+            let get = call.get();
             let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
             assert!(matches!(get_res.return_value(), true));
 
@@ -97,15 +93,14 @@ pub mod flipper {
             let constructor = FlipperRef::new_default();
 
             // when
-            let contract_acc_id = client
+            let contract = client
                 .instantiate("flipper", &ink_e2e::bob(), constructor, 0, None)
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let call = contract.call::<Flipper>();
 
             // then
-            let get = build_message::<FlipperRef>(contract_acc_id.clone())
-                .call(|flipper| flipper.get());
+            let get = call.get();
             let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
             assert!(matches!(get_res.return_value(), false));
 

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
@@ -106,7 +106,7 @@ pub mod constructors_return_value {
 
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
-        use super::ConstructorsReturnValueRef;
+        use super::*;
         use scale::Decode as _;
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -187,7 +187,7 @@ pub mod constructors_return_value {
             );
 
             let constructor = ConstructorsReturnValueRef::try_new(true);
-            let contract_acc_id = client
+            let contract = client
                 .instantiate(
                     "constructors_return_value",
                     &ink_e2e::bob(),
@@ -196,12 +196,10 @@ pub mod constructors_return_value {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<ConstructorsReturnValue>();
 
-            let get =
-                ink_e2e::build_message::<ConstructorsReturnValueRef>(contract_acc_id)
-                    .call(|contract| contract.get_value());
+            let get = call.get_value();
             let value = client
                 .call_dry_run(&ink_e2e::bob(), &get, 0, None)
                 .await

--- a/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
+++ b/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
@@ -67,8 +67,7 @@ mod contract_ref {
 
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
-        use super::ContractRefRef;
-        use ink_e2e::build_message;
+        use super::*;
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -83,24 +82,22 @@ mod contract_ref {
                 .code_hash;
 
             let constructor = ContractRefRef::new(0, flipper_hash);
-            let contract_acc_id = client
+            let contract_ref = client
                 .instantiate("contract_ref", &ink_e2e::alice(), constructor, 0, None)
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract_ref.call::<ContractRef>();
 
-            let get_check = build_message::<ContractRefRef>(contract_acc_id.clone())
-                .call(|contract| contract.get_check());
+            let get_check = call.get_check();
             let get_call_result = client
                 .call_dry_run(&ink_e2e::alice(), &get_check, 0, None)
                 .await;
 
             let initial_value = get_call_result.return_value();
 
-            let flip_check = build_message::<ContractRefRef>(contract_acc_id.clone())
-                .call(|contract| contract.flip_check());
+            let flip_check = call.flip_check();
             let flip_call_result = client
-                .call(&ink_e2e::alice(), flip_check, 0, None)
+                .call(&ink_e2e::alice(), &flip_check, 0, None)
                 .await
                 .expect("Calling `flip` failed");
             assert!(
@@ -129,14 +126,13 @@ mod contract_ref {
 
             let succeed = true;
             let constructor = ContractRefRef::try_new(0, flipper_hash, succeed);
-            let contract_acc_id = client
+            let contract_ref = client
                 .instantiate("contract_ref", &ink_e2e::bob(), constructor, 0, None)
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract_ref.call::<ContractRef>();
 
-            let get_check = build_message::<ContractRefRef>(contract_acc_id.clone())
-                .call(|contract| contract.get_check());
+            let get_check = call.get_check();
             let get_call_result = client
                 .call_dry_run(&ink_e2e::bob(), &get_check, 0, None)
                 .await;

--- a/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
@@ -66,8 +66,7 @@ pub mod integration_flipper {
 
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
-        use super::FlipperRef;
-        use ink_e2e::build_message;
+        use super::*;
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
@@ -75,7 +74,7 @@ pub mod integration_flipper {
             mut client: ink_e2e::Client<C, E>,
         ) -> E2EResult<()> {
             let constructor = FlipperRef::new_default();
-            let contract_acc_id = client
+            let flipper = client
                 .instantiate(
                     "integration_flipper",
                     &ink_e2e::alice(),
@@ -84,20 +83,18 @@ pub mod integration_flipper {
                     None,
                 )
                 .await
-                .expect("Instantiate `integration_flipper` failed")
-                .account_id;
+                .expect("Instantiate `integration_flipper` failed");
+            let mut call = flipper.call::<Flipper>();
 
-            let get = build_message::<FlipperRef>(contract_acc_id.clone())
-                .call(|contract| contract.get());
+            let get = call.get();
             let initial_value = client
                 .call_dry_run(&ink_e2e::alice(), &get, 0, None)
                 .await
                 .return_value();
 
-            let flip = build_message::<FlipperRef>(contract_acc_id)
-                .call(|contract| contract.flip());
+            let flip = call.flip();
             let flip_call_result = client
-                .call(&ink_e2e::alice(), flip, 0, None)
+                .call(&ink_e2e::alice(), &flip, 0, None)
                 .await
                 .expect("Calling `flip` failed");
             assert!(
@@ -119,23 +116,21 @@ pub mod integration_flipper {
             mut client: ink_e2e::Client<C, E>,
         ) -> E2EResult<()> {
             let constructor = FlipperRef::new_default();
-            let contract_acc_id = client
+            let flipper = client
                 .instantiate("integration_flipper", &ink_e2e::bob(), constructor, 0, None)
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = flipper.call::<Flipper>();
 
-            let get = build_message::<FlipperRef>(contract_acc_id.clone())
-                .call(|contract| contract.get());
+            let get = call.get();
             let initial_value = client
                 .call_dry_run(&ink_e2e::bob(), &get, 0, None)
                 .await
                 .return_value();
 
-            let err_flip = build_message::<FlipperRef>(contract_acc_id)
-                .call(|contract| contract.err_flip());
+            let err_flip = call.err_flip();
             let err_flip_call_result =
-                client.call(&ink_e2e::bob(), err_flip, 0, None).await;
+                client.call(&ink_e2e::bob(), &err_flip, 0, None).await;
 
             assert!(matches!(
                 err_flip_call_result,

--- a/integration-tests/mapping-integration-tests/lib.rs
+++ b/integration-tests/mapping-integration-tests/lib.rs
@@ -97,7 +97,7 @@ mod mapping_integration_tests {
         ) -> E2EResult<()> {
             // given
             let constructor = MappingsRef::new();
-            let contract_id = client
+            let contract = client
                 .instantiate(
                     "mapping-integration-tests",
                     &ink_e2e::alice(),
@@ -106,21 +106,19 @@ mod mapping_integration_tests {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<Mappings>();
 
             // when
-            let insert = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.insert_balance(1_000));
+            let insert = call.insert_balance(1_000);
             let size = client
-                .call(&ink_e2e::alice(), insert, 0, None)
+                .call(&ink_e2e::alice(), &insert, 0, None)
                 .await
                 .expect("Calling `insert_balance` failed")
                 .return_value();
 
             // then
-            let get = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.get_balance());
+            let get = call.get_balance();
             let balance = client
                 .call_dry_run(&ink_e2e::alice(), &get, 0, None)
                 .await
@@ -138,7 +136,7 @@ mod mapping_integration_tests {
         ) -> E2EResult<()> {
             // given
             let constructor = MappingsRef::new();
-            let contract_id = client
+            let contract = client
                 .instantiate(
                     "mapping-integration-tests",
                     &ink_e2e::bob(),
@@ -147,21 +145,19 @@ mod mapping_integration_tests {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<Mappings>();
 
             // when
-            let insert = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.insert_balance(1_000));
+            let insert = call.insert_balance(1_000);
             let _ = client
-                .call(&ink_e2e::bob(), insert, 0, None)
+                .call(&ink_e2e::bob(), &insert, 0, None)
                 .await
                 .expect("Calling `insert_balance` failed")
                 .return_value();
 
             // then
-            let contains = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.contains_balance());
+            let contains = call.contains_balance();
             let is_there = client
                 .call_dry_run(&ink_e2e::bob(), &contains, 0, None)
                 .await
@@ -176,7 +172,7 @@ mod mapping_integration_tests {
         async fn reinsert_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
             // given
             let constructor = MappingsRef::new();
-            let contract_id = client
+            let contract = client
                 .instantiate(
                     "mapping-integration-tests",
                     &ink_e2e::charlie(),
@@ -185,22 +181,20 @@ mod mapping_integration_tests {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<Mappings>();
 
             // when
-            let first_insert = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.insert_balance(1_000));
+            let first_insert = call.insert_balance(1_000);
             let _ = client
-                .call(&ink_e2e::charlie(), first_insert, 0, None)
+                .call(&ink_e2e::charlie(), &first_insert, 0, None)
                 .await
                 .expect("Calling `insert_balance` failed")
                 .return_value();
 
-            let insert = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.insert_balance(10_000));
+            let insert = call.insert_balance(10_000);
             let size = client
-                .call(&ink_e2e::charlie(), insert, 0, None)
+                .call(&ink_e2e::charlie(), &insert, 0, None)
                 .await
                 .expect("Calling `insert_balance` failed")
                 .return_value();
@@ -208,8 +202,7 @@ mod mapping_integration_tests {
             // then
             assert!(size.is_some());
 
-            let get = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.get_balance());
+            let get = call.get_balance();
             let balance = client
                 .call_dry_run(&ink_e2e::charlie(), &get, 0, None)
                 .await
@@ -226,7 +219,7 @@ mod mapping_integration_tests {
         ) -> E2EResult<()> {
             // given
             let constructor = MappingsRef::new();
-            let contract_id = client
+            let contract = client
                 .instantiate(
                     "mapping-integration-tests",
                     &ink_e2e::dave(),
@@ -235,28 +228,25 @@ mod mapping_integration_tests {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<Mappings>();
 
             // when
-            let insert = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.insert_balance(3_000));
+            let insert = call.insert_balance(3_000);
             let _ = client
-                .call(&ink_e2e::dave(), insert, 0, None)
+                .call(&ink_e2e::dave(), &insert, 0, None)
                 .await
                 .expect("Calling `insert_balance` failed")
                 .return_value();
 
-            let remove = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.remove_balance());
+            let remove = call.remove_balance();
             let _ = client
-                .call(&ink_e2e::dave(), remove, 0, None)
+                .call(&ink_e2e::dave(), &remove, 0, None)
                 .await
                 .expect("Calling `remove_balance` failed");
 
             // then
-            let get = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.get_balance());
+            let get = call.get_balance();
             let balance = client
                 .call_dry_run(&ink_e2e::dave(), &get, 0, None)
                 .await
@@ -273,7 +263,7 @@ mod mapping_integration_tests {
         ) -> E2EResult<()> {
             // given
             let constructor = MappingsRef::new();
-            let contract_id = client
+            let contract = client
                 .instantiate(
                     "mapping-integration-tests",
                     &ink_e2e::eve(),
@@ -282,22 +272,20 @@ mod mapping_integration_tests {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<Mappings>();
 
             // when
-            let insert = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.insert_balance(4_000));
+            let insert = call.insert_balance(4_000);
             let _ = client
-                .call(&ink_e2e::eve(), insert, 0, None)
+                .call(&ink_e2e::eve(), &insert, 0, None)
                 .await
                 .expect("Calling `insert_balance` failed")
                 .return_value();
 
-            let take = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.take_balance());
+            let take = call.take_balance();
             let balance = client
-                .call(&ink_e2e::eve(), take, 0, None)
+                .call(&ink_e2e::eve(), &take, 0, None)
                 .await
                 .expect("Calling `take_balance` failed")
                 .return_value();
@@ -305,8 +293,7 @@ mod mapping_integration_tests {
             // then
             assert_eq!(balance, Some(4_000));
 
-            let contains = ink_e2e::build_message::<MappingsRef>(contract_id)
-                .call(|contract| contract.contains_balance());
+            let contains = call.contains_balance();
             let is_there = client
                 .call_dry_run(&ink_e2e::eve(), &contains, 0, None)
                 .await

--- a/integration-tests/multi-contract-caller/lib.rs
+++ b/integration-tests/multi-contract-caller/lib.rs
@@ -114,8 +114,7 @@ mod multi_contract_caller {
 
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
-        use super::MultiContractCallerRef;
-        use ink_e2e::build_message;
+        use super::*;
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -150,7 +149,7 @@ mod multi_contract_caller {
                 subber_hash,
             );
 
-            let multi_contract_caller_acc_id = client
+            let multi_contract_caller = client
                 .instantiate(
                     "multi_contract_caller",
                     &ink_e2e::alice(),
@@ -159,33 +158,24 @@ mod multi_contract_caller {
                     None,
                 )
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = multi_contract_caller.call::<MultiContractCaller>();
 
             // when
-            let get = build_message::<MultiContractCallerRef>(
-                multi_contract_caller_acc_id.clone(),
-            )
-            .call(|contract| contract.get());
+            let get = call.get();
             let value = client
                 .call_dry_run(&ink_e2e::bob(), &get, 0, None)
                 .await
                 .return_value();
             assert_eq!(value, 1234);
-            let change = build_message::<MultiContractCallerRef>(
-                multi_contract_caller_acc_id.clone(),
-            )
-            .call(|contract| contract.change(6));
+            let change = call.change(6);
             let _ = client
-                .call(&ink_e2e::bob(), change, 0, None)
+                .call(&ink_e2e::bob(), &change, 0, None)
                 .await
                 .expect("calling `change` failed");
 
             // then
-            let get = build_message::<MultiContractCallerRef>(
-                multi_contract_caller_acc_id.clone(),
-            )
-            .call(|contract| contract.get());
+            let get = call.get();
             let value = client
                 .call_dry_run(&ink_e2e::bob(), &get, 0, None)
                 .await
@@ -193,28 +183,19 @@ mod multi_contract_caller {
             assert_eq!(value, 1234 + 6);
 
             // when
-            let switch = build_message::<MultiContractCallerRef>(
-                multi_contract_caller_acc_id.clone(),
-            )
-            .call(|contract| contract.switch());
+            let switch = call.switch();
             let _ = client
-                .call(&ink_e2e::bob(), switch, 0, None)
+                .call(&ink_e2e::bob(), &switch, 0, None)
                 .await
                 .expect("calling `switch` failed");
-            let change = build_message::<MultiContractCallerRef>(
-                multi_contract_caller_acc_id.clone(),
-            )
-            .call(|contract| contract.change(3));
+            let change = call.change(3);
             let _ = client
-                .call(&ink_e2e::bob(), change, 0, None)
+                .call(&ink_e2e::bob(), &change, 0, None)
                 .await
                 .expect("calling `change` failed");
 
             // then
-            let get = build_message::<MultiContractCallerRef>(
-                multi_contract_caller_acc_id.clone(),
-            )
-            .call(|contract| contract.get());
+            let get = call.get();
             let value = client
                 .call_dry_run(&ink_e2e::bob(), &get, 0, None)
                 .await

--- a/integration-tests/set-code-hash/lib.rs
+++ b/integration-tests/set-code-hash/lib.rs
@@ -68,7 +68,6 @@ pub mod incrementer {
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
         use super::*;
-        use ink_e2e::build_message;
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -76,26 +75,23 @@ pub mod incrementer {
         async fn set_code_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
             // Given
             let constructor = IncrementerRef::new();
-            let contract_acc_id = client
+            let contract = client
                 .instantiate("incrementer", &ink_e2e::alice(), constructor, 0, None)
                 .await
-                .expect("instantiate failed")
-                .account_id;
+                .expect("instantiate failed");
+            let mut call = contract.call::<Incrementer>();
 
-            let get = build_message::<IncrementerRef>(contract_acc_id.clone())
-                .call(|incrementer| incrementer.get());
+            let get = call.get();
             let get_res = client.call_dry_run(&ink_e2e::alice(), &get, 0, None).await;
             assert!(matches!(get_res.return_value(), 0));
 
-            let inc = build_message::<IncrementerRef>(contract_acc_id.clone())
-                .call(|incrementer| incrementer.inc());
+            let inc = call.inc();
             let _inc_result = client
-                .call(&ink_e2e::alice(), inc, 0, None)
+                .call(&ink_e2e::alice(), &inc, 0, None)
                 .await
                 .expect("`inc` failed");
 
-            let get = build_message::<IncrementerRef>(contract_acc_id.clone())
-                .call(|incrementer| incrementer.get());
+            let get = call.get();
             let get_res = client.call_dry_run(&ink_e2e::alice(), &get, 0, None).await;
             assert!(matches!(get_res.return_value(), 1));
 
@@ -107,27 +103,24 @@ pub mod incrementer {
                 .code_hash;
 
             let new_code_hash = new_code_hash.as_ref().try_into().unwrap();
-            let set_code = build_message::<IncrementerRef>(contract_acc_id.clone())
-                .call(|incrementer| incrementer.set_code(new_code_hash));
+            let set_code = call.set_code(new_code_hash);
 
             let _set_code_result = client
-                .call(&ink_e2e::alice(), set_code, 0, None)
+                .call(&ink_e2e::alice(), &set_code, 0, None)
                 .await
                 .expect("`set_code` failed");
 
             // Then
             // Note that our contract's `AccountId` (so `contract_acc_id`) has stayed the
             // same between updates!
-            let inc = build_message::<IncrementerRef>(contract_acc_id.clone())
-                .call(|incrementer| incrementer.inc());
+            let inc = call.inc();
 
             let _inc_result = client
-                .call(&ink_e2e::alice(), inc, 0, None)
+                .call(&ink_e2e::alice(), &inc, 0, None)
                 .await
                 .expect("`inc` failed");
 
-            let get = build_message::<IncrementerRef>(contract_acc_id.clone())
-                .call(|incrementer| incrementer.get());
+            let get = call.get();
             let get_res = client.call_dry_run(&ink_e2e::alice(), &get, 0, None).await;
 
             // Remember, we updated our incrementer contract to increment by `4`.

--- a/integration-tests/trait-dyn-cross-contract-calls/lib.rs
+++ b/integration-tests/trait-dyn-cross-contract-calls/lib.rs
@@ -43,14 +43,15 @@ pub mod caller {
 
 #[cfg(all(test, feature = "e2e-tests"))]
 mod e2e_tests {
-    use super::caller::CallerRef;
-    use dyn_traits::Increment;
-    use ink::{
-        contract_ref,
-        env::DefaultEnvironment,
+    use super::caller::{
+        Caller,
+        CallerRef,
     };
-    use ink_e2e::build_message;
-    use trait_incrementer::incrementer::IncrementerRef;
+    use dyn_traits::Increment;
+    use trait_incrementer::incrementer::{
+        Incrementer,
+        IncrementerRef,
+    };
 
     type E2EResult<T> = Result<T, Box<dyn std::error::Error>>;
 
@@ -78,15 +79,15 @@ mod e2e_tests {
 
         let constructor = IncrementerRef::new();
 
-        let incrementer_account_id = client
+        let incrementer = client
             .instantiate("trait-incrementer", &ink_e2e::alice(), constructor, 0, None)
             .await
-            .expect("instantiate failed")
-            .account_id;
+            .expect("instantiate failed");
+        let incrementer_call = incrementer.call::<Incrementer>();
 
-        let constructor = CallerRef::new(incrementer_account_id.clone());
+        let constructor = CallerRef::new(incrementer.account_id.clone());
 
-        let caller_account_id = client
+        let caller = client
             .instantiate(
                 "trait-incrementer-caller",
                 &ink_e2e::alice(),
@@ -95,12 +96,11 @@ mod e2e_tests {
                 None,
             )
             .await
-            .expect("instantiate failed")
-            .account_id;
+            .expect("instantiate failed");
+        let mut caller_call = caller.call::<Caller>();
 
         // Check through the caller that the value of the incrementer is zero
-        let get = build_message::<CallerRef>(caller_account_id.clone())
-            .call(|contract| contract.get());
+        let get = caller_call.get();
         let value = client
             .call_dry_run(&ink_e2e::alice(), &get, 0, None)
             .await
@@ -108,20 +108,16 @@ mod e2e_tests {
         assert_eq!(value, 0);
 
         // Increment the value of the incrementer via the caller
-        let inc = build_message::<CallerRef>(caller_account_id.clone())
-            .call(|contract| contract.inc());
+        let inc = caller_call.inc();
         let _ = client
-            .call(&ink_e2e::alice(), inc, 0, None)
+            .call(&ink_e2e::alice(), &inc, 0, None)
             .await
             .expect("calling `inc` failed");
 
         // Ask the `trait-increment` about a value. It should be updated by the caller.
         // Also use `contract_ref!(Increment)` instead of `IncrementerRef`
         // to check that it also works with e2e testing.
-        let get = build_message::<contract_ref!(Increment, DefaultEnvironment)>(
-            incrementer_account_id.clone(),
-        )
-        .call(|contract| contract.get());
+        let get = incrementer_call.get();
         let value = client
             .call_dry_run(&ink_e2e::alice(), &get, 0, None)
             .await

--- a/integration-tests/wildcard-selector/lib.rs
+++ b/integration-tests/wildcard-selector/lib.rs
@@ -37,8 +37,19 @@ pub mod wildcard_selector {
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
         use super::*;
-        use ink_e2e::Message;
-        use scale::Encode as _;
+
+        use ink::env::call::{
+            utils::{
+                Argument,
+                ArgumentList,
+                EmptyArgumentList,
+                ReturnType,
+                Set,
+            },
+            Call,
+            CallBuilder,
+            ExecutionInput,
+        };
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
         type Environment = <WildcardSelectorRef as ink::env::ContractEnv>::Env;
@@ -47,8 +58,13 @@ pub mod wildcard_selector {
             account_id: AccountId,
             selector: [u8; 4],
             message: String,
-        ) -> Message<Environment, ()> {
-            let call_builder = ink::env::call::build_call::<Environment>()
+        ) -> CallBuilder<
+            Environment,
+            Set<Call<Environment>>,
+            Set<ExecutionInput<ArgumentList<Argument<String>, EmptyArgumentList>>>,
+            Set<ReturnType<()>>,
+        > {
+            ink::env::call::build_call::<Environment>()
                 .call(account_id)
                 .exec_input(
                     ink::env::call::ExecutionInput::new(ink::env::call::Selector::new(
@@ -56,9 +72,7 @@ pub mod wildcard_selector {
                     ))
                     .push_arg(message),
                 )
-                .returns::<()>();
-            let exec_input = call_builder.params().exec_input().encode();
-            Message::<ink::env::DefaultEnvironment, ()>::new(account_id, exec_input)
+                .returns::<()>()
         }
 
         #[ink_e2e::test]
@@ -83,7 +97,7 @@ pub mod wildcard_selector {
             );
 
             let result = client
-                .call(&ink_e2e::bob(), wildcard, 0, None)
+                .call(&ink_e2e::bob(), &wildcard, 0, None)
                 .await
                 .expect("wildcard failed");
 
@@ -96,7 +110,7 @@ pub mod wildcard_selector {
             );
 
             let result2 = client
-                .call(&ink_e2e::bob(), wildcard2, 0, None)
+                .call(&ink_e2e::bob(), &wildcard2, 0, None)
                 .await
                 .expect("wildcard failed");
 
@@ -135,7 +149,7 @@ pub mod wildcard_selector {
             );
 
             let result = client
-                .call(&ink_e2e::bob(), wildcard, 0, None)
+                .call(&ink_e2e::bob(), &wildcard, 0, None)
                 .await
                 .expect("wildcard failed");
 

--- a/integration-tests/wildcard-selector/lib.rs
+++ b/integration-tests/wildcard-selector/lib.rs
@@ -38,17 +38,10 @@ pub mod wildcard_selector {
     mod e2e_tests {
         use super::*;
 
-        use ink::env::call::{
-            utils::{
-                Argument,
-                ArgumentList,
-                EmptyArgumentList,
-                ReturnType,
-                Set,
-            },
-            Call,
-            CallBuilder,
-            ExecutionInput,
+        use ink::env::call::utils::{
+            Argument,
+            ArgumentList,
+            EmptyArgumentList,
         };
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -58,11 +51,10 @@ pub mod wildcard_selector {
             account_id: AccountId,
             selector: [u8; 4],
             message: String,
-        ) -> CallBuilder<
+        ) -> ink_e2e::CallBuilderFinal<
             Environment,
-            Set<Call<Environment>>,
-            Set<ExecutionInput<ArgumentList<Argument<String>, EmptyArgumentList>>>,
-            Set<ReturnType<()>>,
+            ArgumentList<Argument<String>, EmptyArgumentList>,
+            (),
         > {
             ink::env::call::build_call::<Environment>()
                 .call(account_id)


### PR DESCRIPTION
Resurrecting the idea from https://github.com/paritytech/ink/pull/1669. 

I believe it closes https://github.com/paritytech/ink/issues/1644, since the main thing is removing that ugly callback. This may not be the fina or most sophisticatedl API, but an increment in the right direction for better quality of life for `e2e` test devs.

Replaces `build_message` and callback with a simpler:

```rust
            let erc20 = client
                .instantiate("erc20", &ink_e2e::alice(), constructor, 0, None)
                .await
                .expect("instantiate failed");
            let mut call = erc20.call::<Erc20>();

            // dry run
            let total_supply_msg = call.total_supply();
            let total_supply_res = client
                .call_dry_run(&ink_e2e::bob(), &total_supply_msg, 0, None)
                .await;

            // tx
            let transfer_from =
                call.transfer_from(bob_account.clone(), charlie_account.clone(), amount);
            let transfer_from_result = client
                .call(&ink_e2e::charlie(), &transfer_from, 0, None)
                .await;
```
