### PR TITLE
[E2E alternative backend]: Abstract error and result structs

### DIFF
--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -55,7 +55,7 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
                     return Err(format_err_spanned!(
                         arg,
                         "expected a string literal for `additional_contracts` ink! E2E test configuration argument",
-                    ))
+                    ));
                 }
             } else if arg.name.is_ident("environment") {
                 if let Some((_, ast)) = environment {
@@ -67,7 +67,7 @@ impl TryFrom<ast::AttributeArgs> for E2EConfig {
                     return Err(format_err_spanned!(
                         arg,
                         "expected a path for `environment` ink! E2E test configuration argument",
-                    ))
+                    ));
                 }
             } else {
                 return Err(format_err_spanned!(

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -13,30 +13,54 @@
 // limitations under the License.
 
 use super::{
-    builders::{constructor_exec_input, CreateBuilderPartial},
-    log_error, log_info, sr25519, ContractInstantiateResult, ContractsApi, Signer,
+    builders::{
+        constructor_exec_input,
+        CreateBuilderPartial,
+    },
+    log_error,
+    log_info,
+    sr25519,
+    ContractInstantiateResult,
+    ContractsApi,
+    Signer,
 };
 use crate::contract_results::{
-    CallDryRunResult, CallResult, InstantiationResult, UploadResult,
+    CallDryRunResult,
+    CallResult,
+    InstantiationResult,
+    UploadResult,
 };
 use ink_env::{
     call::{
-        utils::{ReturnType, Set},
-        Call, ExecutionInput,
+        utils::{
+            ReturnType,
+            Set,
+        },
+        Call,
+        ExecutionInput,
     },
     Environment,
 };
 use sp_core::Pair;
 #[cfg(feature = "std")]
-use std::{collections::BTreeMap, fmt::Debug, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    fmt::Debug,
+    path::PathBuf,
+};
 
 use subxt::{
     blocks::ExtrinsicEvents,
     config::ExtrinsicParams,
     events::EventDetails,
     ext::{
-        scale_decode, scale_encode,
-        scale_value::{Composite, Value, ValueDef},
+        scale_decode,
+        scale_encode,
+        scale_value::{
+            Composite,
+            Value,
+            ValueDef,
+        },
     },
     tx::PairSigner,
 };
@@ -308,7 +332,7 @@ where
         ));
         log_info(&format!("instantiate dry run result: {:?}", dry_run.result));
         if dry_run.result.is_err() {
-            return Err(Error::<E>::InstantiateDryRun(dry_run));
+            return Err(Error::<E>::InstantiateDryRun(dry_run))
         }
 
         let tx_events = self
@@ -353,7 +377,7 @@ where
                 log_error(&format!(
                     "extrinsic for instantiate failed: {dispatch_error}"
                 ));
-                return Err(Error::<E>::InstantiateExtrinsic(dispatch_error));
+                return Err(Error::<E>::InstantiateExtrinsic(dispatch_error))
             }
         }
         let account_id = account_id.expect("cannot extract `account_id` from events");
@@ -415,7 +439,7 @@ where
             .await;
         log_info(&format!("upload dry run: {dry_run:?}"));
         if dry_run.is_err() {
-            return Err(Error::<E>::UploadDryRun(dry_run));
+            return Err(Error::<E>::UploadDryRun(dry_run))
         }
 
         let tx_events = self.api.upload(signer, code, storage_deposit_limit).await;
@@ -436,7 +460,7 @@ where
                     uploaded.code_hash
                 ));
                 hash = Some(uploaded.code_hash);
-                break;
+                break
             } else if is_extrinsic_failed_event(&evt) {
                 let metadata = self.api.client.metadata();
                 let dispatch_error =
@@ -444,7 +468,7 @@ where
                         .map_err(|e| Error::<E>::Decoding(e.to_string()))?;
 
                 log_error(&format!("extrinsic for upload failed: {dispatch_error}"));
-                return Err(Error::<E>::UploadExtrinsic(dispatch_error));
+                return Err(Error::<E>::UploadExtrinsic(dispatch_error))
             }
         }
 
