### PR TITLE
Expose `ty` for types that use `RootLayout`

### DIFF
--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -76,7 +76,7 @@ impl Metadata<'_> {
         quote_spanned!(storage_span=>
             // Wrap the layout of the contract into the `RootLayout`, because
             // contract storage key is reserved for all packed fields
-            ::ink::metadata::layout::Layout::Root(::ink::metadata::layout::RootLayout::new(
+            ::ink::metadata::layout::Layout::Root(::ink::metadata::layout::RootLayout::new::<#storage_ident, _>(
                 #layout_key,
                 <#storage_ident as ::ink::storage::traits::StorageLayout>::layout(
                     &#key,

--- a/crates/metadata/src/layout/mod.rs
+++ b/crates/metadata/src/layout/mod.rs
@@ -37,7 +37,6 @@ use scale_info::{
     },
     meta_type,
     IntoPortable,
-    MetaType,
     Registry,
     TypeInfo,
 };

--- a/crates/metadata/src/layout/mod.rs
+++ b/crates/metadata/src/layout/mod.rs
@@ -37,6 +37,7 @@ use scale_info::{
     },
     meta_type,
     IntoPortable,
+    MetaType,
     Registry,
     TypeInfo,
 };
@@ -137,6 +138,8 @@ pub struct RootLayout<F: Form = MetaForm> {
     root_key: LayoutKey,
     /// The storage layout of the unbounded layout elements.
     layout: Box<Layout<F>>,
+    /// The type of the encoded entity.
+    ty: <F as Form>::Type,
 }
 
 impl IntoPortable for RootLayout {
@@ -146,6 +149,7 @@ impl IntoPortable for RootLayout {
         RootLayout {
             root_key: self.root_key,
             layout: Box::new(self.layout.into_portable(registry)),
+            ty: registry.register_type(&self.ty),
         }
     }
 }
@@ -153,16 +157,27 @@ impl IntoPortable for RootLayout {
 impl<F> RootLayout<F>
 where
     F: Form,
+    F::Type: From<MetaType>,
 {
     /// Creates a new root layout.
-    pub fn new<L>(root_key: LayoutKey, layout: L) -> Self
+    pub fn new<Root, L>(root_key: LayoutKey, layout: L) -> Self
     where
+        Root: TypeInfo + 'static,
         L: Into<Layout<F>>,
     {
         Self {
             root_key,
             layout: Box::new(layout.into()),
+            ty: meta_type::<Root>().into(),
         }
+    }
+
+    /// Creates a new root layout with empty root type.
+    pub fn new_empty<L>(root_key: LayoutKey, layout: L) -> Self
+    where
+        L: Into<Layout<F>>,
+    {
+        Self::new::<(), L>(root_key, layout)
     }
 
     /// Returns the root key of the sub-tree.
@@ -173,6 +188,11 @@ where
     /// Returns the storage layout of the unbounded layout elements.
     pub fn layout(&self) -> &Layout<F> {
         &self.layout
+    }
+
+    /// Returns the type of the encoded entity.
+    pub fn ty(&self) -> &F::Type {
+        &self.ty
     }
 }
 

--- a/crates/metadata/src/layout/mod.rs
+++ b/crates/metadata/src/layout/mod.rs
@@ -154,32 +154,33 @@ impl IntoPortable for RootLayout {
     }
 }
 
-impl<F> RootLayout<F>
-where
-    F: Form,
-    F::Type: From<MetaType>,
-{
+impl RootLayout<MetaForm> {
     /// Creates a new root layout.
     pub fn new<Root, L>(root_key: LayoutKey, layout: L) -> Self
     where
         Root: TypeInfo + 'static,
-        L: Into<Layout<F>>,
+        L: Into<Layout<MetaForm>>,
     {
         Self {
             root_key,
             layout: Box::new(layout.into()),
-            ty: meta_type::<Root>().into(),
+            ty: meta_type::<Root>(),
         }
     }
 
     /// Creates a new root layout with empty root type.
     pub fn new_empty<L>(root_key: LayoutKey, layout: L) -> Self
     where
-        L: Into<Layout<F>>,
+        L: Into<Layout<MetaForm>>,
     {
         Self::new::<(), L>(root_key, layout)
     }
+}
 
+impl<F> RootLayout<F>
+where
+    F: Form,
+{
     /// Returns the root key of the sub-tree.
     pub fn root_key(&self) -> &LayoutKey {
         &self.root_key

--- a/crates/metadata/src/layout/validate.rs
+++ b/crates/metadata/src/layout/validate.rs
@@ -108,11 +108,11 @@ mod tests {
     #[test]
     fn valid_layout_tree_only_roots() {
         // Root(0) -> Root(1) -> Root(2) -> u32
-        let layout = RootLayout::new(
+        let layout = RootLayout::new_empty(
             0.into(),
-            RootLayout::new(
+            RootLayout::new_empty(
                 1.into(),
-                RootLayout::new(2.into(), LeafLayout::from_key::<u32>(2.into())),
+                RootLayout::new_empty(2.into(), LeafLayout::from_key::<u32>(2.into())),
             ),
         );
 
@@ -149,7 +149,7 @@ mod tests {
         //                           Root(4)      String
         //                             |
         //                      g:BTreeSet<u64>(4)
-        let layout = RootLayout::new(
+        let layout = RootLayout::new_empty(
             root_0,
             StructLayout::new(
                 "Contract",
@@ -162,7 +162,7 @@ mod tests {
                                 FieldLayout::new("d", LeafLayout::from_key::<u128>(root_0)),
                                 FieldLayout::new(
                                     "f",
-                                    RootLayout::new(
+                                    RootLayout::new_empty(
                                         root_2,
                                         EnumLayout::new(
                                             "Enum",
@@ -178,7 +178,7 @@ mod tests {
                                                                 "Struct1",
                                                                 vec![FieldLayout::new(
                                                                     "g",
-                                                                    RootLayout::new(
+                                                                    RootLayout::new_empty(
                                                                         root_4,
                                                                         LeafLayout::from_key::<
                                                                             BTreeSet<u64>,
@@ -207,7 +207,7 @@ mod tests {
                                                         "Third",
                                                         vec![FieldLayout::new(
                                                             "0",
-                                                            RootLayout::new(
+                                                            RootLayout::new_empty(
                                                                 root_3,
                                                                 LeafLayout::from_key::<String>(
                                                                     root_3,
@@ -226,7 +226,7 @@ mod tests {
                     FieldLayout::new("b", LeafLayout::from_key::<u32>(root_0)),
                     FieldLayout::new(
                         "c",
-                        RootLayout::new(root_1, LeafLayout::from_key::<Vec<u8>>(root_1)),
+                        RootLayout::new_empty(root_1, LeafLayout::from_key::<Vec<u8>>(root_1)),
                     ),
                 ],
             ),

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -255,7 +255,7 @@ const _: () = {
         KeyType: StorageKey + scale_info::TypeInfo + 'static,
     {
         fn layout(_: &Key) -> Layout {
-            Layout::Root(RootLayout::new(
+            Layout::Root(RootLayout::new::<Self, _>(
                 LayoutKey::from(&KeyType::KEY),
                 <V as StorageLayout>::layout(&KeyType::KEY),
             ))

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -209,7 +209,7 @@ const _: () = {
         KeyType: StorageKey + scale_info::TypeInfo + 'static,
     {
         fn layout(_: &Key) -> Layout {
-            Layout::Root(RootLayout::new(
+            Layout::Root(RootLayout::new::<Self, _>(
                 LayoutKey::from(&KeyType::KEY),
                 <V as StorageLayout>::layout(&KeyType::KEY),
             ))


### PR DESCRIPTION
Fixes https://github.com/paritytech/ink/issues/1770

<img width="840" alt="image" src="https://github.com/paritytech/ink/assets/18346821/5ab5f65b-a1ff-48be-83ee-a642a1c6f1d8">
<img width="894" alt="image" src="https://github.com/paritytech/ink/assets/18346821/93d3fafe-bfd8-4f5a-9c66-f102a3ad675e">
