### PR TITLE
Revert "Fix ui tests for Rust 1.70 (#1797)"

### DIFF
--- a/crates/ink/tests/ui/contract/fail/impl-block-using-env-no-marker.stderr
+++ b/crates/ink/tests/ui/contract/fail/impl-block-using-env-no-marker.stderr
@@ -7,5 +7,5 @@ error[E0599]: no method named `env` found for reference `&Contract` in the curre
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
-1  + use ink::codegen::Env;
+1  | use ink::codegen::Env;
    |

--- a/crates/ink/tests/ui/contract/fail/impl-block-using-static-env-no-marker.stderr
+++ b/crates/ink/tests/ui/contract/fail/impl-block-using-static-env-no-marker.stderr
@@ -10,5 +10,5 @@ error[E0599]: no function or associated item named `env` found for struct `Contr
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
-1  + use ink::codegen::StaticEnv;
+1  | use ink::codegen::StaticEnv;
    |

--- a/crates/ink/tests/ui/trait_def/fail/message_input_non_codec.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/message_input_non_codec.stderr
@@ -45,7 +45,9 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call
  --> tests/ui/trait_def/fail/message_input_non_codec.rs:5:5
   |
 5 |     #[ink(message)]
-  |     ^ method cannot be called due to unsatisfied trait bounds
+  |     ^
+  |     |
+  |     method cannot be called due to unsatisfied trait bounds
   |
  ::: $WORKSPACE/crates/env/src/call/execution_input.rs
   |

--- a/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
@@ -28,7 +28,9 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call
   | ------------------- doesn't satisfy `NonCodec: parity_scale_codec::Decode`
 ...
 5 |     #[ink(message)]
-  |     ^ method cannot be called due to unsatisfied trait bounds
+  |     ^
+  |     |
+  |     method cannot be called due to unsatisfied trait bounds
   |
   = note: the following trait bounds were not satisfied:
           `NonCodec: parity_scale_codec::Decode`


### PR DESCRIPTION
This reverts commit 54a9fea6c2736ed604d4b1f2022fdb994e6cd5c0.

Some contracts do not build with `1.70` because of `sign-ext` instruction see https://github.com/paritytech/cargo-contract/issues/1139