### PR TITLE
`[v4.x.x]` fix E2E tests for newer rust toolchain & contracts node

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -12,7 +12,10 @@ FFI
 Gnosis
 GPL
 KECCAK
+L1
+L2
 Polkadot
+PSP22
 RPC
 SHA
 UI/S
@@ -62,6 +65,7 @@ scalability
 scalable
 stdin
 stdout
+subber
 tuple
 unordered
 untyped

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -449,7 +449,7 @@ examples-contract-build-riscv:
         if [ "$example" = "integration-tests/custom_allocator/" ]; then continue; fi;
         if [ "$example" = "integration-tests/call-runtime/" ]; then continue; fi;
         pushd $example &&
-        cargo +stable build --no-default-features --target $RISCV_TARGET -Zbuild-std="core,alloc" &&
+        cargo build --no-default-features --target $RISCV_TARGET -Zbuild-std="core,alloc" &&
         popd;
       done
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,9 +26,7 @@ variables:
   GIT_DEPTH:                       100
   CARGO_INCREMENTAL:               0
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
-  # CI_IMAGE is changed to "-:staging" when the CI image gets rebuilt
-  # read more https://github.com/paritytech/scripts/pull/244
-  CI_IMAGE:                        "paritytech/ink-ci-linux:a1f03f4b-20230420"
+  CI_IMAGE:                        "paritytech/ci-unified:bullseye-1.71.0-2023-05-23"
   PURELY_STD_CRATES:               "ink/codegen metadata engine e2e e2e/macro ink/ir"
   ALSO_WASM_CRATES:                "env storage storage/traits allocator prelude primitives ink ink/macro"
   ALL_CRATES:                      "${PURELY_STD_CRATES} ${ALSO_WASM_CRATES}"

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -29,7 +29,8 @@ tokio = { version = "1.18.2", features = ["rt-multi-thread"] }
 log = { version = "0.4" }
 env_logger = { version = "0.10" }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-subxt = "0.28.0"