@@ -492,7 +516,7 @@ where
         let dry_run = self.call_dry_run(signer, message, value, None).await;
 
         if dry_run.exec_result.result.is_err() {
-            return Err(Error::<E>::CallDryRun(dry_run.exec_result));
+            return Err(Error::<E>::CallDryRun(dry_run.exec_result))
         }
 
         let tx_events = self
@@ -518,7 +542,7 @@ where
                     subxt::error::DispatchError::decode_from(evt.field_bytes(), metadata)
                         .map_err(|e| Error::<E>::Decoding(e.to_string()))?;
                 log_error(&format!("extrinsic for call failed: {dispatch_error}"));
-                return Err(Error::<E>::CallExtrinsic(dispatch_error));
+                return Err(Error::<E>::CallExtrinsic(dispatch_error))
             }
         }
 
@@ -563,7 +587,7 @@ where
                         .map_err(|e| Error::<E>::Decoding(e.to_string()))?;
 
                 log_error(&format!("extrinsic for call failed: {dispatch_error}"));
-                return Err(Error::<E>::CallExtrinsic(dispatch_error));
+                return Err(Error::<E>::CallExtrinsic(dispatch_error))
             }
         }
 

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -1,6 +1,8 @@
+use crate::CallDryRunResult;
 use ink::codegen::ContractCallBuilder;
 use ink_env::call::FromAccountId;
 use ink_env::Environment;
+use ink_primitives::MessageResult;
 use pallet_contracts_primitives::{CodeUploadResult, ContractInstantiateResult};
 use std::fmt::Debug;
 
@@ -64,6 +66,62 @@ where
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("UploadResult")
             .field("code_hash", &self.code_hash)
+            .field("dry_run", &self.dry_run)
+            .field("events", &self.events)
+            .finish()
+    }
+}
+
+/// Result of a contract call.
+pub struct CallResult<E: Environment, V, EventLog> {
+    /// The result of the dry run, contains debug messages if there were any.
+    pub dry_run: CallDryRunResult<E, V>,
+    /// Events that happened with the contract instantiation.
+    pub events: EventLog,
+}
+
+impl<E: Environment, V: scale::Decode, EventLog> CallResult<E, V, EventLog> {
+    /// Returns the [`MessageResult`] from the execution of the dry-run message
+    /// call.
+    ///
+    /// # Panics
+    /// - if the dry-run message call failed to execute.
+    /// - if message result cannot be decoded into the expected return value type.
+    pub fn message_result(&self) -> MessageResult<V> {
+        self.dry_run.message_result()
+    }
+
+    /// Returns the decoded return value of the message from the dry-run.
+    ///
+    /// Panics if the value could not be decoded. The raw bytes can be accessed
+    /// via [`CallResult::return_data`].
+    pub fn return_value(self) -> V {
+        self.dry_run.return_value()
+    }
+
+    /// Returns the return value as raw bytes of the message from the dry-run.
+    ///
+    /// Panics if the dry-run message call failed to execute.
+    pub fn return_data(&self) -> &[u8] {
+        &self.dry_run.exec_return_value().data
+    }
+
+    /// Returns any debug message output by the contract decoded as UTF-8.
+    pub fn debug_message(&self) -> String {
+        self.dry_run.debug_message()
+    }
+}
+
+// TODO(#xxx) Improve the `Debug` implementation.
+impl<E: Environment, V, EventLog> Debug for CallResult<E, V, EventLog>
+where
+    E: Debug,
+    E::Balance: Debug,
+    V: Debug,
+    EventLog: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("CallResult")
             .field("dry_run", &self.dry_run)
             .field("events", &self.events)
             .finish()

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -1,7 +1,7 @@
 use ink::codegen::ContractCallBuilder;
 use ink_env::call::FromAccountId;
 use ink_env::Environment;
-use pallet_contracts_primitives::ContractInstantiateResult;
+use pallet_contracts_primitives::{CodeUploadResult, ContractInstantiateResult};
 use std::fmt::Debug;
 
 /// Result of a contract instantiation.
@@ -38,6 +38,32 @@ where
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("InstantiationResult")
             .field("account_id", &self.account_id)
