### PR TITLE
Script to check if a `integration-test` manifest is a contract

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -428,31 +428,16 @@ examples-contract-build:
   script:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V
-    - for example in integration-tests/*/; do
-        if [ "$example" = "integration-tests/lang-err-integration-tests/" ]; then continue; fi;
-        if [ "$example" = "integration-tests/upgradeable-contracts/" ]; then continue; fi;
-        if [ "$example" = "integration-tests/conditional-compilation/" ]; then
-        pushd $example &&
-        cargo contract build --features "foo" &&
-        popd;
-        pushd $example &&
-        cargo contract build --features "bar" &&
-        popd;
-        pushd $example &&
-        cargo contract build --features "foo, bar" &&
-        popd;
-        fi;
-        pushd $example &&
-        cargo contract build &&
-        popd;
-      done
-    - pushd ./integration-tests/multi-contract-caller/ && ./build-all.sh && popd
-    - for contract in ${LANG_ERR_INTEGRATION_CONTRACTS}; do
-        cargo contract build --manifest-path ./integration-tests/lang-err-integration-tests/${contract}/Cargo.toml;
-      done
-    - for contract in ${UPGRADEABLE_CONTRACTS}; do
-        cargo contract build --manifest-path ./integration-tests/upgradeable-contracts/${contract}/Cargo.toml;
-      done
+    # Build all examples
+    - find ./integration-tests. -name "Cargo.toml"
+        -exec scripts/is_contract.sh {} \;
+        -exec cargo contract build --release --manifest-path {} \;
+    # Build the different features for the conditional compilation example
+    - pushd ./integration-tests/conditional-compilation
+    - cargo contract build --features "foo"
+    - cargo contract build --features "bar"
+    - cargo contract build --features "foo, bar"
+    - popd
 
 # TODO: Use cargo contract as soon as it has RISC-V support
 examples-contract-build-riscv:

--- a/scripts/is_contract.sh
+++ b/scripts/is_contract.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SCRIPT_NAME="${BASH_SOURCE[0]}"
+MANIFEST_PATH=$1
+
+function usage {
+  cat << EOF
+Usage: ${SCRIPT_NAME} MANIFEST_PATH
+
+Succeeds if the crate at MANIFEST_PATH is a contract crate, fails otherwise.
+
+MANIFEST_PATH
+  Path to the Cargo.toml manifest file for a possible contract project
+
+EXAMPLES
+  ${SCRIPT_NAME} ./Cargo.toml
+
+EOF
+}
+
+if [ -z "$MANIFEST_PATH" ]; then
+  usage
+  exit 1
+fi
+
+ROOT_PACKAGE=$(cargo metadata --format-version=1 --manifest-path "$MANIFEST_PATH" |
+  jq -r '.resolve.root')
+SOURCE_PATH=$(cargo metadata --format-version=1 --manifest-path "$MANIFEST_PATH" |
+  jq -r --arg ROOT_PACKAGE "$ROOT_PACKAGE" '
+    .packages[]
+    | select(.id == $ROOT_PACKAGE).targets[]
+    | select(.kind[] | contains("lib")).src_path')
+
+if grep -q '^#\[ink::contract\]' $SOURCE_PATH; then
+    exit 0
+else
+    exit 1
+fi

--- a/scripts/is_contract.sh
+++ b/scripts/is_contract.sh
@@ -7,7 +7,10 @@ function usage {
   cat << EOF
 Usage: ${SCRIPT_NAME} MANIFEST_PATH
 
-Succeeds if the crate at MANIFEST_PATH is a contract crate, fails otherwise.
+Succeeds if the crate at MANIFEST_PATH is *probably* contract crate, fails otherwise. The heuristic used is:
+  - Find the root package of the crate
+  - Find the source file of the root package that is a lib
+  - Check for the presence of the `#[ink::contract]` attribute macro
 
 MANIFEST_PATH
   Path to the Cargo.toml manifest file for a possible contract project


### PR DESCRIPTION
I was using this script locally to check all examples e.g.
```
CARGO_TARGET_DIR=/tmp/integration-tests-target/ find ./integration-tests/ -name "Cargo.toml" \
       -exec scripts/is_contract.sh {} \; \
       -exec cargo contract build --release --manifest-path {} \;^
```
I will try and update some of the CI jobs to use it instead of the current filtering we do, to make it more concise and robust.