+subxt = "0.31.0"
+subxt-signer = { version = "0.31.0", features = ["subxt", "sr25519"] }
 
 # Substrate
 pallet-contracts-primitives = "24.0.0"

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -32,11 +32,11 @@ scale = { package = "parity-scale-codec", version = "3.4", default-features = fa
 subxt = "0.28.0"
 
 # Substrate
-pallet-contracts-primitives = "23.0.0"
-sp-core = "20.0.0"
-sp-keyring = "23.0.0"
-sp-runtime = "23.0.0"
-sp-weights = "19.0.0"
+pallet-contracts-primitives = "24.0.0"
+sp-core = "21.0.0"
+sp-keyring = "24.0.0"
+sp-runtime = "24.0.0"
+sp-weights = "20.0.0"
 
 [dev-dependencies]
 # Required for the doctest of `MessageBuilder::call`

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro = true
 [dependencies]
 ink_ir = { version = "4.2.1", path = "../../ink/ir" }
 cargo_metadata = "0.15.3"
-contract-build = "2.0.2"
+contract-build = "3.2.0"
 derive_more = "0.99.17"
 env_logger = "0.10.0"
 log = "0.4.17"

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use crate::ir;
-use contract_build::ManifestPath;
+use contract_build::{
+    ManifestPath,
+    Target,
+};
 use core::cell::RefCell;
 use derive_more::From;
 use proc_macro2::TokenStream as TokenStream2;
@@ -289,6 +292,7 @@ fn build_contract(path_to_cargo_toml: &str) -> String {
         lint: false,
         output_type: OutputType::HumanReadable,
         skip_wasm_validation: false,
+        target: Target::Wasm,
     };
 
     match contract_build::execute(args) {

--- a/crates/e2e/src/client.rs
+++ b/crates/e2e/src/client.rs
@@ -429,7 +429,6 @@ where
     where
         E::Balance: Clone,
         C::AccountId: Clone + core::fmt::Display + Debug,
-        C::AccountId: From<sp_core::crypto::AccountId32>,
     {
         let (_, phrase, _) =
             <sp_core::sr25519::Pair as sp_core::Pair>::generate_with_phrase(None);

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -21,7 +21,6 @@
 
 mod builders;
 mod client;
-mod default_accounts;
 mod node_proc;
 mod xts;
 
@@ -37,7 +36,6 @@ pub use client::{
     InstantiationResult,
     UploadResult,
 };
-pub use default_accounts::*;
 pub use env_logger;
 pub use ink_e2e_macro::test;
 pub use node_proc::{
@@ -46,9 +44,11 @@ pub use node_proc::{
 };
 pub use sp_core::H256;
 pub use sp_keyring::AccountKeyring;
-pub use subxt::{
+pub use subxt;
+pub use subxt_signer::sr25519::{
     self,
-    tx::PairSigner,
+    dev::*,
+    Keypair,
 };
 pub use tokio;
 
@@ -57,44 +57,13 @@ use pallet_contracts_primitives::{
     ContractExecResult,
     ContractInstantiateResult,
 };
-use sp_core::sr25519;
 use std::{
     cell::RefCell,
     sync::Once,
 };
 use xts::ContractsApi;
 
-/// Default set of commonly used types by Substrate runtimes.
-#[cfg(feature = "std")]
-pub enum SubstrateConfig {}
-
-#[cfg(feature = "std")]
-impl subxt::Config for SubstrateConfig {
-    type Index = u32;
-    type Hash = sp_core::H256;
-    type Hasher = subxt::config::substrate::BlakeTwo256;
-    type AccountId = subxt::config::substrate::AccountId32;
-    type Address = sp_runtime::MultiAddress<Self::AccountId, u32>;
-    type Header = subxt::config::substrate::SubstrateHeader<
-        u32,
-        subxt::config::substrate::BlakeTwo256,
-    >;
-    type Signature = sp_runtime::MultiSignature;
-    type ExtrinsicParams = subxt::config::substrate::SubstrateExtrinsicParams<Self>;
-}
-
-/// Default set of commonly used types by Polkadot nodes.
-#[cfg(feature = "std")]
-pub type PolkadotConfig = subxt::config::WithExtrinsicParams<
-    SubstrateConfig,
-    subxt::config::polkadot::PolkadotExtrinsicParams<SubstrateConfig>,
->;
-
-/// Signer that is used throughout the E2E testing.
-///
-/// The E2E testing can only be used with nodes that support `sr25519`
-/// cryptography.
-pub type Signer<C> = PairSigner<C, sr25519::Pair>;
+pub use subxt::PolkadotConfig;
 
 /// We use this to only initialize `env_logger` once.
 pub static INIT: Once = Once::new();

--- a/crates/e2e/src/node_proc.rs
+++ b/crates/e2e/src/node_proc.rs
@@ -60,10 +60,10 @@ where
 
     /// Attempt to kill the running substrate process.
     pub fn kill(&mut self) -> Result<(), String> {
-        log::info!("Killing node process {}", self.proc.id());
+        tracing::info!("Killing node process {}", self.proc.id());
         if let Err(err) = self.proc.kill() {
             let err = format!("Error killing node process {}: {}", self.proc.id(), err);
-            log::error!("{}", err);
+            tracing::error!("{}", err);
             return Err(err)
         }
         Ok(())
@@ -135,22 +135,22 @@ where
 
         // Wait for RPC port to be logged (it's logged to stderr):
         let stderr = proc.stderr.take().unwrap();
-        let ws_port = find_substrate_port_from_output(stderr);
-        let ws_url = format!("ws://127.0.0.1:{ws_port}");
+        let port = find_substrate_port_from_output(stderr);
+        let url = format!("ws://127.0.0.1:{port}");
 
         // Connect to the node with a `subxt` client:
-        let client = OnlineClient::from_url(ws_url.clone()).await;
+        let client = OnlineClient::from_url(url.clone()).await;
         match client {
             Ok(client) => {
                 Ok(TestNodeProcess {
                     proc,
                     client,
-                    url: ws_url.clone(),
+                    url: url.clone(),
                 })
             }
             Err(err) => {
-                let err = format!("Failed to connect to node rpc at {ws_url}: {err}");
-                log::error!("{}", err);
+                let err = format!("Failed to connect to node rpc at {url}: {err}");
+                tracing::error!("{}", err);
                 proc.kill().map_err(|e| {
                     format!("Error killing substrate process '{}': {}", proc.id(), e)
                 })?;
@@ -176,6 +176,7 @@ fn find_substrate_port_from_output(r: impl Read + Send + 'static) -> u16 {
                 .or_else(|| {
                     line.rsplit_once("Running JSON-RPC WS server: addr=127.0.0.1:")
                 })
+                .or_else(|| line.rsplit_once("Running JSON-RPC server: addr=127.0.0.1:"))
                 .map(|(_, port_str)| port_str)?;
 
             // trim non-numeric chars from the end of the port part of the line.
@@ -184,7 +185,7 @@ fn find_substrate_port_from_output(r: impl Read + Send + 'static) -> u16 {
             // expect to have a number here (the chars after '127.0.0.1:') and parse them
             // into a u16.
             let port_num = port_str.parse().unwrap_or_else(|_| {
-                panic!("valid port expected for log line, got '{port_str}'")
+                panic!("valid port expected for tracing line, got '{port_str}'")
             });
 
             Some(port_num)

--- a/crates/e2e/src/node_proc.rs
+++ b/crates/e2e/src/node_proc.rs
@@ -60,10 +60,10 @@ where
 
     /// Attempt to kill the running substrate process.
     pub fn kill(&mut self) -> Result<(), String> {
-        tracing::info!("Killing node process {}", self.proc.id());
+        log::info!("Killing node process {}", self.proc.id());
         if let Err(err) = self.proc.kill() {
             let err = format!("Error killing node process {}: {}", self.proc.id(), err);
-            tracing::error!("{}", err);
+            log::error!("{}", err);
             return Err(err)
         }
         Ok(())
@@ -116,8 +116,7 @@ where
             .stdout(process::Stdio::piped())
             .stderr(process::Stdio::piped())
             .arg("--port=0")
-            .arg("--rpc-port=0")
-            .arg("--ws-port=0");
+            .arg("--rpc-port=0");
 
         if let Some(authority) = self.authority {
             let authority = format!("{authority:?}");
@@ -150,7 +149,7 @@ where
             }
             Err(err) => {
                 let err = format!("Failed to connect to node rpc at {url}: {err}");
-                tracing::error!("{}", err);
+                log::error!("{}", err);
                 proc.kill().map_err(|e| {
                     format!("Error killing substrate process '{}': {}", proc.id(), e)
                 })?;
@@ -185,7 +184,7 @@ fn find_substrate_port_from_output(r: impl Read + Send + 'static) -> u16 {
             // expect to have a number here (the chars after '127.0.0.1:') and parse them
             // into a u16.
             let port_num = port_str.parse().unwrap_or_else(|_| {
-                panic!("valid port expected for tracing line, got '{port_str}'")
+                panic!("valid port expected for log line, got '{port_str}'")
             });
 
             Some(port_num)

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -18,7 +18,7 @@ use super::{
     sr25519,
     ContractExecResult,
     ContractInstantiateResult,
-    Signer,
+    Keypair,
 };
 use ink_env::Environment;
 
@@ -33,6 +33,7 @@ use subxt::{
     config::ExtrinsicParams,
     ext::scale_encode,
     rpc_params,
+    tx::Signer,
     utils::MultiAddress,
     OnlineClient,
 };
@@ -210,10 +211,10 @@ pub struct ContractsApi<C: subxt::Config, E: Environment> {
 impl<C, E> ContractsApi<C, E>
 where
     C: subxt::Config,
-    C::AccountId: serde::de::DeserializeOwned,
-    C::AccountId: scale::Codec,
+    C::AccountId: From<sr25519::PublicKey> + serde::de::DeserializeOwned + scale::Codec,
+    C::Address: From<sr25519::PublicKey>,
     C::Signature: From<sr25519::Signature>,
-    <C::ExtrinsicParams as ExtrinsicParams<C::Index, C::Hash>>::OtherParams: Default,
+    <C::ExtrinsicParams as ExtrinsicParams<C::Hash>>::OtherParams: Default,
 
     E: Environment,
     E::Balance: scale::HasCompact + serde::Serialize,
@@ -232,7 +233,7 @@ where
     /// invalid (e.g. out of date nonce)
     pub async fn try_transfer_balance(
         &self,
-        origin: &Signer<C>,
+        origin: &Keypair,
         dest: C::AccountId,
         value: E::Balance,
     ) -> Result<(), subxt::Error> {
@@ -267,11 +268,11 @@ where
         code: Vec<u8>,
         data: Vec<u8>,
         salt: Vec<u8>,
-        signer: &Signer<C>,
-    ) -> ContractInstantiateResult<C::AccountId, E::Balance> {
+        signer: &Keypair,
+    ) -> ContractInstantiateResult<C::AccountId, E::Balance, ()> {
         let code = Code::Upload(code);
         let call_request = RpcInstantiateRequest::<C, E> {
-            origin: subxt::tx::Signer::account_id(signer).clone(),
+            origin: Signer::<C>::account_id(signer),
             value,
             gas_limit: None,
             storage_deposit_limit,
@@ -298,7 +299,7 @@ where
     pub async fn submit_extrinsic<Call>(
         &self,
         call: &Call,
-        signer: &Signer<C>,
+        signer: &Keypair,
     ) -> ExtrinsicEvents<C>
     where
         Call: subxt::tx::TxPayload,
@@ -342,7 +343,7 @@ where
         code: Vec<u8>,
         data: Vec<u8>,
         salt: Vec<u8>,
-        signer: &Signer<C>,
+        signer: &Keypair,
     ) -> ExtrinsicEvents<C> {
         let call = subxt::tx::Payload::new(
             "Contracts",
@@ -364,12 +365,12 @@ where
     /// Dry runs the upload of the given `code`.
     pub async fn upload_dry_run(
         &self,
-        signer: &Signer<C>,
+        signer: &Keypair,
         code: Vec<u8>,
         storage_deposit_limit: Option<E::Balance>,
     ) -> CodeUploadResult<E::Hash, E::Balance> {
         let call_request = RpcCodeUploadRequest::<C, E> {
-            origin: subxt::tx::Signer::account_id(signer).clone(),
+            origin: Signer::<C>::account_id(signer),
             code,
             storage_deposit_limit,
             determinism: Determinism::Deterministic,
@@ -394,7 +395,7 @@ where
     /// contains all events that are associated with this transaction.
     pub async fn upload(
         &self,
-        signer: &Signer<C>,
+        signer: &Keypair,
         code: Vec<u8>,
         storage_deposit_limit: Option<E::Balance>,
     ) -> ExtrinsicEvents<C> {
@@ -419,7 +420,7 @@ where
         message: &Message<E, RetType>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> ContractExecResult<E::Balance> {
+    ) -> ContractExecResult<E::Balance, ()> {
         let call_request = RpcCallRequest::<C, E> {
             origin,
             dest: message.account_id().clone(),
@@ -453,7 +454,7 @@ where
         gas_limit: Weight,
         storage_deposit_limit: Option<E::Balance>,
         data: Vec<u8>,
-        signer: &Signer<C>,
+        signer: &Keypair,
     ) -> ExtrinsicEvents<C> {
         let call = subxt::tx::Payload::new(
             "Contracts",
@@ -479,7 +480,7 @@ where
     /// contains all events that are associated with this transaction.
     pub async fn runtime_call<'a>(
         &self,
-        signer: &Signer<C>,
+        signer: &Keypair,
         pallet_name: &'a str,
         call_name: &'a str,
         call_data: Vec<subxt::dynamic::Value>,

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -130,7 +130,7 @@ pub enum Determinism {
     ///
     /// Dispatchables always use this mode in order to make on-chain execution
     /// deterministic.
-    Deterministic,
+    Enforced,
     /// Allow calling or uploading an indeterministic code.
     ///
     /// This is only possible when calling into `pallet-contracts` directly via
@@ -139,7 +139,7 @@ pub enum Determinism {
     /// # Note
     ///
     /// **Never** use this mode for on-chain execution.
-    AllowIndeterminism,
+    Relaxed,
 }
 
 /// A raw call to `pallet-contracts`'s `upload`.
@@ -373,7 +373,7 @@ where
             origin: Signer::<C>::account_id(signer),
             code,
             storage_deposit_limit,
-            determinism: Determinism::Deterministic,
+            determinism: Determinism::Enforced,
         };
         let func = "ContractsApi_upload_code";
         let params = rpc_params![func, Bytes(scale::Encode::encode(&call_request))];
@@ -405,7 +405,7 @@ where
             UploadCode::<E> {
                 code,
                 storage_deposit_limit,
-                determinism: Determinism::Deterministic,
+                determinism: Determinism::Enforced,
             },
         )
         .unvalidated();

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -47,8 +47,8 @@ secp256k1 = { version = "0.27.0", features = ["recovery", "global-context"], opt
 #
 # Sadly couldn't be marked as dev-dependency.
 # Never use this crate outside the off-chain environment!
-scale-decode = { version = "0.5.0", default-features = false, optional = true }
-scale-encode = { version = "0.1.0", default-features = false, optional = true }
+scale-decode = { version = "0.9.0", default-features = false, optional = true }
+scale-encode = { version = "0.5.0", default-features = false, optional = true }
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]

--- a/crates/ink/tests/ui/contract/fail/constructor-input-non-codec.stderr
+++ b/crates/ink/tests/ui/contract/fail/constructor-input-non-codec.stderr
@@ -12,6 +12,9 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeDecode` is not satisfied
 note: required by a bound in `DispatchInput`
   --> src/codegen/dispatch/type_check.rs
    |
+   | pub struct DispatchInput<T>(T)
+   |            ------------- required by a bound in this struct
+   | where
    |     T: scale::Decode + 'static;
    |        ^^^^^^^^^^^^^ required by this bound in `DispatchInput`
 
@@ -50,5 +53,8 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
 note: required by a bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd>>::push_arg`
   --> $WORKSPACE/crates/env/src/call/execution_input.rs
    |
+   |     pub fn push_arg<T>(
+   |            -------- required by a bound in this associated function
+...
    |         T: scale::Encode,
    |            ^^^^^^^^^^^^^ required by this bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd>>::push_arg`

--- a/crates/ink/tests/ui/contract/fail/constructor-return-result-non-codec-error.stderr
+++ b/crates/ink/tests/ui/contract/fail/constructor-return-result-non-codec-error.stderr
@@ -8,6 +8,9 @@ error[E0277]: the trait bound `Result<Result<(), &contract::Error>, LangError>: 
 note: required by a bound in `return_value`
   --> $WORKSPACE/crates/env/src/api.rs
    |
+   | pub fn return_value<R>(return_flags: ReturnFlags, return_value: &R) -> !
+   |        ------------ required by a bound in this function
+   | where
    |     R: scale::Encode,
    |        ^^^^^^^^^^^^^ required by this bound in `return_value`
 
@@ -26,6 +29,9 @@ error[E0277]: the trait bound `contract::Error: WrapperTypeDecode` is not satisf
 note: required by a bound in `CreateBuilder::<E, ContractRef, CodeHash, GasLimit, Endowment, Args, Salt, Unset<ReturnType<()>>>::returns`
   --> $WORKSPACE/crates/env/src/call/create_builder.rs
    |
+   |     pub fn returns<R>(
+   |            ------- required by a bound in this associated function
+...
    |         R: ConstructorReturnType<ContractRef>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CreateBuilder::<E, ContractRef, CodeHash, GasLimit, Endowment, Args, Salt, Unset<ReturnType<()>>>::returns`
 
@@ -51,5 +57,8 @@ error[E0277]: the trait bound `contract::Error: TypeInfo` is not satisfied
 note: required by a bound in `TypeSpec::with_name_str`
  --> $WORKSPACE/crates/metadata/src/specs.rs
   |
+  |     pub fn with_name_str<T>(display_name: &'static str) -> Self
+  |            ------------- required by a bound in this associated function
+  |     where
   |         T: TypeInfo + 'static,
   |            ^^^^^^^^ required by this bound in `TypeSpec::with_name_str`

--- a/crates/ink/tests/ui/contract/fail/constructor-self-receiver-03.stderr
+++ b/crates/ink/tests/ui/contract/fail/constructor-self-receiver-03.stderr
@@ -22,14 +22,14 @@ error[E0411]: cannot find type `Self` in this scope
 8 |         pub fn constructor(this: &Self) -> Self {
   |                                   ^^^^ `Self` is only available in impls, traits, and type definitions
 
-error[E0277]: the trait bound `&'static Contract: WrapperTypeDecode` is not satisfied
+error[E0277]: the trait bound `&Contract: WrapperTypeDecode` is not satisfied
  --> tests/ui/contract/fail/constructor-self-receiver-03.rs:8:9
   |
 8 |         pub fn constructor(this: &Self) -> Self {
-  |         ^^^ the trait `WrapperTypeDecode` is not implemented for `&'static Contract`
+  |         ^^^ the trait `WrapperTypeDecode` is not implemented for `&Contract`
   |
   = help: the following other types implement trait `WrapperTypeDecode`:
             Arc<T>
             Box<T>
             Rc<T>
-  = note: required for `&'static Contract` to implement `parity_scale_codec::Decode`
+  = note: required for `&Contract` to implement `parity_scale_codec::Decode`

--- a/crates/ink/tests/ui/contract/fail/event-too-many-topics-anonymous.stderr
+++ b/crates/ink/tests/ui/contract/fail/event-too-many-topics-anonymous.stderr
@@ -17,5 +17,8 @@ error[E0277]: the trait bound `EventTopics<4>: RespectTopicLimit<2>` is not sati
 note: required by a bound in `EventRespectsTopicLimit`
   --> src/codegen/event/topics.rs
    |
+   | pub struct EventRespectsTopicLimit<Event, const LEN_MAX_TOPICS: usize>
+   |            ----------------------- required by a bound in this struct
+...
    |     <Event as EventLenTopics>::LenTopics: RespectTopicLimit<LEN_MAX_TOPICS>,
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EventRespectsTopicLimit`

--- a/crates/ink/tests/ui/contract/fail/event-too-many-topics.stderr
+++ b/crates/ink/tests/ui/contract/fail/event-too-many-topics.stderr
@@ -17,5 +17,8 @@ error[E0277]: the trait bound `EventTopics<3>: RespectTopicLimit<2>` is not sati
 note: required by a bound in `EventRespectsTopicLimit`
   --> src/codegen/event/topics.rs
    |
+   | pub struct EventRespectsTopicLimit<Event, const LEN_MAX_TOPICS: usize>
+   |            ----------------------- required by a bound in this struct
+...
    |     <Event as EventLenTopics>::LenTopics: RespectTopicLimit<LEN_MAX_TOPICS>,
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EventRespectsTopicLimit`

--- a/crates/ink/tests/ui/contract/fail/impl-block-for-non-storage-01.stderr
+++ b/crates/ink/tests/ui/contract/fail/impl-block-for-non-storage-01.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> tests/ui/contract/fail/impl-block-for-non-storage-01.rs:18:10
    |
 18 |     impl NonContract {
-   |          ^^^^^^^^^^^ expected struct `Contract`, found struct `NonContract`
+   |          ^^^^^^^^^^^ expected `IsSameType<Contract>`, found `IsSameType<NonContract>`
    |
    = note: expected struct `IsSameType<Contract>`
               found struct `IsSameType<NonContract>`
@@ -10,23 +10,37 @@ error[E0308]: mismatched types
 error[E0599]: no function or associated item named `constructor_2` found for struct `Contract` in the current scope
   --> tests/ui/contract/fail/impl-block-for-non-storage-01.rs:20:16
    |
-4  |     pub struct Contract {}
-   |     --- function or associated item `constructor_2` not found for this struct
-...
-20 |         pub fn constructor_2() -> Self {
-   |                ^^^^^^^^^^^^^
-   |                |
-   |                function or associated item not found in `Contract`
-   |                help: there is an associated function with a similar name: `constructor_1`
+4  |       pub struct Contract {}
+   |  _____---________-
+   | |     |
+   | |     function or associated item `constructor_2` not found for this struct
+5  | |
+6  | |     impl Contract {
+7  | |         #[ink(constructor)]
+...  |
+19 | |         #[ink(constructor)]
+20 | |         pub fn constructor_2() -> Self {
+   | |               -^^^^^^^^^^^^^
+   | |               ||
+   | |               |function or associated item not found in `Contract`
+   | |_______________|help: there is an associated function with a similar name: `constructor_1`
+   |
 
 error[E0599]: no function or associated item named `message_2` found for struct `Contract` in the current scope
   --> tests/ui/contract/fail/impl-block-for-non-storage-01.rs:25:16
    |
-4  |     pub struct Contract {}
-   |     --- function or associated item `message_2` not found for this struct
-...
-25 |         pub fn message_2(&self) {}
-   |                ^^^^^^^^^
-   |                |
-   |                function or associated item not found in `Contract`
-   |                help: there is a method with a similar name: `message_1`
+4  |       pub struct Contract {}
+   |  _____---________-
+   | |     |
+   | |     function or associated item `message_2` not found for this struct
+5  | |
+6  | |     impl Contract {
+7  | |         #[ink(constructor)]
+...  |
+24 | |         #[ink(message)]
+25 | |         pub fn message_2(&self) {}
+   | |               -^^^^^^^^^
+   | |               ||
+   | |               |function or associated item not found in `Contract`
+   | |_______________|help: there is a method with a similar name: `message_1`
+   |

--- a/crates/ink/tests/ui/contract/fail/impl-block-for-non-storage-02.stderr
+++ b/crates/ink/tests/ui/contract/fail/impl-block-for-non-storage-02.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> tests/ui/contract/fail/impl-block-for-non-storage-02.rs:19:10
    |
 19 |     impl NonContract {}
-   |          ^^^^^^^^^^^ expected struct `Contract`, found struct `NonContract`
+   |          ^^^^^^^^^^^ expected `IsSameType<Contract>`, found `IsSameType<NonContract>`
    |
    = note: expected struct `IsSameType<Contract>`
               found struct `IsSameType<NonContract>`

--- a/crates/ink/tests/ui/contract/fail/impl-block-using-env-no-marker.stderr
+++ b/crates/ink/tests/ui/contract/fail/impl-block-using-env-no-marker.stderr
@@ -7,5 +7,5 @@ error[E0599]: no method named `env` found for reference `&Contract` in the curre
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
-1  | use ink::codegen::Env;
+1  + use ink::codegen::Env;
    |

--- a/crates/ink/tests/ui/contract/fail/impl-block-using-static-env-no-marker.stderr
+++ b/crates/ink/tests/ui/contract/fail/impl-block-using-static-env-no-marker.stderr
@@ -10,5 +10,5 @@ error[E0599]: no function or associated item named `env` found for struct `Contr
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
-1  | use ink::codegen::StaticEnv;
+1  + use ink::codegen::StaticEnv;
    |

--- a/crates/ink/tests/ui/contract/fail/message-input-non-codec.stderr
+++ b/crates/ink/tests/ui/contract/fail/message-input-non-codec.stderr
@@ -12,6 +12,9 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeDecode` is not satisfied
 note: required by a bound in `DispatchInput`
   --> src/codegen/dispatch/type_check.rs
    |
+   | pub struct DispatchInput<T>(T)
+   |            ------------- required by a bound in this struct
+   | where
    |     T: scale::Decode + 'static;
    |        ^^^^^^^^^^^^^ required by this bound in `DispatchInput`
 
@@ -50,10 +53,13 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
 note: required by a bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd>>::push_arg`
   --> $WORKSPACE/crates/env/src/call/execution_input.rs
    |
+   |     pub fn push_arg<T>(
+   |            -------- required by a bound in this associated function
+...
    |         T: scale::Encode,
    |            ^^^^^^^^^^^^^ required by this bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd>>::push_arg`
 
-error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvironment, Set<Call<DefaultEnvironment>>, Set<ExecutionInput<ArgumentList<Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>>>, Set<ReturnType<()>>>`, but its trait bounds were not satisfied
+error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvironment, Set<Call<DefaultEnvironment>>, Set<ExecutionInput<...>>, ...>`, but its trait bounds were not satisfied
   --> tests/ui/contract/fail/message-input-non-codec.rs:16:9
    |
 16 |         pub fn message(&self, _input: NonCodecType) {}
@@ -65,4 +71,4 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvi
    | ----------------------------------- doesn't satisfy `_: Encode`
    |
    = note: the following trait bounds were not satisfied:
-           `ArgumentList<ink::ink_env::call::utils::Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>: Encode`
+           `ArgumentList<Argument<NonCodecType>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>: Encode`

--- a/crates/ink/tests/ui/contract/fail/message-returns-non-codec.stderr
+++ b/crates/ink/tests/ui/contract/fail/message-returns-non-codec.stderr
@@ -18,6 +18,9 @@ error[E0277]: the trait bound `NonCodecType: WrapperTypeEncode` is not satisfied
 note: required by a bound in `DispatchOutput`
   --> src/codegen/dispatch/type_check.rs
    |
+   | pub struct DispatchOutput<T>(T)
+   |            -------------- required by a bound in this struct
+   | where
    |     T: scale::Encode + 'static;
    |        ^^^^^^^^^^^^^ required by this bound in `DispatchOutput`
 
@@ -31,10 +34,13 @@ error[E0277]: the trait bound `Result<NonCodecType, LangError>: Encode` is not s
 note: required by a bound in `return_value`
   --> $WORKSPACE/crates/env/src/api.rs
    |
+   | pub fn return_value<R>(return_flags: ReturnFlags, return_value: &R) -> !
+   |        ------------ required by a bound in this function
+   | where
    |     R: scale::Encode,
    |        ^^^^^^^^^^^^^ required by this bound in `return_value`
 
-error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvironment, Set<Call<DefaultEnvironment>>, Set<ExecutionInput<ArgumentList<ArgumentListEnd, ArgumentListEnd>>>, Set<ReturnType<NonCodecType>>>`, but its trait bounds were not satisfied
+error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvironment, Set<Call<DefaultEnvironment>>, Set<ExecutionInput<...>>, ...>`, but its trait bounds were not satisfied
   --> tests/ui/contract/fail/message-returns-non-codec.rs:16:9
    |
 4  |     pub struct NonCodecType;
@@ -46,7 +52,7 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<DefaultEnvi
    = note: the following trait bounds were not satisfied:
            `NonCodecType: parity_scale_codec::Decode`
 note: the trait `parity_scale_codec::Decode` must be implemented
-  --> $CARGO/parity-scale-codec-3.5.0/src/codec.rs
+  --> $CARGO/parity-scale-codec-3.6.4/src/codec.rs
    |
    | pub trait Decode: Sized {
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/ink/tests/ui/trait_def/fail/message_input_non_codec.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/message_input_non_codec.stderr
@@ -12,6 +12,9 @@ error[E0277]: the trait bound `NonCodec: WrapperTypeDecode` is not satisfied
 note: required by a bound in `DispatchInput`
  --> src/codegen/dispatch/type_check.rs
   |
+  | pub struct DispatchInput<T>(T)
+  |            ------------- required by a bound in this struct
+  | where
   |     T: scale::Decode + 'static;
   |        ^^^^^^^^^^^^^ required by this bound in `DispatchInput`
 
@@ -38,10 +41,13 @@ error[E0277]: the trait bound `NonCodec: WrapperTypeEncode` is not satisfied
 note: required by a bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd>>::push_arg`
  --> $WORKSPACE/crates/env/src/call/execution_input.rs
   |
+  |     pub fn push_arg<T>(
+  |            -------- required by a bound in this associated function
+...
   |         T: scale::Encode,
   |            ^^^^^^^^^^^^^ required by this bound in `ExecutionInput::<ArgumentList<ArgumentListEnd, ArgumentListEnd>>::push_arg`
 
-error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>>>, Set<ReturnType<()>>>`, but its trait bounds were not satisfied
+error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call<E>>, Set<ExecutionInput<ArgumentList<Argument<NonCodec>, ...>>>, ...>`, but its trait bounds were not satisfied
  --> tests/ui/trait_def/fail/message_input_non_codec.rs:5:5
   |
 5 |     #[ink(message)]
@@ -53,4 +59,4 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call
   | ----------------------------------- doesn't satisfy `_: Encode`
   |
   = note: the following trait bounds were not satisfied:
-          `ArgumentList<ink::ink_env::call::utils::Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>: Encode`
+          `ArgumentList<Argument<NonCodec>, ArgumentList<ArgumentListEnd, ArgumentListEnd>>: Encode`

--- a/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/message_output_non_codec.stderr
@@ -18,6 +18,9 @@ error[E0277]: the trait bound `NonCodec: WrapperTypeEncode` is not satisfied
 note: required by a bound in `DispatchOutput`
  --> src/codegen/dispatch/type_check.rs
   |
+  | pub struct DispatchOutput<T>(T)
+  |            -------------- required by a bound in this struct
+  | where
   |     T: scale::Encode + 'static;
   |        ^^^^^^^^^^^^^ required by this bound in `DispatchOutput`
 
@@ -33,7 +36,7 @@ error[E0599]: the method `try_invoke` exists for struct `CallBuilder<E, Set<Call
   = note: the following trait bounds were not satisfied:
           `NonCodec: parity_scale_codec::Decode`
 note: the trait `parity_scale_codec::Decode` must be implemented
- --> $CARGO/parity-scale-codec-3.5.0/src/codec.rs
+ --> $CARGO/parity-scale-codec-3.6.4/src/codec.rs
   |
   | pub trait Decode: Sized {
   | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -18,8 +18,8 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 ink_prelude = { version = "4.2.1", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
-scale-decode = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
-scale-encode = { version = "0.1.0", default-features = false, features = ["derive"], optional = true }
+scale-decode = { version = "0.9.0", default-features = false, features = ["derive"], optional = true }
+scale-encode = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 xxhash-rust = { version = "0.8", features = ["const_xxh32"] }
 

--- a/integration-tests/call-runtime/Cargo.toml
+++ b/integration-tests/call-runtime/Cargo.toml
@@ -17,8 +17,8 @@ scale-info = { version = "2.5", default-features = false, features = ["derive"],
 # (especially for global allocator).
 #
 # See also: https://substrate.stackexchange.com/questions/4733/error-when-compiling-a-contract-using-the-xcm-chain-extension.
-sp-io = { version = "22.0.0", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
-sp-runtime = { version = "23.0.0", default-features = false }
+sp-io = { version = "23.0.0", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-runtime = { version = "24.0.0", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }

--- a/integration-tests/call-runtime/lib.rs
+++ b/integration-tests/call-runtime/lib.rs
@@ -82,8 +82,6 @@ mod runtime_call {
         ///
         /// Fails if:
         ///  - called in the off-chain environment
-        ///  - the chain doesn't allow `call-runtime` API (`UnsafeUnstableInterface` is
-        ///    turned off)
         ///  - the chain forbids contracts to call `Balances::transfer` (`CallFilter` is
         ///    too restrictive)
         ///  - after the transfer, `receiver` doesn't have at least existential deposit
@@ -133,7 +131,6 @@ mod runtime_call {
         const UNIT: Balance = 1_000_000_000_000;
 
         /// The contract will be given 1000 tokens during instantiation.
-        #[cfg(feature = "permissive-node")]
         const CONTRACT_BALANCE: Balance = 1_000 * UNIT;
 
         /// The receiver will get enough funds to have the required existential deposit.
@@ -145,14 +142,12 @@ mod runtime_call {
         /// empty account fails.
         ///
         /// Must not be zero, because such an operation would be a successful no-op.
-        #[cfg(feature = "permissive-node")]
         const INSUFFICIENT_TRANSFER_VALUE: Balance = 1;
 
         /// Positive case scenario:
         ///  - `call_runtime` is enabled
         ///  - the call is valid
         ///  - the call execution succeeds
-        #[cfg(feature = "permissive-node")]
         #[ink_e2e::test]
         async fn transfer_with_call_runtime_works(
             mut client: Client<C, E>,
@@ -219,7 +214,6 @@ mod runtime_call {
         ///  - `call_runtime` is enabled
         ///  - the call is valid
         ///  - the call execution fails
-        #[cfg(feature = "permissive-node")]
         #[ink_e2e::test]
         async fn transfer_with_call_runtime_fails_when_execution_fails(
             mut client: Client<C, E>,
@@ -260,7 +254,6 @@ mod runtime_call {
         /// Negative case scenario:
         ///  - `call_runtime` is enabled
         ///  - the call is invalid
-        #[cfg(feature = "permissive-node")]
         #[ink_e2e::test]
         async fn transfer_with_call_runtime_fails_when_call_is_invalid(
             mut client: Client<C, E>,
@@ -289,37 +282,6 @@ mod runtime_call {
 
             // then
             assert!(call_res.is_err());
-
-            Ok(())
-        }
-
-        /// Negative case scenario:
-        ///  - `call_runtime` is disabled
-        #[cfg(not(feature = "permissive-node"))]
-        #[ink_e2e::test]
-        async fn call_runtime_fails_when_forbidden(
-            mut client: Client<C, E>,
-        ) -> E2EResult<()> {
-            // given
-            let constructor = RuntimeCallerRef::new();
-            let contract_acc_id = client
-                .instantiate("call-runtime", &ink_e2e::alice(), constructor, 0, None)
-                .await
-                .expect("instantiate failed")
-                .account_id;
-
-            let receiver: AccountId = default_accounts::<DefaultEnvironment>().bob;
-
-            let transfer_message = build_message::<RuntimeCallerRef>(contract_acc_id)
-                .call(|caller| caller.transfer_through_runtime(receiver, TRANSFER_VALUE));
-
-            // when
-            let call_res = client
-                .call(&ink_e2e::alice(), transfer_message, 0, None)
-                .await;
-
-            // then
-            assert!(matches!(call_res, Err(ink_e2e::Error::CallExtrinsic(_))));
 
             Ok(())
         }

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -13,7 +13,7 @@ scale-info = { version = "2.5", default-features = false, features = ["derive"],
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }
-subxt = { version = "0.28.0", default-features = false }
+subxt = { version = "0.31.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -37,6 +37,7 @@ pub mod e2e_call_runtime {
                 .await
                 .expect("instantiate failed")
                 .account_id;
+            let transfer_amount = 100_000_000_000u128;
 
             // when
             let call_data = vec![
@@ -45,8 +46,15 @@ pub mod e2e_call_runtime {
                 // bytes for our destination address
                 Value::unnamed_variant("Id", [Value::from_bytes(&contract_acc_id)]),
                 // A value representing the amount we'd like to transfer.
-                Value::u128(100_000_000_000u128),
+                Value::u128(transfer_amount),
             ];
+
+            let get_balance = build_message::<ContractRef>(contract_acc_id.clone())
+                .call(|contract| contract.get_contract_balance());
+            let pre_balance = client
+                .call_dry_run(&ink_e2e::alice(), &get_balance, 0, None)
+                .await
+                .return_value();
 
             // Send funds from Alice to the contract using Balances::transfer
             client
@@ -61,10 +69,10 @@ pub mod e2e_call_runtime {
                 .call_dry_run(&ink_e2e::alice(), &get_balance, 0, None)
                 .await;
 
-            assert!(matches!(
+            assert_eq!(
                 get_balance_res.return_value(),
-                100_000_000_000u128
-            ));
+                pre_balance + transfer_amount
+            );
 
             Ok(())
         }

--- a/integration-tests/multi_contract_caller/accumulator/lib.rs
+++ b/integration-tests/multi_contract_caller/accumulator/lib.rs
@@ -15,7 +15,7 @@ pub mod accumulator {
 
     impl Accumulator {
         /// Initializes the value to the initial value.
-        #[ink(constructor)]
+        #[ink(constructor, payable)]
         pub fn new(init_value: i32) -> Self {
             Self { value: init_value }
         }

--- a/integration-tests/multi_contract_caller/adder/lib.rs
+++ b/integration-tests/multi_contract_caller/adder/lib.rs
@@ -18,7 +18,7 @@ mod adder {
 
     impl Adder {
         /// Creates a new `adder` from the given `accumulator`.
-        #[ink(constructor)]
+        #[ink(constructor, payable)]
         pub fn new(accumulator: AccumulatorRef) -> Self {
             Self { accumulator }
         }

--- a/integration-tests/multi_contract_caller/lib.rs
+++ b/integration-tests/multi_contract_caller/lib.rs
@@ -50,7 +50,7 @@ mod multi_contract_caller {
     impl MultiContractCaller {
         /// Instantiate a `multi_contract_caller` contract with the given sub-contract
         /// codes.
-        #[ink(constructor)]
+        #[ink(constructor, payable)]
         pub fn new(
             init_value: i32,
             version: u32,
@@ -155,7 +155,7 @@ mod multi_contract_caller {
                     "multi_contract_caller",
                     &ink_e2e::alice(),
                     constructor,
-                    0,
+                    10_000_000_000_000,
                     None,
                 )
                 .await

--- a/integration-tests/multi_contract_caller/subber/lib.rs
+++ b/integration-tests/multi_contract_caller/subber/lib.rs
@@ -18,7 +18,7 @@ mod subber {
 
     impl Subber {
         /// Creates a new `subber` from the given `accumulator`.
-        #[ink(constructor)]
+        #[ink(constructor, payable)]
         pub fn new(accumulator: AccumulatorRef) -> Self {
             Self { accumulator }
         }

--- a/integration-tests/payment-channel/Cargo.toml
+++ b/integration-tests/payment-channel/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 ink = { path = "../../crates/ink", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 hex-literal = { version = "0.3" }


### PR DESCRIPTION
Fixes https://github.com/paritytech/ink/issues/1875

- Uses `3.2.0` of `contract-build` so as not to fix `signext` compat. #1883
- Fix interaction with newer node versions which don't accept `--ws-port` and also have different output logs. #1850