+            .field("dry_run", &self.dry_run)
+            .field("events", &self.events)
+            .finish()
+    }
+}
+
+/// Result of a contract upload.
+pub struct UploadResult<E: Environment, EventLog> {
+    /// The hash with which the contract can be instantiated.
+    pub code_hash: E::Hash,
+    /// The result of the dry run, contains debug messages if there were any.
+    pub dry_run: CodeUploadResult<E::Hash, E::Balance>,
+    /// Events that happened with the contract instantiation.
+    pub events: EventLog,
+}
+
+/// We implement a custom `Debug` here, to avoid requiring the trait bound `Debug` for `E`.
+impl<E: Environment, EventLog> Debug for UploadResult<E, EventLog>
+where
+    E::Balance: Debug,
+    E::Hash: Debug,
+    EventLog: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("UploadResult")
+            .field("code_hash", &self.code_hash)
             .field("dry_run", &self.dry_run)
             .field("events", &self.events)
             .finish()

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -1,10 +1,12 @@
-use crate::CallDryRunResult;
 use ink::codegen::ContractCallBuilder;
 use ink_env::call::FromAccountId;
 use ink_env::Environment;
 use ink_primitives::MessageResult;
-use pallet_contracts_primitives::{CodeUploadResult, ContractInstantiateResult};
+use pallet_contracts_primitives::{
+    CodeUploadResult, ContractExecResult, ContractInstantiateResult, ExecReturnValue,
+};
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 /// Result of a contract instantiation.
 pub struct InstantiationResult<E: Environment, EventLog> {
@@ -125,5 +127,69 @@ where
             .field("dry_run", &self.dry_run)
             .field("events", &self.events)
             .finish()
+    }
+}
+
+/// Result of the dry run of a contract call.
+#[derive(Debug)]
+pub struct CallDryRunResult<E: Environment, V> {
+    /// The result of the dry run, contains debug messages if there were any.
+    pub exec_result: ContractExecResult<E::Balance, ()>,
+    pub _marker: PhantomData<V>,
+}
+
+impl<E: Environment, V: scale::Decode> CallDryRunResult<E, V> {
+    /// Returns true if the dry-run execution resulted in an error.
+    pub fn is_err(&self) -> bool {
+        self.exec_result.result.is_err()
+    }
+
+    /// Returns the [`ExecReturnValue`] resulting from the dry-run message call.
+    ///
+    /// Panics if the dry-run message call failed to execute.
+    pub fn exec_return_value(&self) -> &ExecReturnValue {
+        self.exec_result
+            .result
+            .as_ref()
+            .unwrap_or_else(|call_err| panic!("Call dry-run failed: {call_err:?}"))
+    }
+
+    /// Returns the [`MessageResult`] from the execution of the dry-run message call.
+    ///
+    /// # Panics
+    /// - if the dry-run message call failed to execute.
+    /// - if message result cannot be decoded into the expected return value type.
+    pub fn message_result(&self) -> MessageResult<V> {
+        let data = &self.exec_return_value().data;
+        scale::Decode::decode(&mut data.as_ref()).unwrap_or_else(|env_err| {
+            panic!(
+                "Decoding dry run result to ink! message return type failed: {env_err}"
+            )
+        })
+    }
+
+    /// Returns the decoded return value of the message from the dry-run.
+    ///
+    /// Panics if the value could not be decoded. The raw bytes can be accessed via
+    /// [`CallResult::return_data`].
+    pub fn return_value(self) -> V {
+        self.message_result()
+            .unwrap_or_else(|lang_err| {
+                panic!(
+                    "Encountered a `LangError` while decoding dry run result to ink! message: {lang_err:?}"
+                )
+            })
+    }
+
+    /// Returns the return value as raw bytes of the message from the dry-run.
+    ///
+    /// Panics if the dry-run message call failed to execute.
+    pub fn return_data(&self) -> &[u8] {
+        &self.exec_return_value().data
+    }
+
+    /// Returns any debug message output by the contract decoded as UTF-8.
+    pub fn debug_message(&self) -> String {
+        String::from_utf8_lossy(&self.exec_result.debug_message).into()
     }
 }

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -1,0 +1,45 @@
+use ink::codegen::ContractCallBuilder;
+use ink_env::call::FromAccountId;
+use ink_env::Environment;
+use pallet_contracts_primitives::ContractInstantiateResult;
+use std::fmt::Debug;
+
+/// Result of a contract instantiation.
+pub struct InstantiationResult<E: Environment, EventLog> {
+    /// The account id at which the contract was instantiated.
+    pub account_id: E::AccountId,
+    /// The result of the dry run, contains debug messages
+    /// if there were any.
+    pub dry_run: ContractInstantiateResult<E::AccountId, E::Balance, ()>,
+    /// Events that happened with the contract instantiation.
+    pub events: EventLog,
+}
+
+impl<E: Environment, EventLog> InstantiationResult<E, EventLog> {
+    /// Returns the account id at which the contract was instantiated.
+    pub fn call<Contract>(&self) -> <Contract as ContractCallBuilder>::Type
+    where
+        Contract: ContractCallBuilder,
+        Contract::Type: FromAccountId<E>,
+    {
+        <<Contract as ContractCallBuilder>::Type as FromAccountId<E>>::from_account_id(
+            self.account_id.clone(),
+        )
+    }
+}
+
+/// We implement a custom `Debug` here, as to avoid requiring the trait bound `Debug` for `E`.
+impl<E: Environment, EventLog> Debug for InstantiationResult<E, EventLog>
+where
+    E::AccountId: Debug,
+    E::Balance: Debug,
+    EventLog: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("InstantiationResult")
+            .field("account_id", &self.account_id)
+            .field("dry_run", &self.dry_run)
+            .field("events", &self.events)
+            .finish()
+    }
+}

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -1,12 +1,19 @@
 use ink::codegen::ContractCallBuilder;
