### PR TITLE
Update `contract-build` to `4.0.0-alpha`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ array-init = { version = "2.0", default-features = false }
 blake2 = { version = "0.10" }
 cargo_metadata = { version = "0.17.0" }
 cfg-if = { version = "1.0" }
-contract-build = { version = "3.1.0" }
+contract-build = { version = "4.0.0-alpha" }
 derive_more = { version = "0.99.17", default-features = false }
 either = { version = "1.5", default-features = false }
 funty = { version = "2.0.0" }


### PR DESCRIPTION
`3.1.0` has been yanked, replaced by `4.0.0-alpha` see https://github.com/paritytech/cargo-contract/pull/1243