### PR TITLE
Update `subxt`, `scale-*` and `sp-*` dependencies

### DIFF
--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -21,7 +21,7 @@ ink_env = { version = "4.2.0", path = "../env" }
 ink_primitives = { version = "4.2.0", path = "../primitives" }
 
 funty = "2.0.0"
-impl-serde = { version = "0.3.1", default-features = false }
+impl-serde = { version = "0.4.0", default-features = false }
 jsonrpsee = { version = "0.18.0", features = ["ws-client"] }
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.81" }
@@ -29,14 +29,14 @@ tokio = { version = "1.18.2", features = ["rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-subxt = "0.28.0"
+subxt = "0.29.0"
 
 # Substrate
 pallet-contracts-primitives = "23.0.0"
-sp-core = "20.0.0"
-sp-keyring = "23.0.0"
-sp-runtime = "23.0.0"
-sp-weights = "19.0.0"
+sp-core = "21.0.0"
+sp-keyring = "24.0.0"
+sp-runtime = "24.0.0"
+sp-weights = "20.0.0"
 
 [dev-dependencies]
 # Required for the doctest of `MessageBuilder::call`

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -36,7 +36,7 @@ pallet-contracts-primitives = "23.0.0"
 sp-core = "21.0.0"
 sp-keyring = "24.0.0"
 sp-runtime = "24.0.0"
-sp-weights = "20.0.0"
+sp-weights = "19.0.0"
 
 [dev-dependencies]
 # Required for the doctest of `MessageBuilder::call`

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -33,7 +33,7 @@ subxt = "0.29.0"
 
 # Substrate
 pallet-contracts-primitives = "23.0.0"
-sp-core = "21.0.0"
+sp-core = { version = "21.0.0", default-features = false }
 sp-keyring = "24.0.0"
 sp-runtime = "24.0.0"
 sp-weights = "19.0.0"

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -32,11 +32,11 @@ scale = { package = "parity-scale-codec", version = "3.4", default-features = fa
 subxt = "0.29.0"
 
 # Substrate
-pallet-contracts-primitives = "23.0.0"
+pallet-contracts-primitives = "24.0.0"
 sp-core = { version = "21.0.0", default-features = false }
 sp-keyring = "24.0.0"
 sp-runtime = "24.0.0"
-sp-weights = "19.0.0"
+sp-weights = "20.0.0"
 
 [dev-dependencies]
 # Required for the doctest of `MessageBuilder::call`

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -81,7 +81,7 @@ pub struct InstantiationResult<C: subxt::Config, E: Environment> {
     pub account_id: E::AccountId,
     /// The result of the dry run, contains debug messages
     /// if there were any.
-    pub dry_run: ContractInstantiateResult<C::AccountId, E::Balance>,
+    pub dry_run: ContractInstantiateResult<C::AccountId, E::Balance, ()>,
     /// Events that happened with the contract instantiation.
     pub events: ExtrinsicEvents<C>,
 }
@@ -227,7 +227,7 @@ where
 pub struct CallDryRunResult<E: Environment, V> {
     /// The result of the dry run, contains debug messages
     /// if there were any.
-    pub exec_result: ContractExecResult<E::Balance>,
+    pub exec_result: ContractExecResult<E::Balance, ()>,
     _marker: PhantomData<V>,
 }
 
@@ -307,7 +307,7 @@ where
     /// No contract with the given name found in scope.
     ContractNotFound(String),
     /// The `instantiate_with_code` dry run failed.
-    InstantiateDryRun(ContractInstantiateResult<C::AccountId, E::Balance>),
+    InstantiateDryRun(ContractInstantiateResult<C::AccountId, E::Balance, ()>),
     /// The `instantiate_with_code` extrinsic failed.
     InstantiateExtrinsic(subxt::error::DispatchError),
     /// The `upload` dry run failed.
@@ -315,7 +315,7 @@ where
     /// The `upload` extrinsic failed.
     UploadExtrinsic(subxt::error::DispatchError),
     /// The `call` dry run failed.
-    CallDryRun(ContractExecResult<E::Balance>),
+    CallDryRun(ContractExecResult<E::Balance, ()>),
     /// The `call` extrinsic failed.
     CallExtrinsic(subxt::error::DispatchError),
     /// Error fetching account balance.
@@ -534,7 +534,7 @@ where
         constructor: CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> ContractInstantiateResult<C::AccountId, E::Balance>
+    ) -> ContractInstantiateResult<C::AccountId, E::Balance, ()>
     where
         Args: scale::Encode,
     {

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -64,6 +64,7 @@ use subxt::{
         },
     },
     tx::PairSigner,
+    Config,
 };
 
 /// Represents an initialized contract message builder.
@@ -992,6 +993,6 @@ where
 }
 
 /// Returns true if the give event is System::Extrinsic failed.