-use ink_env::call::FromAccountId;
-use ink_env::Environment;
+use ink_env::{
+    call::FromAccountId,
+    Environment,
+};
 use ink_primitives::MessageResult;
 use pallet_contracts_primitives::{
-    CodeUploadResult, ContractExecResult, ContractInstantiateResult, ExecReturnValue,
+    CodeUploadResult,
+    ContractExecResult,
+    ContractInstantiateResult,
+    ExecReturnValue,
 };
-use std::fmt::Debug;
-use std::marker::PhantomData;
+use std::{
+    fmt::Debug,
+    marker::PhantomData,
+};
 
 /// Result of a contract instantiation.
 pub struct InstantiationResult<E: Environment, EventLog> {
@@ -32,7 +39,8 @@ impl<E: Environment, EventLog> InstantiationResult<E, EventLog> {
     }
 }
 
-/// We implement a custom `Debug` here, as to avoid requiring the trait bound `Debug` for `E`.
+/// We implement a custom `Debug` here, as to avoid requiring the trait bound `Debug` for
+/// `E`.
 impl<E: Environment, EventLog> Debug for InstantiationResult<E, EventLog>
 where
     E::AccountId: Debug,
@@ -58,7 +66,8 @@ pub struct UploadResult<E: Environment, EventLog> {
     pub events: EventLog,
 }
 
-/// We implement a custom `Debug` here, to avoid requiring the trait bound `Debug` for `E`.
+/// We implement a custom `Debug` here, to avoid requiring the trait bound `Debug` for
+/// `E`.
 impl<E: Environment, EventLog> Debug for UploadResult<E, EventLog>
 where
     E::Balance: Debug,

--- a/crates/e2e/src/error.rs
+++ b/crates/e2e/src/error.rs
@@ -1,0 +1,31 @@
+use pallet_contracts_primitives::{
+    CodeUploadResult, ContractExecResult, ContractInstantiateResult,
+};
+
+/// An error occurred while interacting with the Substrate node.
+///
+/// We only convey errors here that are caused by the contract's
+/// testing logic. For anything concerning the node (like inability
+/// to communicate with it, fetch the nonce, account info, etc.) we
+/// panic.
+#[derive(Debug)]
+pub enum Error<AccountId, Balance, CodeHash, DispatchError> {
+    /// No contract with the given name found in scope.
+    ContractNotFound(String),
+    /// The `instantiate_with_code` dry run failed.
+    InstantiateDryRun(ContractInstantiateResult<AccountId, Balance, ()>),
+    /// The `instantiate_with_code` extrinsic failed.
+    InstantiateExtrinsic(DispatchError),
+    /// The `upload` dry run failed.
+    UploadDryRun(CodeUploadResult<CodeHash, Balance>),
+    /// The `upload` extrinsic failed.
+    UploadExtrinsic(DispatchError),
+    /// The `call` dry run failed.
+    CallDryRun(ContractExecResult<Balance, ()>),
+    /// The `call` extrinsic failed.
+    CallExtrinsic(DispatchError),
+    /// Error fetching account balance.
+    Balance(String),
+    /// Decoding failed.
+    Decoding(String),
+}

