### PR TITLE
Use `contract-build` version `3.2.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ array-init = { version = "2.0", default-features = false }
 blake2 = { version = "0.10" }
 cargo_metadata = { version = "0.17.0" }
 cfg-if = { version = "1.0" }
-contract-build = { version = "4.0.0-alpha" }
+contract-build = { version = "3.2.0" }
 derive_more = { version = "0.99.17", default-features = false }
 either = { version = "1.5", default-features = false }
 funty = { version = "2.0.0" }

--- a/crates/e2e/src/contract_build.rs
+++ b/crates/e2e/src/contract_build.rs
@@ -179,7 +179,6 @@ fn build_contract(path_to_cargo_toml: &Path) -> PathBuf {
         output_type: OutputType::HumanReadable,
         skip_wasm_validation: false,
         target: Target::Wasm,
-        ..ExecuteArgs::default()
     };
 
     match contract_build::execute(args) {


### PR DESCRIPTION
Use the recently released https://github.com/paritytech/cargo-contract/releases/tag/v3.2.0.

This enables E2E tests to be run with newer Rust toolchains against older node versions which don't support `signext` instructions.