### PR TITLE
Pin inter crate dependencies to specific version

### DIFF
--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_e2e_macro = { version = "4.2.0", path = "./macro" }
-ink = { version = "4.2.0", path = "../ink" }
-ink_env = { version = "4.2.0", path = "../env" }
-ink_primitives = { version = "4.2.0", path = "../primitives" }
+ink_e2e_macro = { version = "=4.2.0", path = "./macro" }
+ink = { version = "=4.2.0", path = "../ink" }
+ink_env = { version = "=4.2.0", path = "../env" }
+ink_primitives = { version = "=4.2.0", path = "../primitives" }
 
 funty = "2.0.0"
 impl-serde = { version = "0.3.1", default-features = false }

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -19,7 +19,7 @@ name = "ink_e2e_macro"
 proc-macro = true
 
 [dependencies]
-ink_ir = { version = "4.2.0", path = "../../ink/ir" }
+ink_ir = { version = "=4.2.0", path = "../../ink/ir" }
 cargo_metadata = "0.15.3"
 contract-build = "3.0.0"
 derive_more = "0.99.17"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_primitives = { version = "4.2.0", path = "../../crates/primitives", default-features = false }
+ink_primitives = { version = "=4.2.0", path = "../../crates/primitives", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -16,10 +16,10 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_allocator = { version = "4.2.0", path = "../allocator", default-features = false }
-ink_storage_traits = { version = "4.2.0", path = "../storage/traits", default-features = false }
-ink_prelude = { version = "4.2.0", path = "../prelude", default-features = false }
-ink_primitives = { version = "4.2.0", path = "../primitives", default-features = false }
+ink_allocator = { version = "=4.2.0", path = "../allocator", default-features = false }
+ink_storage_traits = { version = "=4.2.0", path = "../storage/traits", default-features = false }
+ink_prelude = { version = "=4.2.0", path = "../prelude", default-features = false }
+ink_primitives = { version = "=4.2.0", path = "../primitives", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -33,7 +33,7 @@ static_assertions = "1.1"
 rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ink_engine = { version = "4.2.0", path = "../engine/", optional = true }
+ink_engine = { version = "=4.2.0", path = "../engine/", optional = true }
 
 # Hashes for the off-chain environment.
 sha2 = { version = "0.10", optional = true }

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -16,12 +16,12 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.2.0", path = "../env", default-features = false }
-ink_storage = { version = "4.2.0", path = "../storage", default-features = false }
-ink_primitives = { version = "4.2.0", path = "../primitives", default-features = false }
-ink_metadata = { version = "4.2.0", path = "../metadata", default-features = false, optional = true }
-ink_prelude = { version = "4.2.0", path = "../prelude", default-features = false }
-ink_macro = { version = "4.2.0", path = "macro", default-features = false }
+ink_env = { version = "=4.2.0", path = "../env", default-features = false }
+ink_storage = { version = "=4.2.0", path = "../storage", default-features = false }
+ink_primitives = { version = "=4.2.0", path = "../primitives", default-features = false }
+ink_metadata = { version = "=4.2.0", path = "../metadata", default-features = false, optional = true }
+ink_prelude = { version = "=4.2.0", path = "../prelude", default-features = false }
+ink_macro = { version = "=4.2.0", path = "macro", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -18,8 +18,8 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 name = "ink_codegen"
 
 [dependencies]
-ink_primitives = { version = "4.2.0", path = "../../primitives" }
-ir = { version = "4.2.0", package = "ink_ir", path = "../ir", default-features = false }
+ink_primitives = { version = "=4.2.0", path = "../../primitives" }
+ir = { version = "=4.2.0", package = "ink_ir", path = "../ir", default-features = false }
 quote = "1"
 syn = { version = "2.0", features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = "1.0"

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -15,9 +15,9 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_ir = { version = "4.2.0", path = "../ir", default-features = false }
-ink_codegen = { version = "4.2.0", path = "../codegen", default-features = false }
-ink_primitives = { version = "4.2.0", path = "../../primitives/", default-features = false }
+ink_ir = { version = "=4.2.0", path = "../ir", default-features = false }
+ink_codegen = { version = "=4.2.0", path = "../codegen", default-features = false }
+ink_primitives = { version = "=4.2.0", path = "../../primitives/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 syn = "2"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "4.2.0", path = "../prelude/", default-features = false }
-ink_primitives = { version = "4.2.0", path = "../primitives/", default-features = false }
+ink_prelude = { version = "=4.2.0", path = "../prelude/", default-features = false }
+ink_primitives = { version = "=4.2.0", path = "../primitives/", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.4.0"

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -16,7 +16,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-ink_prelude = { version = "4.2.0", path = "../prelude/", default-features = false }
+ink_prelude = { version = "=4.2.0", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-decode = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
 scale-encode = { version = "0.1.0", default-features = false, features = ["derive"], optional = true }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.2.0", path = "../env/", default-features = false }
-ink_metadata = { version = "4.2.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.2.0", path = "../primitives/", default-features = false }
-ink_storage_traits = { version = "4.2.0", path = "traits", default-features = false }
-ink_prelude = { version = "4.2.0", path = "../prelude/", default-features = false }
+ink_env = { version = "=4.2.0", path = "../env/", default-features = false }
+ink_metadata = { version = "=4.2.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "=4.2.0", path = "../primitives/", default-features = false }
+ink_storage_traits = { version = "=4.2.0", path = "traits", default-features = false }
+ink_prelude = { version = "=4.2.0", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -15,9 +15,9 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "4.2.0", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.2.0", path = "../../primitives", default-features = false }
-ink_prelude = { version = "4.2.0", path = "../../prelude", default-features = false }
+ink_metadata = { version = "=4.2.0", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "=4.2.0", path = "../../primitives", default-features = false }
+ink_prelude = { version = "=4.2.0", path = "../../prelude", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 


### PR DESCRIPTION
Raised by @deuszx.

Currently dependencies between the `ink` crates are specified with a range i.e. `4.2.0` which means `>= 4.2.0, <5.0`.

This means that when we released `4.2.1` recently, and contracts with an `ink` dependency of `4.2.0` could pull in the new versions sub crates.

This PR pins the versions of the inter-crate dependencies of all the `ink` crates, since they are always released together.