--- a/crates/e2e/src/error.rs
+++ b/crates/e2e/src/error.rs
@@ -1,12 +1,14 @@
 use pallet_contracts_primitives::{
-    CodeUploadResult, ContractExecResult, ContractInstantiateResult,
+    CodeUploadResult,
+    ContractExecResult,
+    ContractInstantiateResult,
 };
 
 /// An error occurred while interacting with the E2E backend.
 ///
-/// We only convey errors here that are caused by the contract's testing logic. For anything
-/// concerning the execution environment (like inability to communicate with node or runtime, fetch
-/// the nonce, account info, etc.) we panic.
+/// We only convey errors here that are caused by the contract's testing logic. For
+/// anything concerning the execution environment (like inability to communicate with node
+/// or runtime, fetch the nonce, account info, etc.) we panic.
 #[derive(Debug)]
 pub enum Error<AccountId, Balance, CodeHash, DispatchError> {
     /// No contract with the given name found in scope.

--- a/crates/e2e/src/error.rs
+++ b/crates/e2e/src/error.rs
@@ -2,12 +2,11 @@ use pallet_contracts_primitives::{
     CodeUploadResult, ContractExecResult, ContractInstantiateResult,
 };
 
-/// An error occurred while interacting with the Substrate node.
+/// An error occurred while interacting with the E2E backend.
 ///
-/// We only convey errors here that are caused by the contract's
-/// testing logic. For anything concerning the node (like inability
-/// to communicate with it, fetch the nonce, account info, etc.) we
-/// panic.
+/// We only convey errors here that are caused by the contract's testing logic. For anything
+/// concerning the execution environment (like inability to communicate with node or runtime, fetch
+/// the nonce, account info, etc.) we panic.
 #[derive(Debug)]
 pub enum Error<AccountId, Balance, CodeHash, DispatchError> {
     /// No contract with the given name found in scope.

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -22,43 +22,28 @@
 mod builders;
 mod client;
 mod default_accounts;
+mod error;
 mod node_proc;
 mod xts;
 
 pub use client::{
-    CallBuilderFinal,
-    CallDryRunResult,
-    CallResult,
-    Client,
-    Error,
-    InstantiationResult,
+    CallBuilderFinal, CallDryRunResult, CallResult, Client, Error, InstantiationResult,
     UploadResult,
 };
 pub use default_accounts::*;
 pub use ink_e2e_macro::test;
-pub use node_proc::{
-    TestNodeProcess,
-    TestNodeProcessBuilder,
-};
+pub use node_proc::{TestNodeProcess, TestNodeProcessBuilder};
 pub use sp_core::H256;
 pub use sp_keyring::AccountKeyring;
-pub use subxt::{
-    self,
-    tx::PairSigner,
-};
+pub use subxt::{self, tx::PairSigner};
 pub use tokio;
 pub use tracing_subscriber;
 
 use pallet_contracts_primitives::{
-    CodeUploadResult,
-    ContractExecResult,
-    ContractInstantiateResult,
+    CodeUploadResult, ContractExecResult, ContractInstantiateResult,
 };
 use sp_core::sr25519;
-use std::{
-    cell::RefCell,
-    sync::Once,
-};
+use std::{cell::RefCell, sync::Once};
 use xts::ContractsApi;
 
 pub use subxt::PolkadotConfig;

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -27,10 +27,8 @@ mod error;
 mod node_proc;
 mod xts;
 
-pub use client::{
-    CallBuilderFinal, CallDryRunResult, CallResult, Client, Error, UploadResult,
-};
-pub use contract_results::InstantiationResult;
+pub use client::{CallBuilderFinal, CallDryRunResult, CallResult, Client, Error};
+pub use contract_results::{InstantiationResult, UploadResult};
 pub use default_accounts::*;
 pub use ink_e2e_macro::test;
 pub use node_proc::{TestNodeProcess, TestNodeProcessBuilder};
@@ -40,9 +38,7 @@ pub use subxt::{self, tx::PairSigner};
 pub use tokio;
 pub use tracing_subscriber;
 
-use pallet_contracts_primitives::{
-    CodeUploadResult, ContractExecResult, ContractInstantiateResult,
-};
+use pallet_contracts_primitives::{ContractExecResult, ContractInstantiateResult};
 use sp_core::sr25519;
 use std::{cell::RefCell, sync::Once};
 use xts::ContractsApi;

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -27,8 +27,10 @@ mod error;
 mod node_proc;
 mod xts;
 
-pub use client::{CallBuilderFinal, CallDryRunResult, Client, Error};
-pub use contract_results::{CallResult, InstantiationResult, UploadResult};
+pub use client::{CallBuilderFinal, Client, Error};
+pub use contract_results::{
+    CallDryRunResult, CallResult, InstantiationResult, UploadResult,
+};
 pub use default_accounts::*;
 pub use ink_e2e_macro::test;
 pub use node_proc::{TestNodeProcess, TestNodeProcessBuilder};

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -27,22 +27,41 @@ mod error;
 mod node_proc;
 mod xts;
 
-pub use client::{CallBuilderFinal, Client, Error};
+pub use client::{
+    CallBuilderFinal,
+    Client,
+    Error,
+};
 pub use contract_results::{
-    CallDryRunResult, CallResult, InstantiationResult, UploadResult,
+    CallDryRunResult,
+    CallResult,
+    InstantiationResult,
+    UploadResult,
 };
 pub use default_accounts::*;
 pub use ink_e2e_macro::test;
-pub use node_proc::{TestNodeProcess, TestNodeProcessBuilder};
+pub use node_proc::{
+    TestNodeProcess,
+    TestNodeProcessBuilder,
+};
 pub use sp_core::H256;
 pub use sp_keyring::AccountKeyring;
-pub use subxt::{self, tx::PairSigner};
+pub use subxt::{
+    self,
+    tx::PairSigner,
+};
 pub use tokio;
 pub use tracing_subscriber;
 
-use pallet_contracts_primitives::{ContractExecResult, ContractInstantiateResult};
+use pallet_contracts_primitives::{
+    ContractExecResult,
+    ContractInstantiateResult,
+};
 use sp_core::sr25519;
-use std::{cell::RefCell, sync::Once};
+use std::{
+    cell::RefCell,
+    sync::Once,
+};
 use xts::ContractsApi;
 
 pub use subxt::PolkadotConfig;

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -27,8 +27,8 @@ mod error;
 mod node_proc;
 mod xts;
 
-pub use client::{CallBuilderFinal, CallDryRunResult, CallResult, Client, Error};
-pub use contract_results::{InstantiationResult, UploadResult};
+pub use client::{CallBuilderFinal, CallDryRunResult, Client, Error};
+pub use contract_results::{CallResult, InstantiationResult, UploadResult};
 pub use default_accounts::*;
 pub use ink_e2e_macro::test;
 pub use node_proc::{TestNodeProcess, TestNodeProcessBuilder};

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -21,15 +21,16 @@
 
 mod builders;
 mod client;
+mod contract_results;
 mod default_accounts;
 mod error;
 mod node_proc;
 mod xts;
 
 pub use client::{
-    CallBuilderFinal, CallDryRunResult, CallResult, Client, Error, InstantiationResult,
-    UploadResult,
+    CallBuilderFinal, CallDryRunResult, CallResult, Client, Error, UploadResult,
 };
+pub use contract_results::InstantiationResult;
 pub use default_accounts::*;
 pub use ink_e2e_macro::test;
 pub use node_proc::{TestNodeProcess, TestNodeProcessBuilder};

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -12,15 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{log_info, sr25519, ContractExecResult, ContractInstantiateResult, Signer};
+use super::{
+    log_info,
+    sr25519,
+    ContractExecResult,
+    ContractInstantiateResult,
+    Signer,
+};
 use ink_env::Environment;
 
 use core::marker::PhantomData;
 use pallet_contracts_primitives::CodeUploadResult;
-use sp_core::{Bytes, H256};
+use sp_core::{
+    Bytes,
+    H256,
+};
 use subxt::{
-    blocks::ExtrinsicEvents, config::ExtrinsicParams, ext::scale_encode, rpc_params,
-    utils::MultiAddress, OnlineClient,
+    blocks::ExtrinsicEvents,
+    config::ExtrinsicParams,
+    ext::scale_encode,
+    rpc_params,
+    utils::MultiAddress,
+    OnlineClient,
 };
 
 /// Copied from `sp_weight` to additionally implement `scale_encode::EncodeAsType`.

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -12,28 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{
-    log_info,
-    sr25519,
-    ContractExecResult,
-    ContractInstantiateResult,
-    Signer,
-};
+use super::{log_info, sr25519, ContractExecResult, ContractInstantiateResult, Signer};
 use ink_env::Environment;
 
 use core::marker::PhantomData;
 use pallet_contracts_primitives::CodeUploadResult;
-use sp_core::{
-    Bytes,
-    H256,
-};
+use sp_core::{Bytes, H256};
 use subxt::{
-    blocks::ExtrinsicEvents,
-    config::ExtrinsicParams,
-    ext::scale_encode,
-    rpc_params,
-    utils::MultiAddress,
-    OnlineClient,
+    blocks::ExtrinsicEvents, config::ExtrinsicParams, ext::scale_encode, rpc_params,
+    utils::MultiAddress, OnlineClient,
 };
 
 /// Copied from `sp_weight` to additionally implement `scale_encode::EncodeAsType`.
@@ -267,7 +254,7 @@ where
         data: Vec<u8>,
         salt: Vec<u8>,
         signer: &Signer<C>,
-    ) -> ContractInstantiateResult<C::AccountId, E::Balance, ()> {
+    ) -> ContractInstantiateResult<E::AccountId, E::Balance, ()> {
         let code = Code::Upload(code);
         let call_request = RpcInstantiateRequest::<C, E> {
             origin: subxt::tx::Signer::account_id(signer).clone(),

--- a/crates/ink/ir/src/ir/item_mod.rs
+++ b/crates/ink/ir/src/ir/item_mod.rs
@@ -316,7 +316,7 @@ impl ItemMod {
                             message.callable().span(),
                             "encountered ink! message with wildcard complement `selector = @` but no \
                              wildcard `selector = _` defined"
-                        ))
+                        ));
                     }
                 }
             }

