### PR TITLE
[🦖 T-Rex]  Pin `parity-scale-codec-derive` to `3.1.4`

### DIFF
--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -616,8 +616,8 @@ where
     ///         .params();
     ///     self.env()
     ///         .invoke_contract_delegate(&call_params)
-    ///         .unwrap_or_else(|env_err| {
-    ///             panic!("Received an error from the Environment: {:?}", env_err)
+    ///         .unwrap_or_else(|env_error| {
+    ///             panic!("Received an error from the Environment: {:?}", env_error)
     ///         })
     ///         .unwrap_or_else(|lang_err| panic!("Received a `LangError`: {:?}", lang_err))
     /// }

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -616,8 +616,8 @@ where
     ///         .params();
     ///     self.env()
     ///         .invoke_contract_delegate(&call_params)
-    ///         .unwrap_or_else(|err| {
-    ///             panic!("Received an error from the Environment: {:?}", err)
+    ///         .unwrap_or_else(|env_err| {
+    ///             panic!("Received an error from the Environment: {:?}", env_err)
     ///         })
     ///         .unwrap_or_else(|lang_err| panic!("Received a `LangError`: {:?}", lang_err))
     /// }

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -616,8 +616,8 @@ where
     ///         .params();
     ///     self.env()
     ///         .invoke_contract_delegate(&call_params)
-    ///         .unwrap_or_else(|env_err| {
-    ///             panic!("Received an error from the Environment: {:?}", env_err)
+    ///         .unwrap_or_else(|err| {
+    ///             panic!("Received an error from the Environment: {:?}", err)
     ///         })
     ///         .unwrap_or_else(|lang_err| panic!("Received a `LangError`: {:?}", lang_err))
     /// }

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -616,8 +616,8 @@ where
     ///         .params();
     ///     self.env()
     ///         .invoke_contract_delegate(&call_params)
-    ///         .unwrap_or_else(|env_error| {
-    ///             panic!("Received an error from the Environment: {:?}", env_error)
+    ///         .unwrap_or_else(|env_err| {
+    ///             panic!("Received an error from the Environment: {:?}", env_err)
     ///         })
     ///         .unwrap_or_else(|lang_err| panic!("Received a `LangError`: {:?}", lang_err))
     /// }

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -17,6 +17,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 [dependencies]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 ink_prelude = { version = "4.2.0", path = "../prelude/", default-features = false }
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-decode = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
 scale-encode = { version = "0.1.0", default-features = false, features = ["derive"], optional = true }

--- a/integration-tests/basic-contract-caller/Cargo.toml
+++ b/integration-tests/basic-contract-caller/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/basic-contract-caller/other-contract/Cargo.toml
+++ b/integration-tests/basic-contract-caller/other-contract/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/call-runtime/Cargo.toml
+++ b/integration-tests/call-runtime/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/conditional-compilation/Cargo.toml
+++ b/integration-tests/conditional-compilation/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/contract-terminate/Cargo.toml
+++ b/integration-tests/contract-terminate/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/contract-transfer/Cargo.toml
+++ b/integration-tests/contract-transfer/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/custom-allocator/Cargo.toml
+++ b/integration-tests/custom-allocator/Cargo.toml
@@ -13,6 +13,7 @@ ink = { path = "../../crates/ink", default-features = false, features = ["no-all
 # This is going to be our new global memory allocator.
 dlmalloc = {version = "0.2", default-features = false, features = ["global"] }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/custom-environment/Cargo.toml
+++ b/integration-tests/custom-environment/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/dns/Cargo.toml
+++ b/integration-tests/dns/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/erc1155/Cargo.toml
+++ b/integration-tests/erc1155/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/erc20/Cargo.toml
+++ b/integration-tests/erc20/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/erc721/Cargo.toml
+++ b/integration-tests/erc721/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/flipper/Cargo.toml
+++ b/integration-tests/flipper/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/incrementer/Cargo.toml
+++ b/integration-tests/incrementer/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/mapping-integration-tests/Cargo.toml
+++ b/integration-tests/mapping-integration-tests/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/mother/Cargo.toml
+++ b/integration-tests/mother/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/multi-contract-caller/Cargo.toml
+++ b/integration-tests/multi-contract-caller/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/multi-contract-caller/accumulator/Cargo.toml
+++ b/integration-tests/multi-contract-caller/accumulator/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/multi-contract-caller/adder/Cargo.toml
+++ b/integration-tests/multi-contract-caller/adder/Cargo.toml
@@ -9,6 +9,7 @@ ink = { path = "../../../crates/ink", default-features = false }
 
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/multi-contract-caller/subber/Cargo.toml
+++ b/integration-tests/multi-contract-caller/subber/Cargo.toml
@@ -9,6 +9,7 @@ ink = { path = "../../../crates/ink", default-features = false }
 
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/multisig/Cargo.toml
+++ b/integration-tests/multisig/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/payment-channel/Cargo.toml
+++ b/integration-tests/payment-channel/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/psp22-extension/Cargo.toml
+++ b/integration-tests/psp22-extension/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/rand-extension/Cargo.toml
+++ b/integration-tests/rand-extension/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/set-code-hash/Cargo.toml
+++ b/integration-tests/set-code-hash/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/set-code-hash/updated-incrementer/Cargo.toml
+++ b/integration-tests/set-code-hash/updated-incrementer/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/trait-dyn-cross-contract-calls/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/trait-erc20/Cargo.toml
+++ b/integration-tests/trait-erc20/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/trait-flipper/Cargo.toml
+++ b/integration-tests/trait-flipper/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/trait-incrementer/Cargo.toml
+++ b/integration-tests/trait-incrementer/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 traits = { path = "./traits", default-features = false }

--- a/integration-tests/trait-incrementer/traits/Cargo.toml
+++ b/integration-tests/trait-incrementer/traits/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/wildcard-selector/Cargo.toml
+++ b/integration-tests/wildcard-selector/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
+parity-scale-codec-derive = { version = "=3.1.4", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 


### PR DESCRIPTION
Temporary solution until https://github.com/paritytech/parity-scale-codec/issues/454 gets released 