-fn is_extrinsic_failed_event(event: &EventDetails) -> bool {
+fn is_extrinsic_failed_event<C: Config>(event: &EventDetails<C>) -> bool {
     event.pallet_name() == "System" && event.variant_name() == "ExtrinsicFailed"
 }

--- a/crates/e2e/src/node_proc.rs
+++ b/crates/e2e/src/node_proc.rs
@@ -116,8 +116,7 @@ where
             .stdout(process::Stdio::piped())
             .stderr(process::Stdio::piped())
             .arg("--port=0")
-            .arg("--rpc-port=0")
-            .arg("--ws-port=0");
+            .arg("--rpc-port=0");
 
         if let Some(authority) = self.authority {
             let authority = format!("{authority:?}");
@@ -174,7 +173,7 @@ fn find_substrate_port_from_output(r: impl Read + Send + 'static) -> u16 {
             let line_end = line
                 .rsplit_once("Listening for new connections on 127.0.0.1:")
                 .or_else(|| {
-                    line.rsplit_once("Running JSON-RPC WS server: addr=127.0.0.1:")
+                    line.rsplit_once("Running JSON-RPC server: addr=127.0.0.1:")
                 })
                 .map(|(_, port_str)| port_str)?;
 

--- a/crates/e2e/src/node_proc.rs
+++ b/crates/e2e/src/node_proc.rs
@@ -172,9 +172,7 @@ fn find_substrate_port_from_output(r: impl Read + Send + 'static) -> u16 {
             // substrate).
             let line_end = line
                 .rsplit_once("Listening for new connections on 127.0.0.1:")
-                .or_else(|| {
-                    line.rsplit_once("Running JSON-RPC server: addr=127.0.0.1:")
-                })
+                .or_else(|| line.rsplit_once("Running JSON-RPC server: addr=127.0.0.1:"))
                 .map(|(_, port_str)| port_str)?;
 
             // trim non-numeric chars from the end of the port part of the line.

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -267,7 +267,7 @@ where
         data: Vec<u8>,
         salt: Vec<u8>,
         signer: &Signer<C>,
-    ) -> ContractInstantiateResult<C::AccountId, E::Balance> {
+    ) -> ContractInstantiateResult<C::AccountId, E::Balance, ()> {
         let code = Code::Upload(code);
         let call_request = RpcInstantiateRequest::<C, E> {
             origin: subxt::tx::Signer::account_id(signer).clone(),
@@ -419,7 +419,7 @@ where
         input_data: Vec<u8>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> ContractExecResult<E::Balance> {
+    ) -> ContractExecResult<E::Balance, ()> {
         let call_request = RpcCallRequest::<C, E> {
             origin,
             dest,

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -47,8 +47,8 @@ secp256k1 = { version = "0.27.0", features = ["recovery", "global-context"], opt
 #
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside the off-chain environment!
-scale-decode = { version = "0.5.0", default-features = false, optional = true }
-scale-encode = { version = "0.1.0", default-features = false, optional = true }
+scale-decode = { version = "0.7.0", default-features = false, optional = true }
+scale-encode = { version = "0.3.0", default-features = false, optional = true }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -18,8 +18,8 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 ink_prelude = { version = "4.2.0", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-scale-decode = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
-scale-encode = { version = "0.1.0", default-features = false, features = ["derive"], optional = true }
+scale-decode = { version = "0.7.0", default-features = false, features = ["derive"], optional = true }
+scale-encode = { version = "0.3.0", default-features = false, features = ["derive"], optional = true }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", features = ["const_xxh32"] }
 

--- a/integration-tests/call-runtime/Cargo.toml
+++ b/integration-tests/call-runtime/Cargo.toml
@@ -17,8 +17,8 @@ scale-info = { version = "2.6", default-features = false, features = ["derive"],
 # (especially for global allocator).
 #
 # See also: https://substrate.stackexchange.com/questions/4733/error-when-compiling-a-contract-using-the-xcm-chain-extension.
-sp-io = { version = "22.0.0", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
-sp-runtime = { version = "23.0.0", default-features = false }
+sp-io = { version = "23.0.0", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-runtime = { version = "24.0.0", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -13,7 +13,7 @@ scale-info = { version = "2.6", default-features = false, features = ["derive"],
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }
-subxt = { version = "0.28.0", default-features = false }
+subxt = { version = "0.29.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/payment-channel/Cargo.toml
+++ b/integration-tests/payment-channel/Cargo.toml
@@ -13,7 +13,7 @@ scale-info = { version = "2.6", default-features = false, features = ["derive"],
 
 [dev-dependencies]
 hex-literal = { version = "0.3" }
-sp-core = "6.0.0"
+sp-core = { version = "21.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/payment-channel/Cargo.toml
+++ b/integration-tests/payment-channel/Cargo.toml
@@ -12,7 +12,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
-hex-literal = { version = "0.3" }
+hex-literal = { version = "0.4.1" }
 sp-core = { version = "21.0.0", default-features = false }
 
 [lib]
@@ -24,6 +24,7 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
+    "sp-core/std",
 ]
 
 ink-as-dependency = []


### PR DESCRIPTION
Compatible with https://github.com/paritytech/substrate-contracts-node/releases/tag/v0.27.0

Also updates to latest `pallet-contract-primitives` release, and fixes compilation errors with new `EventRecord` type parameter on the result types.

Note for now we are using `()` as the `EventRecord` type, so the events decoding itself will be skipped, and the dry-run events will not be used. This is because at the moment we don't have a top level `Event` type available to us for decoding. For that we would need to use the `subxt` macro again to get the generated `Event` type which would couple us tightly to a specific version of `substrate-contracts-node`. While the dry-run events would be useful, we will defer this work for a future PR.