### PR TITLE
Release `v4.3.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Version 4.3.0
+
+This release is to fix compatibility of `ink_e2e` with newer (> 1.69) versions of Rust,
+which produce `signext` instructions, and older versions of `pallet_contracts` which do
+not yet support these instructions.
+
+- Backport use of `contract-build` to `3.2.0` to include `signext` lowering, and update
+`subxt` to remove incompatible `wasmi-instrument` transient dependency ‒ [#1884](https://github.com/paritytech/ink/pull/1884)
+
 ## Version 4.2.1
 
 This release contains a low-severity security related fix. Users of the `4.x` series of

--- a/crates/allocator/Cargo.toml
+++ b/crates/allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_allocator"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_e2e"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -15,10 +15,10 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_e2e_macro = { version = "4.2.1", path = "./macro" }
-ink = { version = "4.2.1", path = "../ink" }
-ink_env = { version = "4.2.1", path = "../env" }
-ink_primitives = { version = "4.2.1", path = "../primitives" }
+ink_e2e_macro = { version = "4.3.0", path = "./macro" }
+ink = { version = "4.3.0", path = "../ink" }
+ink_env = { version = "4.3.0", path = "../env" }
+ink_primitives = { version = "4.3.0", path = "../primitives" }
 
 funty = "2.0.0"
 impl-serde = { version = "0.3.1", default-features = false }

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_e2e_macro"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -19,7 +19,7 @@ name = "ink_e2e_macro"
 proc-macro = true
 
 [dependencies]
-ink_ir = { version = "4.2.1", path = "../../ink/ir" }
+ink_ir = { version = "4.3.0", path = "../../ink/ir" }
 cargo_metadata = "0.15.3"
 contract-build = "3.2.0"
 derive_more = "0.99.17"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_engine"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Michael Müller <michi@parity.io>"]
 edition = "2021"
 
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_primitives = { version = "4.2.1", path = "../../crates/primitives", default-features = false }
+ink_primitives = { version = "4.3.0", path = "../../crates/primitives", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
 

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_env"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 rust-version = "1.68"
@@ -16,10 +16,10 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_allocator = { version = "4.2.1", path = "../allocator", default-features = false }
-ink_storage_traits = { version = "4.2.1", path = "../storage/traits", default-features = false }
-ink_prelude = { version = "4.2.1", path = "../prelude", default-features = false }
-ink_primitives = { version = "4.2.1", path = "../primitives", default-features = false }
+ink_allocator = { version = "4.3.0", path = "../allocator", default-features = false }
+ink_storage_traits = { version = "4.3.0", path = "../storage/traits", default-features = false }
+ink_prelude = { version = "4.3.0", path = "../prelude", default-features = false }
+ink_primitives = { version = "4.3.0", path = "../primitives", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
@@ -33,7 +33,7 @@ static_assertions = "1.1"
 rlibc = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ink_engine = { version = "4.2.1", path = "../engine/", optional = true }
+ink_engine = { version = "4.3.0", path = "../engine/", optional = true }
 
 # Hashes for the off-chain environment.
 sha2 = { version = "0.10", optional = true }

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 rust-version = "1.63"
@@ -16,12 +16,12 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.2.1", path = "../env", default-features = false }
-ink_storage = { version = "4.2.1", path = "../storage", default-features = false }
-ink_primitives = { version = "4.2.1", path = "../primitives", default-features = false }
-ink_metadata = { version = "4.2.1", path = "../metadata", default-features = false, optional = true }
-ink_prelude = { version = "4.2.1", path = "../prelude", default-features = false }
-ink_macro = { version = "4.2.1", path = "macro", default-features = false }
+ink_env = { version = "4.3.0", path = "../env", default-features = false }
+ink_storage = { version = "4.3.0", path = "../storage", default-features = false }
+ink_primitives = { version = "4.3.0", path = "../primitives", default-features = false }
+ink_metadata = { version = "4.3.0", path = "../metadata", default-features = false, optional = true }
+ink_prelude = { version = "4.3.0", path = "../prelude", default-features = false }
+ink_macro = { version = "4.3.0", path = "macro", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from"] }

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_codegen"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -18,8 +18,8 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 name = "ink_codegen"
 
 [dependencies]
-ink_primitives = { version = "4.2.1", path = "../../primitives" }
-ir = { version = "4.2.1", package = "ink_ir", path = "../ir", default-features = false }
+ink_primitives = { version = "4.3.0", path = "../../primitives" }
+ir = { version = "4.3.0", package = "ink_ir", path = "../ir", default-features = false }
 quote = "1"
 syn = { version = "2.0", features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = "1.0"

--- a/crates/ink/ir/Cargo.toml
+++ b/crates/ink/ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_ir"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_macro"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,9 +15,9 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_ir = { version = "4.2.1", path = "../ir", default-features = false }
-ink_codegen = { version = "4.2.1", path = "../codegen", default-features = false }
-ink_primitives = { version = "4.2.1", path = "../../primitives/", default-features = false }
+ink_ir = { version = "4.3.0", path = "../ir", default-features = false }
+ink_codegen = { version = "4.3.0", path = "../codegen", default-features = false }
+ink_primitives = { version = "4.3.0", path = "../../primitives/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 syn = "2"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_metadata"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,8 +15,8 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_prelude = { version = "4.2.1", path = "../prelude/", default-features = false }
-ink_primitives = { version = "4.2.1", path = "../primitives/", default-features = false }
+ink_prelude = { version = "4.3.0", path = "../prelude/", default-features = false }
+ink_primitives = { version = "4.3.0", path = "../primitives/", default-features = false }
 
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 impl-serde = "0.4.0"

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_prelude"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_primitives"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -16,7 +16,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }
-ink_prelude = { version = "4.2.1", path = "../prelude/", default-features = false }
+ink_prelude = { version = "4.3.0", path = "../prelude/", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-decode = { version = "0.9.0", default-features = false, features = ["derive"], optional = true }
 scale-encode = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition = "2021"
 
@@ -15,11 +15,11 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_env = { version = "4.2.1", path = "../env/", default-features = false }
-ink_metadata = { version = "4.2.1", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.2.1", path = "../primitives/", default-features = false }
-ink_storage_traits = { version = "4.2.1", path = "traits", default-features = false }
-ink_prelude = { version = "4.2.1", path = "../prelude/", default-features = false }
+ink_env = { version = "4.3.0", path = "../env/", default-features = false }
+ink_metadata = { version = "4.3.0", path = "../metadata/", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "4.3.0", path = "../primitives/", default-features = false }
+ink_storage_traits = { version = "4.3.0", path = "traits", default-features = false }
+ink_prelude = { version = "4.3.0", path = "../prelude/", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }

--- a/crates/storage/traits/Cargo.toml
+++ b/crates/storage/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_storage_traits"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -15,9 +15,9 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE"]
 
 [dependencies]
-ink_metadata = { version = "4.2.1", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
-ink_primitives = { version = "4.2.1", path = "../../primitives", default-features = false }
-ink_prelude = { version = "4.2.1", path = "../../prelude", default-features = false }
+ink_metadata = { version = "4.3.0", path = "../../metadata", default-features = false, features = ["derive"], optional = true }
+ink_primitives = { version = "4.3.0", path = "../../primitives", default-features = false }
+ink_prelude = { version = "4.3.0", path = "../../prelude", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 

--- a/integration-tests/basic_contract_caller/Cargo.toml
+++ b/integration-tests/basic_contract_caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basic_contract_caller"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/basic_contract_caller/other_contract/Cargo.toml
+++ b/integration-tests/basic_contract_caller/other_contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "other_contract"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-terminate/Cargo.toml
+++ b/integration-tests/contract-terminate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_terminate"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-transfer/Cargo.toml
+++ b/integration-tests/contract-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_transfer"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/custom-environment/Cargo.toml
+++ b/integration-tests/custom-environment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom-environment"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/custom_allocator/Cargo.toml
+++ b/integration-tests/custom_allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom_allocator"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/dns/Cargo.toml
+++ b/integration-tests/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e2e_call_runtime"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc1155/Cargo.toml
+++ b/integration-tests/erc1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc1155"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc20/Cargo.toml
+++ b/integration-tests/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc20"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc721/Cargo.toml
+++ b/integration-tests/erc721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc721"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/flipper/Cargo.toml
+++ b/integration-tests/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/incrementer/Cargo.toml
+++ b/integration-tests/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder_delegate"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constructors_return_value"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_ref"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_flipper"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/mapping_integration_tests/Cargo.toml
+++ b/integration-tests/mapping_integration_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mapping-integration-tests"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/mother/Cargo.toml
+++ b/integration-tests/mother/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mother"
 description = "Mother of all contracts"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/multi_contract_caller/Cargo.toml
+++ b/integration-tests/multi_contract_caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi_contract_caller"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/multi_contract_caller/accumulator/Cargo.toml
+++ b/integration-tests/multi_contract_caller/accumulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulator"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi_contract_caller/adder/Cargo.toml
+++ b/integration-tests/multi_contract_caller/adder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adder"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi_contract_caller/subber/Cargo.toml
+++ b/integration-tests/multi_contract_caller/subber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subber"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multisig/Cargo.toml
+++ b/integration-tests/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/payment-channel/Cargo.toml
+++ b/integration-tests/payment-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payment_channel"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/psp22-extension/Cargo.toml
+++ b/integration-tests/psp22-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_extension"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/rand-extension/Cargo.toml
+++ b/integration-tests/rand-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_extension"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/set_code_hash/Cargo.toml
+++ b/integration-tests/set_code_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/set_code_hash/updated_incrementer/Cargo.toml
+++ b/integration-tests/set_code_hash/updated_incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated_incrementer"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-erc20/Cargo.toml
+++ b/integration-tests/trait-erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_erc20"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-flipper/Cargo.toml
+++ b/integration-tests/trait-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_flipper"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-incrementer/Cargo.toml
+++ b/integration-tests/trait-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-incrementer/traits/Cargo.toml
+++ b/integration-tests/trait-incrementer/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traits"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_linting"
-version = "4.2.1"
+version = "4.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false


### PR DESCRIPTION
## Version 4.3.0

This release is to fix compatibility of `ink_e2e` with newer (> 1.69) versions of Rust,
which produce `signext` instructions, and older versions of `pallet_contracts` which do
not yet support these instructions.

- Backport use of `contract-build` to `3.2.0` to include `signext` lowering, and update
`subxt` to remove incompatible `wasmi-instrument` transient dependency ‒ [#1884](https://github.com/paritytech/ink/pull/1884)