### PR TITLE
Show docs for Result type aliases

### DIFF
--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -58,9 +58,7 @@ pub enum LangError {
 }
 
 /// The `Result` type for ink! messages.
-#[doc(hidden)]
 pub type MessageResult<T> = ::core::result::Result<T, LangError>;
 
 /// The `Result` type for ink! constructors.
-#[doc(hidden)]
 pub type ConstructorResult<T> = ::core::result::Result<T, LangError>;


### PR DESCRIPTION
At the moment where these type aliases are used, you cannot navigate to the definition e.g. https://docs.rs/ink_env/4.2.1/ink_env/fn.invoke_contract.html.

This PR removes the `#[doc(hidden)]` so those types are shown now in the `ink_primitives` crate.