### PR TITLE
impl From<Hash> for [u8; 32]

### DIFF
--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -118,6 +118,12 @@ impl AsMut<[u8]> for Hash {
     }
 }
 
+impl From<Hash> for [u8; 32] {
+    fn from(hash: Hash) -> Self {
+        hash.0
+    }
+}
+
 /// The equivalent of `Zero` for hashes.
 ///
 /// A hash that consists only of 0 bits is clear.


### PR DESCRIPTION
Sometimes, we need to convert the `ink::primitives::Hash` to `[u8; 32]` or to the runtime Hash type in the chain extension. I don't find an elegant way to do so. It should be better to make it able to be converted to `[u8; 32]`.