### PR TITLE
Fix ink dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,8 @@ ink_allocator = { version = "=4.2.0", path = "crates/allocator", default-feature
 ink_codegen = { version = "=4.2.0", path = "crates/ink/codegen", default-features = false }
 ink_e2e_macro = { version = "=4.2.0", path = "crates/e2e/macro", default-features = false }
 ink_engine = { version = "=4.2.0", path = "crates/engine", default-features = false }
-ink_env = { version = "4.2.0", path = "crates/env", default-features = false }
-ink_ir = { version = "4.2.0", path = "crates/ink/ir", default-features = false }
+ink_env = { version = "=4.2.0", path = "crates/env", default-features = false }
+ink_ir = { version = "=4.2.0", path = "crates/ink/ir", default-features = false }
 ink_macro = { version = "=4.2.0", path = "crates/ink/macro", default-features = false }
 ink_metadata = { version = "=4.2.0", path = "crates/metadata", default-features = false }
 ink_prelude = { version = "=4.2.0", path = "crates/prelude", default-features = false }


### PR DESCRIPTION
Two ink dependencies are missing fixed version as pointed here: https://github.com/paritytech/ink/pull/1835#discussion_r1274124781 - this must have been messed up while rebasing the previous PR.