### PR TITLE
Usage of the crate includes defined there events

### DIFF
--- a/integration-tests/events/event-def-unused/src/lib.rs
+++ b/integration-tests/events/event-def-unused/src/lib.rs
@@ -1,5 +1,11 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
+#[ink::trait_definition]
+pub trait FlipperTrait {
+    #[ink(message)]
+    fn flip(&mut self);
+}
+
 #[ink::event]
 pub struct EventDefUnused {
     #[ink(topic)]

--- a/integration-tests/events/lib.rs
+++ b/integration-tests/events/lib.rs
@@ -77,6 +77,13 @@ pub mod events {
         }
     }
 
+    impl event_def_unused::FlipperTrait for Events {
+        #[ink(message)]
+        fn flip(&mut self) {
+            self.value = !self.value;
+        }
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;

--- a/integration-tests/events/lib.rs
+++ b/integration-tests/events/lib.rs
@@ -77,6 +77,8 @@ pub mod events {
         }
     }
 
+    /// Implementing the trait from the `event_def_unused` crate includes all defined
+    /// events there.
     impl event_def_unused::FlipperTrait for Events {
         #[ink(message)]
         fn flip(&mut self) {
@@ -92,7 +94,7 @@ pub mod events {
         #[test]
         fn collects_specs_for_all_linked_and_used_events() {
             let event_specs = ink::metadata::collect_events();
-            assert_eq!(6, event_specs.len());
+            assert_eq!(7, event_specs.len());
 
             assert!(event_specs
                 .iter()
@@ -113,7 +115,9 @@ pub mod events {
                 .iter()
                 .any(|evt| evt.label() == &"InlineAnonymousEvent"));
 
-            assert!(!event_specs
+            // The event is not used in the code by being included in the metadata
+            // because we implement trait form `event_def_unused` crate.
+            assert!(event_specs
                 .iter()
                 .any(|evt| evt.label() == &"EventDefUnused"));
         }


### PR DESCRIPTION
The PR shows that including any code from the crate also imports all defined there events. We discussed about the potential [solution](https://github.com/paritytech/ink/pull/1243#issuecomment-1119838754) during previous PR=)