### PR TITLE
:t-rex: fix spellcheck for new version, add words to dict

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -12,7 +12,10 @@ FFI
 Gnosis
 GPL
 KECCAK
+L1
+L2
 Polkadot
+PSP22
 RPC
 SHA
 UI/S
@@ -62,6 +65,7 @@ scalability
 scalable
 stdin
 stdout
+subber
 tuple
 unordered
 untyped


### PR DESCRIPTION
These words were causing spellcheck errors for the new version of `cargo-spellcheck` released yesterday: https://crates.io/crates/cargo-spellcheck/0.12.4