### PR TITLE
[E2E alternative backend]: Make tests generic over client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Stabilize `call_runtime` ‒ [#1749](https://github.com/paritytech/ink/pull/1749)
+- Make E2E testcases generic over `E2EBackend` trait - [#1867](https://github.com/paritytech/ink/pull/1867)
 
 ### Added
 - Schema generation - [#1765](https://github.com/paritytech/ink/pull/1765)

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -20,14 +20,20 @@ use crate::{
     InstantiationResult,
     UploadResult,
 };
-use ink_env::{DefaultEnvironment, Environment};
+use ink_env::{
+    DefaultEnvironment,
+    Environment,
+};
 use jsonrpsee::core::async_trait;
 use pallet_contracts_primitives::ContractInstantiateResult;
 use subxt::dynamic::Value;
 
 /// Full E2E testing backend: combines general chain API and contract-specific operations.
 #[async_trait]
-pub trait E2EBackend<E: Environment = DefaultEnvironment>: ChainBackend + ContractsBackend<E> {}
+pub trait E2EBackend<E: Environment = DefaultEnvironment>:
+    ChainBackend + ContractsBackend<E>
+{
+}
 
 /// General chain operations useful in contract testing.
 #[async_trait]

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -20,14 +20,14 @@ use crate::{
     InstantiationResult,
     UploadResult,
 };
-use ink_env::Environment;
+use ink_env::{DefaultEnvironment, Environment};
 use jsonrpsee::core::async_trait;
 use pallet_contracts_primitives::ContractInstantiateResult;
 use subxt::dynamic::Value;
 
 /// Full E2E testing backend: combines general chain API and contract-specific operations.
 #[async_trait]
-pub trait E2EBackend<E: Environment>: ChainBackend + ContractsBackend<E> {}
+pub trait E2EBackend<E: Environment = DefaultEnvironment>: ChainBackend + ContractsBackend<E> {}
 
 /// General chain operations useful in contract testing.
 #[async_trait]

--- a/integration-tests/call-builder-return-value/lib.rs
+++ b/integration-tests/call-builder-return-value/lib.rs
@@ -116,13 +116,16 @@ mod call_builder {
         use ink_e2e::{
             ChainBackend,
             ContractsBackend,
+            E2EBackend,
         };
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn e2e_delegate_call_return_value_returns_correct_value(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_delegate_call_return_value_returns_correct_value<
+            Client: E2EBackend,
+        >(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::alice(), 10_000_000_000_000)
@@ -159,8 +162,10 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_delegate_call_return_value_errors_if_return_data_too_long(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_delegate_call_return_value_errors_if_return_data_too_long<
+            Client: E2EBackend,
+        >(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::alice(), 10_000_000_000_000)
@@ -201,8 +206,10 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_forward_call_return_value_returns_correct_value(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_forward_call_return_value_returns_correct_value<
+            Client: E2EBackend,
+        >(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::alice(), 10_000_000_000_000)
@@ -239,8 +246,10 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_forward_call_return_value_errors_if_return_data_too_long(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_forward_call_return_value_errors_if_return_data_too_long<
+            Client: E2EBackend,
+        >(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::alice(), 10_000_000_000_000)

--- a/integration-tests/call-runtime/lib.rs
+++ b/integration-tests/call-runtime/lib.rs
@@ -151,8 +151,8 @@ mod runtime_call {
         ///  - the call is valid
         ///  - the call execution succeeds
         #[ink_e2e::test]
-        async fn transfer_with_call_runtime_works(
-            mut client: Client<C, E>,
+        async fn transfer_with_call_runtime_works<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = RuntimeCallerRef::new();
@@ -216,8 +216,10 @@ mod runtime_call {
         ///  - the call is valid
         ///  - the call execution fails
         #[ink_e2e::test]
-        async fn transfer_with_call_runtime_fails_when_execution_fails(
-            mut client: Client<C, E>,
+        async fn transfer_with_call_runtime_fails_when_execution_fails<
+            Client: E2EBackend,
+        >(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = RuntimeCallerRef::new();
@@ -253,8 +255,10 @@ mod runtime_call {
         /// Negative case scenario:
         ///  - the call is invalid
         #[ink_e2e::test]
-        async fn transfer_with_call_runtime_fails_when_call_is_invalid(
-            mut client: Client<C, E>,
+        async fn transfer_with_call_runtime_fails_when_call_is_invalid<
+            Client: E2EBackend,
+        >(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = RuntimeCallerRef::new();

--- a/integration-tests/contract-terminate/lib.rs
+++ b/integration-tests/contract-terminate/lib.rs
@@ -61,8 +61,8 @@ pub mod just_terminates {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn e2e_contract_terminates(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_contract_terminates<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = JustTerminateRef::new();

--- a/integration-tests/contract-transfer/lib.rs
+++ b/integration-tests/contract-transfer/lib.rs
@@ -190,8 +190,8 @@ pub mod give_me {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn e2e_sending_value_to_give_me_must_fail(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_sending_value_to_give_me_must_fail<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = GiveMeRef::new();
@@ -226,8 +226,8 @@ pub mod give_me {
         }
 
         #[ink_e2e::test]
-        async fn e2e_contract_must_transfer_value_to_sender(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_contract_must_transfer_value_to_sender<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = GiveMeRef::new();

--- a/integration-tests/custom-allocator/lib.rs
+++ b/integration-tests/custom-allocator/lib.rs
@@ -114,7 +114,7 @@ mod custom_allocator {
         /// We test that we can upload and instantiate the contract using its default
         /// constructor.
         #[ink_e2e::test]
-        async fn default_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn default_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // Given
             let constructor = CustomAllocatorRef::default();
 
@@ -136,7 +136,7 @@ mod custom_allocator {
         /// We test that we can read and write a value from the on-chain contract
         /// contract.
         #[ink_e2e::test]
-        async fn it_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn it_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // Given
             let constructor = CustomAllocatorRef::new(false);
             let contract = client

--- a/integration-tests/custom-environment/lib.rs
+++ b/integration-tests/custom-environment/lib.rs
@@ -90,8 +90,8 @@ mod runtime_call {
 
         #[cfg(feature = "permissive-node")]
         #[ink_e2e::test(environment = crate::EnvironmentWithManyTopics)]
-        async fn calling_custom_environment_works(
-            mut client: Client<C, E>,
+        async fn calling_custom_environment_works<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = TopicsRef::new();
@@ -123,8 +123,10 @@ mod runtime_call {
 
         #[cfg(not(feature = "permissive-node"))]
         #[ink_e2e::test(environment = crate::EnvironmentWithManyTopics)]
-        async fn calling_custom_environment_fails_if_incompatible_with_node(
-            mut client: Client<C, E>,
+        async fn calling_custom_environment_fails_if_incompatible_with_node<
+            Client: E2EBackend,
+        >(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = TopicsRef::new();

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -30,7 +30,9 @@ pub mod e2e_call_runtime {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn call_runtime_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn call_runtime_works<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
             // given
             let constructor = ContractRef::new();
             let contract = client

--- a/integration-tests/erc20/lib.rs
+++ b/integration-tests/erc20/lib.rs
@@ -514,7 +514,7 @@ mod erc20 {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn e2e_transfer(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn e2e_transfer<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // given
             let total_supply = 1_000_000_000;
             let constructor = Erc20Ref::new(total_supply);
@@ -555,7 +555,7 @@ mod erc20 {
         }
 
         #[ink_e2e::test]
-        async fn e2e_allowances(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn e2e_allowances<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // given
             let total_supply = 1_000_000_000;
             let constructor = Erc20Ref::new(total_supply);

--- a/integration-tests/events/lib.rs
+++ b/integration-tests/events/lib.rs
@@ -209,7 +209,9 @@ pub mod events {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn emits_foreign_event(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn emits_foreign_event<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
             // given
             let init_value = false;
             let constructor = EventsRef::new(init_value);
@@ -248,7 +250,9 @@ pub mod events {
         }
 
         #[ink_e2e::test]
-        async fn emits_inline_event(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn emits_inline_event<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
             // given
             let init_value = false;
             let constructor = EventsRef::new(init_value);
@@ -286,8 +290,8 @@ pub mod events {
         }
 
         #[ink_e2e::test]
-        async fn emits_event_with_option_topic_none(
-            mut client: ink_e2e::Client<C, E>,
+        async fn emits_event_with_option_topic_none<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let init_value = false;

--- a/integration-tests/flipper/lib.rs
+++ b/integration-tests/flipper/lib.rs
@@ -60,7 +60,7 @@ pub mod flipper {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn it_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn it_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // given
             let constructor = FlipperRef::new(false);
             let contract = client
@@ -89,7 +89,7 @@ pub mod flipper {
         }
 
         #[ink_e2e::test]
-        async fn default_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn default_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // given
             let constructor = FlipperRef::new_default();
 

--- a/integration-tests/lang-err-integration-tests/call-builder-delegate/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder-delegate/lib.rs
@@ -102,8 +102,8 @@ mod call_builder {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn e2e_invalid_message_selector_can_be_handled(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_invalid_message_selector_can_be_handled<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::bob(), 10_000_000_000_000)
@@ -139,8 +139,8 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_invalid_message_selector_panics_on_invoke(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_invalid_message_selector_panics_on_invoke<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::charlie(), 10_000_000_000_000)

--- a/integration-tests/lang-err-integration-tests/call-builder/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder/lib.rs
@@ -341,7 +341,9 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_with_infallible_revert_constructor_encodes_ok<Client: E2EBackend>(
+        async fn e2e_create_builder_with_infallible_revert_constructor_encodes_ok<
+            Client: E2EBackend,
+        >(
             mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
@@ -384,7 +386,9 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_can_handle_fallible_constructor_success<Client: E2EBackend>(
+        async fn e2e_create_builder_can_handle_fallible_constructor_success<
+            Client: E2EBackend,
+        >(
             mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
@@ -423,7 +427,9 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_can_handle_fallible_constructor_error<Client: E2EBackend>(
+        async fn e2e_create_builder_can_handle_fallible_constructor_error<
+            Client: E2EBackend,
+        >(
             mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
@@ -469,7 +475,9 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_with_fallible_revert_constructor_encodes_ok<Client: E2EBackend>(
+        async fn e2e_create_builder_with_fallible_revert_constructor_encodes_ok<
+            Client: E2EBackend,
+        >(
             mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
@@ -512,7 +520,9 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_with_fallible_revert_constructor_encodes_err<Client: E2EBackend>(
+        async fn e2e_create_builder_with_fallible_revert_constructor_encodes_err<
+            Client: E2EBackend,
+        >(
             mut client: Client,
         ) -> E2EResult<()> {
             let origin = client

--- a/integration-tests/lang-err-integration-tests/call-builder/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder/lib.rs
@@ -178,8 +178,8 @@ mod call_builder {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn e2e_invalid_message_selector_can_be_handled(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_invalid_message_selector_can_be_handled<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::alice(), 10_000_000_000_000)
@@ -228,8 +228,8 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_invalid_message_selector_panics_on_invoke(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_invalid_message_selector_panics_on_invoke<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::bob(), 10_000_000_000_000)
@@ -263,8 +263,8 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_works_with_valid_selector(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_create_builder_works_with_valid_selector<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::bob(), 10_000_000_000_000)
@@ -302,8 +302,8 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_fails_with_invalid_selector(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_create_builder_fails_with_invalid_selector<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::bob(), 10_000_000_000_000)
@@ -341,8 +341,8 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_with_infallible_revert_constructor_encodes_ok(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_create_builder_with_infallible_revert_constructor_encodes_ok<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::bob(), 10_000_000_000_000)
@@ -384,8 +384,8 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_can_handle_fallible_constructor_success(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_create_builder_can_handle_fallible_constructor_success<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::bob(), 10_000_000_000_000)
@@ -423,8 +423,8 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_can_handle_fallible_constructor_error(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_create_builder_can_handle_fallible_constructor_error<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::bob(), 10_000_000_000_000)
@@ -469,8 +469,8 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_with_fallible_revert_constructor_encodes_ok(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_create_builder_with_fallible_revert_constructor_encodes_ok<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::bob(), 10_000_000_000_000)
@@ -512,8 +512,8 @@ mod call_builder {
         }
 
         #[ink_e2e::test]
-        async fn e2e_create_builder_with_fallible_revert_constructor_encodes_err(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_create_builder_with_fallible_revert_constructor_encodes_err<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let origin = client
                 .create_and_fund_account(&ink_e2e::bob(), 10_000_000_000_000)

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
@@ -113,8 +113,8 @@ pub mod constructors_return_value {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn e2e_infallible_constructor(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_infallible_constructor<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let constructor = ConstructorsReturnValueRef::new(true);
             let infallible_constructor_result = client
@@ -155,8 +155,8 @@ pub mod constructors_return_value {
         }
 
         #[ink_e2e::test]
-        async fn e2e_fallible_constructor_succeed(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_fallible_constructor_succeed<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let constructor = ConstructorsReturnValueRef::try_new(true);
             let result = client
@@ -215,8 +215,8 @@ pub mod constructors_return_value {
         }
 
         #[ink_e2e::test]
-        async fn e2e_fallible_constructor_fails(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_fallible_constructor_fails<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let constructor = ConstructorsReturnValueRef::try_new(false);
 

--- a/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
+++ b/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
@@ -73,8 +73,8 @@ mod contract_ref {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn e2e_ref_can_flip_correctly(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_ref_can_flip_correctly<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let flipper_hash = client
                 .upload("integration_flipper", &ink_e2e::alice(), None)
@@ -116,8 +116,8 @@ mod contract_ref {
         }
 
         #[ink_e2e::test]
-        async fn e2e_fallible_ref_can_be_instantiated(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_fallible_ref_can_be_instantiated<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let flipper_hash = client
                 .upload("integration_flipper", &ink_e2e::bob(), None)
@@ -145,8 +145,8 @@ mod contract_ref {
         }
 
         #[ink_e2e::test]
-        async fn e2e_fallible_ref_fails_to_be_instantiated(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_fallible_ref_fails_to_be_instantiated<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let flipper_hash = client
                 .upload("integration_flipper", &ink_e2e::charlie(), None)

--- a/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
@@ -72,8 +72,8 @@ pub mod integration_flipper {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn e2e_can_flip_correctly(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_can_flip_correctly<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let constructor = FlipperRef::new_default();
             let flipper = client
@@ -114,8 +114,8 @@ pub mod integration_flipper {
         }
 
         #[ink_e2e::test]
-        async fn e2e_message_error_reverts_state(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_message_error_reverts_state<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             let constructor = FlipperRef::new_default();
             let flipper = client

--- a/integration-tests/mapping-integration-tests/lib.rs
+++ b/integration-tests/mapping-integration-tests/lib.rs
@@ -94,8 +94,8 @@ mod mapping_integration_tests {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn insert_and_get_works(
-            mut client: ink_e2e::Client<C, E>,
+        async fn insert_and_get_works<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = MappingsRef::new();
@@ -133,8 +133,8 @@ mod mapping_integration_tests {
         }
 
         #[ink_e2e::test]
-        async fn insert_and_contains_works(
-            mut client: ink_e2e::Client<C, E>,
+        async fn insert_and_contains_works<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = MappingsRef::new();
@@ -171,7 +171,7 @@ mod mapping_integration_tests {
         }
 
         #[ink_e2e::test]
-        async fn reinsert_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn reinsert_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // given
             let constructor = MappingsRef::new();
             let contract = client
@@ -216,8 +216,8 @@ mod mapping_integration_tests {
         }
 
         #[ink_e2e::test]
-        async fn insert_and_remove_works(
-            mut client: ink_e2e::Client<C, E>,
+        async fn insert_and_remove_works<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = MappingsRef::new();
@@ -260,8 +260,8 @@ mod mapping_integration_tests {
         }
 
         #[ink_e2e::test]
-        async fn insert_and_take_works(
-            mut client: ink_e2e::Client<C, E>,
+        async fn insert_and_take_works<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = MappingsRef::new();

--- a/integration-tests/multi-contract-caller/lib.rs
+++ b/integration-tests/multi-contract-caller/lib.rs
@@ -120,8 +120,8 @@ mod multi_contract_caller {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test]
-        async fn e2e_multi_contract_caller(
-            mut client: ink_e2e::Client<C, E>,
+        async fn e2e_multi_contract_caller<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let accumulator_hash = client

--- a/integration-tests/set-code-hash/lib.rs
+++ b/integration-tests/set-code-hash/lib.rs
@@ -73,7 +73,7 @@ pub mod incrementer {
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
         #[ink_e2e::test(additional_contracts = "./updated-incrementer/Cargo.toml")]
-        async fn set_code_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+        async fn set_code_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // Given
             let constructor = IncrementerRef::new();
             let contract = client

--- a/integration-tests/trait-dyn-cross-contract-calls/lib.rs
+++ b/integration-tests/trait-dyn-cross-contract-calls/lib.rs
@@ -63,8 +63,8 @@ mod e2e_tests {
     /// The test verifies that we can increment the value of the `Incrementer` contract
     /// through the `Caller` contract.
     #[ink_e2e::test(additional_contracts = "contracts/incrementer/Cargo.toml")]
-    async fn e2e_cross_contract_calls(
-        mut client: ink_e2e::Client<C, E>,
+    async fn e2e_cross_contract_calls<Client: E2EBackend>(
+        mut client: Client,
     ) -> E2EResult<()> {
         let _ = client
             .upload("trait-incrementer", &ink_e2e::alice(), None)

--- a/integration-tests/wildcard-selector/lib.rs
+++ b/integration-tests/wildcard-selector/lib.rs
@@ -69,8 +69,8 @@ pub mod wildcard_selector {
         }
 
         #[ink_e2e::test]
-        async fn arbitrary_selectors_handled_by_wildcard(
-            mut client: ink_e2e::Client<C, E>,
+        async fn arbitrary_selectors_handled_by_wildcard<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = WildcardSelectorRef::new();
@@ -122,8 +122,8 @@ pub mod wildcard_selector {
         }
 
         #[ink_e2e::test]
-        async fn wildcard_complement_works(
-            mut client: ink_e2e::Client<C, E>,
+        async fn wildcard_complement_works<Client: E2EBackend>(
+            mut client: Client,
         ) -> E2EResult<()> {
             // given
             let constructor = WildcardSelectorRef::new();


### PR DESCRIPTION
Small PR making all the e2e integration tests generic over backend trait.

Note: Since the testcase signature is partly abandoned, the generic bound `Client: E2EBackend` is not necessary (even import is not needed). However, I left it anyway for transparency.

Note: These testcases have to be generic, since `E2EBackend` is not object safe trait (nor are `ChainBackend` and `ContractsBackend`).