### PR TITLE
Minor refactors in e2e crate

### DIFF
--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -155,7 +155,7 @@ impl InkE2ETest {
 
                 let run = async {
                     // spawn a contracts node process just for this test
-                    let node_proc = ::ink_e2e::TestNodeProcess::<::subxt::PolkadotConfig>
+                    let node_proc = ::ink_e2e::TestNodeProcess::<::ink_e2e::PolkadotConfig>
                         ::build(#contracts_node)
                         .spawn()
                         .await
@@ -164,7 +164,7 @@ impl InkE2ETest {
                         );
 
                     let mut client = ::ink_e2e::Client::<
-                        ::subxt::PolkadotConfig,
+                        ::ink_e2e::PolkadotConfig,
                         #environment
                     >::new(
                         node_proc.client(),

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -151,7 +151,7 @@ impl InkE2ETest {
 
                 let run = async {
                     // spawn a contracts node process just for this test
-                    let node_proc = ::ink_e2e::TestNodeProcess::<::ink_e2e::PolkadotConfig>
+                    let node_proc = ::ink_e2e::TestNodeProcess::<::subxt::PolkadotConfig>
                         ::build(#contracts_node)
                         .spawn()
                         .await
@@ -160,7 +160,7 @@ impl InkE2ETest {
                         );
 
                     let mut client = ::ink_e2e::Client::<
-                        ::ink_e2e::PolkadotConfig,
+                        ::subxt::PolkadotConfig,
                         #environment
                     >::new(
                         node_proc.client(),

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -26,8 +26,9 @@ use std::{
     sync::Once,
 };
 
-/// We use this to initialize the tracing subscriber only once.
-static INIT_ONCE: Once = Once::new();
+/// We use this to only build the contracts once for all tests, at the
+/// time of generating the Rust code for the tests, so at compile time.
+static BUILD_ONCE: Once = Once::new();
 
 thread_local! {
     // We save a mapping of `contract_manifest_path` to the built `*.contract` files.
@@ -64,8 +65,6 @@ impl InkE2ETest {
             return quote! {}
         }
 
-        INIT_ONCE.call_once(tracing_subscriber::fmt::init);
-
         let item_fn = &self.test.item_fn.item_fn;
         let fn_name = &item_fn.sig.ident;
         let block = &item_fn.block;
@@ -99,15 +98,28 @@ impl InkE2ETest {
             };
 
         let mut already_built_contracts = already_built_contracts();
-        // Some contracts have already been built and we check if the
-        // `additional_contracts` for this particular test contain ones
-        // that haven't been build before
-        for manifest_path in contracts_to_build_and_import {
-            already_built_contracts
-                .entry(manifest_path.clone())
-                .or_insert_with(|| build_contract(&manifest_path));
+        if already_built_contracts.is_empty() {
+            // Build all of them for the first time and initialize everything
+            BUILD_ONCE.call_once(|| {
+                tracing_subscriber::fmt::init();
+                for manifest_path in contracts_to_build_and_import {
+                    let dest_wasm = build_contract(&manifest_path);
+                    let _ = already_built_contracts.insert(manifest_path, dest_wasm);
+                }
+                set_already_built_contracts(already_built_contracts.clone());
+            });
+        } else if !already_built_contracts.is_empty() {
+            // Some contracts have already been built and we check if the
+            // `additional_contracts` for this particular test contain ones
+            // that haven't been build before
+            for manifest_path in contracts_to_build_and_import {
+                if already_built_contracts.get(&manifest_path).is_none() {
+                    let dest_wasm = build_contract(&manifest_path);
+                    let _ = already_built_contracts.insert(manifest_path, dest_wasm);
+                }
+            }
+            set_already_built_contracts(already_built_contracts.clone());
         }
-        set_already_built_contracts(already_built_contracts.clone());
 
         assert!(
             !already_built_contracts.is_empty(),

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -15,17 +15,12 @@
 use ink_ir::{
     ast,
     format_err_spanned,
-    utils::{
-        duplicate_config_err,
-        WhitelistedAttributes,
-    },
+    utils::duplicate_config_err,
 };
 
 /// The End-to-End test configuration.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct E2EConfig {
-    /// The set of attributes that can be passed to call builder in the codegen.
-    whitelisted_attributes: WhitelistedAttributes,
     /// Additional contracts that have to be built before executing the test.
     additional_contracts: Vec<String>,
     /// The [`Environment`](https://docs.rs/ink_env/4.1.0/ink_env/trait.Environment.html) to use
@@ -41,14 +36,11 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
     type Error = syn::Error;
 
     fn try_from(args: ast::AttributeArgs) -> Result<Self, Self::Error> {
-        let mut whitelisted_attributes = WhitelistedAttributes::default();
         let mut additional_contracts: Option<(syn::LitStr, ast::MetaNameValue)> = None;
         let mut environment: Option<(syn::Path, ast::MetaNameValue)> = None;
 
         for arg in args.into_iter() {
-            if arg.name.is_ident("keep_attr") {
-                whitelisted_attributes.parse_arg_value(&arg)?;
-            } else if arg.name.is_ident("additional_contracts") {
+            if arg.name.is_ident("additional_contracts") {
                 if let Some((_, ast)) = additional_contracts {
                     return Err(duplicate_config_err(
                         ast,
@@ -91,7 +83,6 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
 
         Ok(E2EConfig {
             additional_contracts,
-            whitelisted_attributes,
             environment,
         })
     }
@@ -197,38 +188,12 @@ mod tests {
                 environment = crate::CustomEnvironment,
             },
             Ok(E2EConfig {
-                whitelisted_attributes: Default::default(),
                 additional_contracts: vec![
                     "adder/Cargo.toml".into(),
                     "flipper/Cargo.toml".into(),
                 ],
                 environment: Some(syn::parse_quote! { crate::CustomEnvironment }),
             }),
-        );
-    }
-
-    #[test]
-    fn keep_attr_works() {
-        let mut attrs = WhitelistedAttributes::default();
-        attrs.0.insert("foo".to_string(), ());
-        attrs.0.insert("bar".to_string(), ());
-        assert_try_from(
-            syn::parse_quote! {
-                keep_attr = "foo, bar"
-            },
-            Ok(E2EConfig {
-                whitelisted_attributes: attrs,
-                additional_contracts: Vec::new(),
-                environment: None,
-            }),
-        )
-    }
-
-    #[test]
-    fn keep_attr_invalid_value_fails() {
-        assert_try_from(
-            syn::parse_quote! { keep_attr = 1u16 },
-            Err("expected a string with attributes separated by `,`"),
         );
     }
 }

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -61,32 +61,6 @@ use std::{
 };
 use xts::ContractsApi;
 
-/// Default set of commonly used types by Substrate runtimes.
-#[cfg(feature = "std")]
-pub enum SubstrateConfig {}
-
-#[cfg(feature = "std")]
-impl subxt::Config for SubstrateConfig {
-    type Index = u32;
-    type Hash = sp_core::H256;
-    type Hasher = subxt::config::substrate::BlakeTwo256;
-    type AccountId = subxt::config::substrate::AccountId32;
-    type Address = sp_runtime::MultiAddress<Self::AccountId, u32>;
-    type Header = subxt::config::substrate::SubstrateHeader<
-        u32,
-        subxt::config::substrate::BlakeTwo256,
-    >;
-    type Signature = sp_runtime::MultiSignature;
-    type ExtrinsicParams = subxt::config::substrate::SubstrateExtrinsicParams<Self>;
-}
-
-/// Default set of commonly used types by Polkadot nodes.
-#[cfg(feature = "std")]
-pub type PolkadotConfig = subxt::config::WithExtrinsicParams<
-    SubstrateConfig,
-    subxt::config::polkadot::PolkadotExtrinsicParams<SubstrateConfig>,
->;
-
 /// Signer that is used throughout the E2E testing.
 ///
 /// The E2E testing can only be used with nodes that support `sr25519`

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -61,6 +61,8 @@ use std::{
 };
 use xts::ContractsApi;
 
+pub use subxt::PolkadotConfig;
+
 /// Signer that is used throughout the E2E testing.
 ///
 /// The E2E testing can only be used with nodes that support `sr25519`

--- a/crates/ink/tests/ui/contract/fail/message-returns-non-codec.stderr
+++ b/crates/ink/tests/ui/contract/fail/message-returns-non-codec.stderr
@@ -46,7 +46,7 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvi
    = note: the following trait bounds were not satisfied:
            `NonCodecType: parity_scale_codec::Decode`
 note: the trait `parity_scale_codec::Decode` must be implemented
-  --> $CARGO/parity-scale-codec-3.6.1/src/codec.rs
+  --> $CARGO/parity-scale-codec-3.6.2/src/codec.rs
    |
    | pub trait Decode: Sized {
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/ink/tests/ui/contract/fail/message-returns-non-codec.stderr
+++ b/crates/ink/tests/ui/contract/fail/message-returns-non-codec.stderr
@@ -46,7 +46,7 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvi
    = note: the following trait bounds were not satisfied:
            `NonCodecType: parity_scale_codec::Decode`
 note: the trait `parity_scale_codec::Decode` must be implemented
-  --> $CARGO/parity-scale-codec-3.6.2/src/codec.rs
+  --> $CARGO/parity-scale-codec-3.6.3/src/codec.rs
    |
    | pub trait Decode: Sized {
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
@@ -35,7 +35,7 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call
   = note: the following trait bounds were not satisfied:
           `NonCodec: parity_scale_codec::Decode`
 note: the trait `parity_scale_codec::Decode` must be implemented
- --> $CARGO/parity-scale-codec-3.6.2/src/codec.rs
+ --> $CARGO/parity-scale-codec-3.6.3/src/codec.rs
   |
   | pub trait Decode: Sized {
   | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
@@ -35,7 +35,7 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call
   = note: the following trait bounds were not satisfied:
           `NonCodec: parity_scale_codec::Decode`
 note: the trait `parity_scale_codec::Decode` must be implemented
- --> $CARGO/parity-scale-codec-3.6.1/src/codec.rs
+ --> $CARGO/parity-scale-codec-3.6.2/src/codec.rs
   |
   | pub trait Decode: Sized {
   | ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
1. `E2EConfig` doesn't need `whitelisted_attributes` (copied from another macro config)
2. We can reuse `subxt` Polkadot configuration