### PR TITLE
Persist buffer size in the metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stabilize `call_runtime` ‒ [#1749](https://github.com/paritytech/ink/pull/1749)
 - Make E2E testcases generic over `E2EBackend` trait - [#1867](https://github.com/paritytech/ink/pull/1867)
 - Modify static buffer size via environmental variables - [#1869](https://github.com/paritytech/ink/pull/1869)
+- Persist static buffer size in metadata - [#1880](https://github.com/paritytech/ink/pull/1880)
 
 ### Added
 - Schema generation - [#1765](https://github.com/paritytech/ink/pull/1765)

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -387,6 +387,7 @@ impl Metadata<'_> {
         let timestamp = Self::generate_type_spec(&timestamp);
         let block_number = Self::generate_type_spec(&block_number);
         let chain_extension = Self::generate_type_spec(&chain_extension);
+        let buffer_size_const = quote!(::ink::env::BUFFER_SIZE);
         quote_spanned!(span=>
             ::ink::metadata::EnvironmentSpec::new()
                 .account_id(#account_id)
@@ -396,6 +397,7 @@ impl Metadata<'_> {
                 .block_number(#block_number)
                 .chain_extension(#chain_extension)
                 .max_event_topics(MAX_EVENT_TOPICS)
+                .static_buffer_size(#buffer_size_const)
                 .done()
         )
     }

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -1823,7 +1823,7 @@ where
     TypeSpec<F>: Default,
     EnvironmentSpec<F>: Default,
 {
-    /// Sets the `MAX_EVENT_TOPICS` value of the environment.
+    /// Sets the size of the static buffer configured via environment variable.`
     pub fn static_buffer_size(
         self,
         static_buffer_size: usize,

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -661,7 +661,7 @@ mod state {
     pub struct ChainExtension;
     /// Type state for the max number of topics specified in the environment.
     pub struct MaxEventTopics;
-    /// Type state for the size of the static buffer specified via env var.
+    /// Type state for the size of the static buffer configured via environment variable.`
     pub struct BufferSize;
 }
 

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -661,6 +661,8 @@ mod state {
     pub struct ChainExtension;
     /// Type state for the max number of topics specified in the environment.
     pub struct MaxEventTopics;
+    /// Type state for the size of the static buffer specified via env var.
+    pub struct BufferSize;
 }
 
 impl<F> MessageSpec<F>
@@ -1551,6 +1553,7 @@ where
     block_number: TypeSpec<F>,
     chain_extension: TypeSpec<F>,
     max_event_topics: usize,
+    static_buffer_size: usize,
 }
 
 impl<F> Default for EnvironmentSpec<F>
@@ -1567,6 +1570,7 @@ where
             block_number: Default::default(),
             chain_extension: Default::default(),
             max_event_topics: Default::default(),
+            static_buffer_size: Default::default(),
         }
     }
 }
@@ -1583,6 +1587,7 @@ impl IntoPortable for EnvironmentSpec {
             block_number: self.block_number.into_portable(registry),
             chain_extension: self.chain_extension.into_portable(registry),
             max_event_topics: self.max_event_topics,
+            static_buffer_size: self.static_buffer_size,
         }
     }
 }
@@ -1638,6 +1643,7 @@ where
         Missing<state::BlockNumber>,
         Missing<state::ChainExtension>,
         Missing<state::MaxEventTopics>,
+        Missing<state::BufferSize>,
     > {
         EnvironmentSpecBuilder {
             spec: Default::default(),
@@ -1649,18 +1655,18 @@ where
 /// An environment specification builder.
 #[allow(clippy::type_complexity)]
 #[must_use]
-pub struct EnvironmentSpecBuilder<F, A, B, H, T, BN, C, M>
+pub struct EnvironmentSpecBuilder<F, A, B, H, T, BN, C, M, BS>
 where
     F: Form,
     TypeSpec<F>: Default,
     EnvironmentSpec<F>: Default,
 {
     spec: EnvironmentSpec<F>,
-    marker: PhantomData<fn() -> (A, B, H, T, BN, C, M)>,
+    marker: PhantomData<fn() -> (A, B, H, T, BN, C, M, BS)>,
 }
 
-impl<F, B, H, T, BN, C, M>
-    EnvironmentSpecBuilder<F, Missing<state::AccountId>, B, H, T, BN, C, M>
+impl<F, B, H, T, BN, C, M, BS>
+    EnvironmentSpecBuilder<F, Missing<state::AccountId>, B, H, T, BN, C, M, BS>
 where
     F: Form,
     TypeSpec<F>: Default,
@@ -1670,7 +1676,7 @@ where
     pub fn account_id(
         self,
         account_id: TypeSpec<F>,
-    ) -> EnvironmentSpecBuilder<F, state::AccountId, B, H, T, BN, C, M> {
+    ) -> EnvironmentSpecBuilder<F, state::AccountId, B, H, T, BN, C, M, BS> {
         EnvironmentSpecBuilder {
             spec: EnvironmentSpec {
                 account_id,
@@ -1681,8 +1687,8 @@ where
     }
 }
 
-impl<F, A, H, T, BN, C, M>
-    EnvironmentSpecBuilder<F, A, Missing<state::Balance>, H, T, BN, C, M>
+impl<F, A, H, T, BN, C, M, BS>
+    EnvironmentSpecBuilder<F, A, Missing<state::Balance>, H, T, BN, C, M, BS>
 where
     F: Form,
     TypeSpec<F>: Default,
@@ -1692,7 +1698,7 @@ where
     pub fn balance(
         self,
         balance: TypeSpec<F>,
-    ) -> EnvironmentSpecBuilder<F, A, state::Balance, H, T, BN, C, M> {
+    ) -> EnvironmentSpecBuilder<F, A, state::Balance, H, T, BN, C, M, BS> {
         EnvironmentSpecBuilder {
             spec: EnvironmentSpec {
                 balance,
@@ -1703,8 +1709,8 @@ where
     }
 }
 
-impl<F, A, B, T, BN, C, M>
-    EnvironmentSpecBuilder<F, A, B, Missing<state::Hash>, T, BN, C, M>
+impl<F, A, B, T, BN, C, M, BS>
+    EnvironmentSpecBuilder<F, A, B, Missing<state::Hash>, T, BN, C, M, BS>
 where
     F: Form,
     TypeSpec<F>: Default,
@@ -1714,7 +1720,7 @@ where
     pub fn hash(
         self,
         hash: TypeSpec<F>,
-    ) -> EnvironmentSpecBuilder<F, A, B, state::Hash, T, BN, C, M> {
+    ) -> EnvironmentSpecBuilder<F, A, B, state::Hash, T, BN, C, M, BS> {
         EnvironmentSpecBuilder {
             spec: EnvironmentSpec { hash, ..self.spec },
             marker: PhantomData,
@@ -1722,8 +1728,8 @@ where
     }
 }
 
-impl<F, A, B, H, BN, C, M>
-    EnvironmentSpecBuilder<F, A, B, H, Missing<state::Timestamp>, BN, C, M>
+impl<F, A, B, H, BN, C, M, BS>
+    EnvironmentSpecBuilder<F, A, B, H, Missing<state::Timestamp>, BN, C, M, BS>
 where
     F: Form,
     TypeSpec<F>: Default,
@@ -1733,7 +1739,7 @@ where
     pub fn timestamp(
         self,
         timestamp: TypeSpec<F>,
-    ) -> EnvironmentSpecBuilder<F, A, B, H, state::Timestamp, BN, C, M> {
+    ) -> EnvironmentSpecBuilder<F, A, B, H, state::Timestamp, BN, C, M, BS> {
         EnvironmentSpecBuilder {
             spec: EnvironmentSpec {
                 timestamp,
@@ -1744,8 +1750,8 @@ where
     }
 }
 
-impl<F, A, B, H, T, C, M>
-    EnvironmentSpecBuilder<F, A, B, H, T, Missing<state::BlockNumber>, C, M>
+impl<F, A, B, H, T, C, M, BS>
+    EnvironmentSpecBuilder<F, A, B, H, T, Missing<state::BlockNumber>, C, M, BS>
 where
     F: Form,
     TypeSpec<F>: Default,
@@ -1755,7 +1761,7 @@ where
     pub fn block_number(
         self,
         block_number: TypeSpec<F>,
-    ) -> EnvironmentSpecBuilder<F, A, B, H, T, state::BlockNumber, C, M> {
+    ) -> EnvironmentSpecBuilder<F, A, B, H, T, state::BlockNumber, C, M, BS> {
         EnvironmentSpecBuilder {
             spec: EnvironmentSpec {
                 block_number,
@@ -1766,8 +1772,8 @@ where
     }
 }
 
-impl<F, A, B, H, T, BN, M>
-    EnvironmentSpecBuilder<F, A, B, H, T, BN, Missing<state::ChainExtension>, M>
+impl<F, A, B, H, T, BN, M, BS>
+    EnvironmentSpecBuilder<F, A, B, H, T, BN, Missing<state::ChainExtension>, M, BS>
 where
     F: Form,
     TypeSpec<F>: Default,
@@ -1777,7 +1783,7 @@ where
     pub fn chain_extension(
         self,
         chain_extension: TypeSpec<F>,
-    ) -> EnvironmentSpecBuilder<F, A, B, H, T, BN, state::ChainExtension, M> {
+    ) -> EnvironmentSpecBuilder<F, A, B, H, T, BN, state::ChainExtension, M, BS> {
         EnvironmentSpecBuilder {
             spec: EnvironmentSpec {
                 chain_extension,
@@ -1788,8 +1794,8 @@ where
     }
 }
 
-impl<F, A, B, H, T, BN, C>
-    EnvironmentSpecBuilder<F, A, B, H, T, BN, C, Missing<state::MaxEventTopics>>
+impl<F, A, B, H, T, BN, C, BS>
+    EnvironmentSpecBuilder<F, A, B, H, T, BN, C, Missing<state::MaxEventTopics>, BS>
 where
     F: Form,
     TypeSpec<F>: Default,
@@ -1799,10 +1805,32 @@ where
     pub fn max_event_topics(
         self,
         max_event_topics: usize,
-    ) -> EnvironmentSpecBuilder<F, A, B, H, T, BN, C, state::MaxEventTopics> {
+    ) -> EnvironmentSpecBuilder<F, A, B, H, T, BN, C, state::MaxEventTopics, BS> {
         EnvironmentSpecBuilder {
             spec: EnvironmentSpec {
                 max_event_topics,
+                ..self.spec
+            },
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<F, A, B, H, T, BN, C, M>
+    EnvironmentSpecBuilder<F, A, B, H, T, BN, C, M, Missing<state::BufferSize>>
+where
+    F: Form,
+    TypeSpec<F>: Default,
+    EnvironmentSpec<F>: Default,
+{
+    /// Sets the `MAX_EVENT_TOPICS` value of the environment.
+    pub fn static_buffer_size(
+        self,
+        static_buffer_size: usize,
+    ) -> EnvironmentSpecBuilder<F, A, B, H, T, BN, C, M, state::BufferSize> {
+        EnvironmentSpecBuilder {
+            spec: EnvironmentSpec {
+                static_buffer_size,
                 ..self.spec
             },
             marker: PhantomData,
@@ -1820,6 +1848,7 @@ impl<F>
         state::BlockNumber,
         state::ChainExtension,
         state::MaxEventTopics,
+        state::BufferSize,
     >
 where
     F: Form,

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -157,6 +157,7 @@ fn spec_contract_only_one_default_constructor_allowed() {
 )]
 fn spec_contract_event_definition_exceeds_environment_topics_limit() {
     const MAX_EVENT_TOPICS: usize = 2;
+    const BUFFER_SIZE: usize = 1 << 14;
 
     ContractSpec::new()
         .constructors(vec![ConstructorSpec::from_label("new")
@@ -238,6 +239,7 @@ fn spec_contract_event_definition_exceeds_environment_topics_limit() {
                 .block_number(TypeSpec::of_type::<u128>())
                 .chain_extension(TypeSpec::of_type::<()>())
                 .max_event_topics(MAX_EVENT_TOPICS)
+                .static_buffer_size(BUFFER_SIZE)
                 .done(),
         )
         .done();
@@ -249,6 +251,7 @@ fn spec_contract_event_definition_exceeds_environment_topics_limit() {
 )]
 fn spec_contract_event_definition_signature_topic_collision() {
     const SIGNATURE_TOPIC: Option<[u8; 32]> = Some([42u8; 32]);
+    const BUFFER_SIZE: usize = 1 << 14;
 
     ContractSpec::new()
         .constructors(vec![ConstructorSpec::from_label("new")
@@ -303,6 +306,7 @@ fn spec_contract_event_definition_signature_topic_collision() {
                 .block_number(TypeSpec::of_type::<u128>())
                 .chain_extension(TypeSpec::of_type::<()>())
                 .max_event_topics(2)
+                .static_buffer_size(BUFFER_SIZE)
                 .done(),
         )
         .done();
@@ -320,6 +324,7 @@ fn spec_contract_json() {
     type BlockNumber = u128;
     type ChainExtension = NoChainExtension;
     const MAX_EVENT_TOPICS: usize = 4;
+    const BUFFER_SIZE: usize = 1 << 14;
 
     // given
     let contract: ContractSpec = ContractSpec::new()
@@ -424,6 +429,7 @@ fn spec_contract_json() {
                     ),
                 ))
                 .max_event_topics(MAX_EVENT_TOPICS)
+                .static_buffer_size(BUFFER_SIZE)
                 .done(),
         )
         .done();
@@ -503,6 +509,7 @@ fn spec_contract_json() {
                     ],
                     "type": 9,
                 },
+                "staticBufferSize": 16384,
                 "chainExtension":  {
                     "displayName":  [
                         "ChainExtension",
@@ -714,6 +721,7 @@ fn environment_spec() -> EnvironmentSpec<PortableForm> {
         .block_number(Default::default())
         .chain_extension(Default::default())
         .max_event_topics(4)
+        .static_buffer_size(16384)
         .done()
 }
 


### PR DESCRIPTION
Feat to #1869 and closes #1879 

Adds `"staticBufferSize"` field to the metadata file:

Example:
```json
      "maxEventTopics": 4,
      "staticBufferSize": 16384,
      "timestamp": {
        "displayName": [
          "Timestamp"
        ],
        "type": 11
      }
```