--- a/crates/ink/ir/src/ir/trait_def/item/mod.rs
+++ b/crates/ink/ir/src/ir/trait_def/item/mod.rs
@@ -384,7 +384,7 @@ impl InkItemTrait {
                 ).into_combine(format_err_spanned!(
                     duplicate_selector,
                     "first ink! trait constructor or message with same selector found here",
-                )))
+                )));
             }
             assert!(
                 duplicate_ident.is_none(),

--- a/integration-tests/contract-transfer/lib.rs
+++ b/integration-tests/contract-transfer/lib.rs
@@ -208,7 +208,7 @@ pub mod give_me {
             let call_res = client.call(&ink_e2e::bob(), &transfer, 10, None).await;
 
             // then
-            if let Err(ink_e2e::Error::CallDryRun(dry_run)) = call_res {
+            if let Err(ink_e2e::Error::<E>::CallDryRun(dry_run)) = call_res {
                 let debug_message = String::from_utf8_lossy(&dry_run.debug_message);
                 assert!(debug_message.contains("paid an unpayable message"))
             } else {

--- a/integration-tests/contract-transfer/lib.rs
+++ b/integration-tests/contract-transfer/lib.rs
@@ -208,7 +208,10 @@ pub mod give_me {
             let call_res = client.call(&ink_e2e::bob(), &transfer, 10, None).await;
 
             // then
-            if let Err(ink_e2e::Error::<E>::CallDryRun(dry_run)) = call_res {
+            if let Err(ink_e2e::Error::<ink::env::DefaultEnvironment>::CallDryRun(
+                dry_run,
+            )) = call_res
+            {
                 let debug_message = String::from_utf8_lossy(&dry_run.debug_message);
                 assert!(debug_message.contains("paid an unpayable message"))
             } else {

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
@@ -1,9 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 pub use self::constructors_return_value::{
-    ConstructorError,
-    ConstructorsReturnValue,
-    ConstructorsReturnValueRef,
+    ConstructorError, ConstructorsReturnValue, ConstructorsReturnValueRef,
 };
 
 #[ink::contract]
@@ -259,7 +257,7 @@ pub mod constructors_return_value {
                 .await;
 
             assert!(
-                matches!(result, Err(ink_e2e::Error::InstantiateExtrinsic(_))),
+                matches!(result, Err(ink_e2e::Error::<E>::InstantiateExtrinsic(_))),
                 "Constructor should fail"
             );
 

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
@@ -1,7 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 pub use self::constructors_return_value::{
-    ConstructorError, ConstructorsReturnValue, ConstructorsReturnValueRef,
+    ConstructorError,
+    ConstructorsReturnValue,
+    ConstructorsReturnValueRef,
 };
 
 #[ink::contract]

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
@@ -259,7 +259,7 @@ pub mod constructors_return_value {
                 .await;
 
             assert!(
-                matches!(result, Err(ink_e2e::Error::<E>::InstantiateExtrinsic(_))),
+                matches!(result, Err(ink_e2e::Error::<ink::env::DefaultEnvironment>::InstantiateExtrinsic(_))),
                 "Constructor should fail"
             );
 

--- a/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
+++ b/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
@@ -165,7 +165,7 @@ mod contract_ref {
             );
 
             let contains_err_msg = match instantiate_result.unwrap_err() {
-                ink_e2e::Error::InstantiateDryRun(dry_run) => {
+                ink_e2e::Error::<E>::InstantiateDryRun(dry_run) => {
                     String::from_utf8_lossy(&dry_run.debug_message).contains(
                         "Received an error from the Flipper constructor while instantiating Flipper FlipperError"
                     )

--- a/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
+++ b/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
@@ -165,7 +165,7 @@ mod contract_ref {
             );
 
             let contains_err_msg = match instantiate_result.unwrap_err() {
-                ink_e2e::Error::<E>::InstantiateDryRun(dry_run) => {
+                ink_e2e::Error::<ink::env::DefaultEnvironment>::InstantiateDryRun(dry_run) => {
                     String::from_utf8_lossy(&dry_run.debug_message).contains(
                         "Received an error from the Flipper constructor while instantiating Flipper FlipperError"
                     )

--- a/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-pub use self::integration_flipper::{Flipper, FlipperRef};
+pub use self::integration_flipper::{
+    Flipper,
+    FlipperRef,
+};
 
 #[ink::contract]
 pub mod integration_flipper {

--- a/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
@@ -1,9 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-pub use self::integration_flipper::{
-    Flipper,
-    FlipperRef,
-};
+pub use self::integration_flipper::{Flipper, FlipperRef};
 
 #[ink::contract]
 pub mod integration_flipper {
@@ -134,7 +131,7 @@ pub mod integration_flipper {
 
             assert!(matches!(
                 err_flip_call_result,
-                Err(ink_e2e::Error::CallExtrinsic(_))
+                Err(ink_e2e::Error::<E>::CallExtrinsic(_))
             ));
 
             let flipped_value = client

--- a/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
@@ -134,7 +134,7 @@ pub mod integration_flipper {
 
             assert!(matches!(
                 err_flip_call_result,
-                Err(ink_e2e::Error::<E>::CallExtrinsic(_))
+                Err(ink_e2e::Error::<ink::env::DefaultEnvironment>::CallExtrinsic(_))
             ));
 
             let flipped_value = client


### PR DESCRIPTION
First step for introducing common backend trait:
 - move `Error` enum to a separate module and make it backend-agnostic
 - move `CallDryRunResult`, `CallResult`, `InstantiationResult`, `UploadResult` to a separate module and make them backend-agnostic

Fortunately, no changes to the test code is needed (apart from some type annotation for errors).

ref: #1834 