### PR TITLE
:t-rex: script to execute command against all contract projects

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -346,12 +346,12 @@ examples-test:
     # Fix linking of `linkme`: https://github.com/dtolnay/linkme/issues/49
     RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc"
   script:
-    # run the static buffer test with a custom buffer size
-    - cargo clean --manifest-path integration-tests/static-buffer/Cargo.toml 
-    - INK_STATIC_BUFFER_SIZE=30 cargo test --verbose --manifest-path integration-tests/static-buffer/Cargo.toml --all-features
     # run all tests with --all-features, which will run the e2e-tests feature if present
     - scripts/for_all_contracts_exec.sh integration-tests
       cargo test --verbose --all-features --manifest-path {}
+    # run the static buffer test with a custom buffer size
+    - cargo clean --manifest-path integration-tests/static-buffer/Cargo.toml
+    - INK_STATIC_BUFFER_SIZE=30 cargo test --verbose --manifest-path integration-tests/static-buffer/Cargo.toml --all-features
 
 examples-contract-build:
   stage:                           examples

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,8 +115,9 @@ examples-fmt:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - scripts/for_all_contracts_exec.sh integration-tests
-      cargo +nightly fmt --verbose --manifest-path {} -- --check
+    - scripts/for_all_contracts_exec.sh 
+      --path integration-tests
+      -- cargo +nightly fmt --verbose --manifest-path {} -- --check
     # This file is not a part of the cargo project, so it wouldn't be formatted the usual way
     - rustfmt +nightly --verbose --check ./integration-tests/psp22-extension/runtime/psp22-extension-example.rs
   allow_failure:                   true
@@ -145,8 +146,9 @@ examples-clippy-std:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - scripts/for_all_contracts_exec.sh integration-tests
-      cargo clippy --verbose --all-targets --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED
+    - scripts/for_all_contracts_exec.sh 
+      --path integration-tests
+      -- cargo clippy --verbose --all-targets --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED
   allow_failure:                   true
 
 examples-clippy-wasm:
@@ -154,8 +156,9 @@ examples-clippy-wasm:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - scripts/for_all_contracts_exec.sh integration-tests
-      cargo clippy --verbose --manifest-path {} --no-default-features --target wasm32-unknown-unknown -- -D warnings -A $CLIPPY_ALLOWED
+    - scripts/for_all_contracts_exec.sh 
+      --path integration-tests
+      -- cargo clippy --verbose --manifest-path {} --no-default-features --target wasm32-unknown-unknown -- -D warnings -A $CLIPPY_ALLOWED
   allow_failure:                   true
 
 
@@ -347,8 +350,10 @@ examples-test:
     RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc"
   script:
     # run all tests with --all-features, which will run the e2e-tests feature if present
-    - scripts/for_all_contracts_exec.sh integration-tests
-      cargo test --verbose --all-features --manifest-path {}
+    - scripts/for_all_contracts_exec.sh 
+      --path integration-tests
+      --ignore static-buffer
+      -- cargo test --verbose --all-features --manifest-path {}
     # run the static buffer test with a custom buffer size
     - cargo clean --manifest-path integration-tests/static-buffer/Cargo.toml
     - INK_STATIC_BUFFER_SIZE=30 cargo test --verbose --manifest-path integration-tests/static-buffer/Cargo.toml --all-features
@@ -364,8 +369,9 @@ examples-contract-build:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V
     # Build all examples
-    - scripts/for_all_contracts_exec.sh integration-tests
-      cargo contract build --release --manifest-path {}
+    - scripts/for_all_contracts_exec.sh 
+      --path integration-tests
+      -- cargo contract build --release --manifest-path {}
     # Build the different features for the conditional compilation example
     - pushd ./integration-tests/conditional-compilation
     - cargo contract build --release --features "foo"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,7 +115,7 @@ examples-fmt:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - scripts/for_all_contracts_exec.sh
+    - scripts/for_all_contracts_exec.sh integration-tests
       cargo +nightly fmt --verbose --manifest-path {} -- --check
     # This file is not a part of the cargo project, so it wouldn't be formatted the usual way
     - rustfmt +nightly --verbose --check ./integration-tests/psp22-extension/runtime/psp22-extension-example.rs
@@ -145,7 +145,7 @@ examples-clippy-std:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - scripts/for_all_contracts_exec.sh
+    - scripts/for_all_contracts_exec.sh integration-tests
       cargo clippy --verbose --all-targets --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED
   allow_failure:                   true
 
@@ -154,7 +154,7 @@ examples-clippy-wasm:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - scripts/for_all_contracts_exec.sh
+    - scripts/for_all_contracts_exec.sh integration-tests
       cargo clippy --verbose --manifest-path {} --no-default-features --target wasm32-unknown-unknown -- -D warnings -A $CLIPPY_ALLOWED
   allow_failure:                   true
 
@@ -350,7 +350,7 @@ examples-test:
     - cargo clean --manifest-path integration-tests/static-buffer/Cargo.toml 
     - INK_STATIC_BUFFER_SIZE=30 cargo test --verbose --manifest-path integration-tests/static-buffer/Cargo.toml --all-features
     # run all tests with --all-features, which will run the e2e-tests feature if present
-    - scripts/for_all_contracts_exec.sh
+    - scripts/for_all_contracts_exec.sh integration-tests
       cargo test --verbose --all-features --manifest-path {}
 
 examples-contract-build:
@@ -364,7 +364,7 @@ examples-contract-build:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V
     # Build all examples
-    - scripts/for_all_contracts_exec.sh
+    - scripts/for_all_contracts_exec.sh integration-tests
       cargo contract build --release --manifest-path {}
     # Build the different features for the conditional compilation example
     - pushd ./integration-tests/conditional-compilation

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,9 +115,8 @@ examples-fmt:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - find integration-tests -name "Cargo.toml" 
-      -exec scripts/is_contract.sh {} \; 
-      -exec cargo +nightly fmt --verbose --manifest-path {} -- --check \;
+    - scripts/for_all_contracts_exec.sh
+      cargo +nightly fmt --verbose --manifest-path {} -- --check
     # This file is not a part of the cargo project, so it wouldn't be formatted the usual way
     - rustfmt +nightly --verbose --check ./integration-tests/psp22-extension/runtime/psp22-extension-example.rs
   allow_failure:                   true
@@ -146,9 +145,8 @@ examples-clippy-std:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - find integration-tests -name "Cargo.toml"
-      -exec scripts/is_contract.sh {} \;
-      -exec cargo clippy --verbose --all-targets --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED \;
+    - scripts/for_all_contracts_exec.sh
+      cargo clippy --verbose --all-targets --manifest-path {} -- -D warnings -A $CLIPPY_ALLOWED
   allow_failure:                   true
 
 examples-clippy-wasm:
@@ -156,9 +154,8 @@ examples-clippy-wasm:
   <<:                              *docker-env
   <<:                              *test-refs
   script:
-    - find integration-tests -name "Cargo.toml"
-      -exec scripts/is_contract.sh {} \;
-      -exec cargo clippy --verbose --manifest-path {} --no-default-features --target wasm32-unknown-unknown -- -D warnings -A $CLIPPY_ALLOWED \;
+    - scripts/for_all_contracts_exec.sh
+      cargo clippy --verbose --manifest-path {} --no-default-features --target wasm32-unknown-unknown -- -D warnings -A $CLIPPY_ALLOWED
   allow_failure:                   true
 
 
@@ -354,7 +351,7 @@ examples-test:
     - INK_STATIC_BUFFER_SIZE=30 cargo test --verbose --manifest-path integration-tests/static-buffer/Cargo.toml --all-features
     # run all tests with --all-features, which will run the e2e-tests feature if present
     - scripts/for_all_contracts_exec.sh
-      cargo test --verbose --all-features --manifest-path
+      cargo test --verbose --all-features --manifest-path {}
 
 examples-contract-build:
   stage:                           examples
@@ -367,9 +364,8 @@ examples-contract-build:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V
     # Build all examples
-    - find integration-tests -name "Cargo.toml"
-      -exec scripts/is_contract.sh {} \;
-      -exec cargo contract build --release --manifest-path {} \;
+    - scripts/for_all_contracts_exec.sh
+      cargo contract build --release --manifest-path {}
     # Build the different features for the conditional compilation example
     - pushd ./integration-tests/conditional-compilation
     - cargo contract build --release --features "foo"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -353,9 +353,8 @@ examples-test:
     - cargo clean --manifest-path integration-tests/static-buffer/Cargo.toml 
     - INK_STATIC_BUFFER_SIZE=30 cargo test --verbose --manifest-path integration-tests/static-buffer/Cargo.toml --all-features
     # run all tests with --all-features, which will run the e2e-tests feature if present
-    - find integration-tests -name "Cargo.toml"
-      -exec scripts/is_contract.sh {} \;
-      -exec cargo test --verbose --manifest-path {} --all-features \;
+    - scripts/for_all_contracts_exec.sh
+      cargo test --verbose --all-features --manifest-path
 
 examples-contract-build:
   stage:                           examples

--- a/integration-tests/mother/lib.rs
+++ b/integration-tests/mother/lib.rs
@@ -7,9 +7,8 @@
 //!
 //! Currently, this includes the following:
 //!
-//!   1. Use complex nested input and output types.
-//!      This is done with the use case of a data structure
-//!      needed to store data of a candle auction.
+//!   1. Use complex nested input and output types. This is done with the use case of a
+//!      data structure needed to store data of a candle auction.
 //!   2. Make contract fail with `ContractTrapped`.
 //!   3. Make contract fail with returning an `Error`.
 //!   4. Perform debug printing from contract into the node's log.

--- a/integration-tests/upgradeable-contracts/delegator/delegatee/lib.rs
+++ b/integration-tests/upgradeable-contracts/delegator/delegatee/lib.rs
@@ -2,7 +2,10 @@
 
 #[ink::contract]
 pub mod delegatee {
-    use ink::storage::{Mapping, traits::ManualKey};
+    use ink::storage::{
+        traits::ManualKey,
+        Mapping,
+    };
     #[ink(storage)]
     pub struct Delegatee {
         addresses: Mapping<AccountId, i32, ManualKey<0x23>>,
@@ -12,8 +15,8 @@ pub mod delegatee {
     }
 
     impl Delegatee {
-        /// When using the delegate call. You only upload the code of the delegatee contract.
-        /// However, the code and storage do not get initialized.
+        /// When using the delegate call. You only upload the code of the delegatee
+        /// contract. However, the code and storage do not get initialized.
         ///
         /// Because of this. The constructor actually never gets called.
         #[allow(clippy::new_without_default)]
@@ -29,7 +32,6 @@ pub mod delegatee {
         pub fn inc(&mut self) {
             self.counter += 2;
         }
-
 
         /// Adds current value of counter to the `addresses`
         #[ink(message)]

--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+SCRIPT_NAME="${BASH_SOURCE[0]}"
+FIND_PATH=$1
+
+function usage {
+  cat << EOF
+Usage: ${SCRIPT_NAME} cmd
+
+TODO
+
+EOF
+}
+
+# enable recursive globs
+shopt -s globstar
+
+SCRIPTS_PATH=$( cd "$(dirname "$SCRIPT_NAME")" || exit; pwd -P )
+
+for manifest_path in "$FIND_PATH"/**/Cargo.toml;
+  do if "$SCRIPTS_PATH"/is_contract.sh "$manifest_path"; then
+    echo Running: "${@:2}" "$manifest_path";
+  fi
+done

--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -1,28 +1,32 @@
 #!/bin/bash
 
-SCRIPT_NAME="${BASH_SOURCE[0]}"
-FIND_PATH=$1
-COMMAND=${@:2}
+script_name="${BASH_SOURCE[0]}"
+scripts_path=$( cd "$(dirname "$script_name")" || exit; pwd -P )
+find_path=$1
+command=( "${@:2}" )
 
 function usage {
   cat << EOF
-Usage: ${SCRIPT_NAME} FIND_PATH COMMAND [INITIAL-ARGS]
+Usage: ${script_name} FIND_PATH COMMAND [INITIAL-ARGS]
 
 Execute the supplied COMMAND with INITIAL-ARGS for all ink! contracts (recursively) found in the given path.
-The manifest path (full path to the Cargo.toml file) is passed as the last argument to the supplied command.
+The manifest path (full path to the Cargo.toml file) is passed either:
+  - in place of the "{}" placeholder in the command, if present
+  - as the last argument to the command, if "{}" is not present
 
 Returns 0 (success) if the command succeeds against *all* contract projects, if any fail returns 1 (failure).
 
-FIND_PATH
+find_path
   Path to recursively find contract projects for which to execute the supplied command
 
 EXAMPLES
-   ${SCRIPT_NAME} integration-tests cargo check --manifest-path
+   ${script_name} integration-tests cargo check --manifest-path
+   ${script_name} integration-tests cargo contract build --manifest-path {} --release
 
 EOF
 }
 
-if [ -z "$FIND_PATH" ] || [ -z "$COMMAND" ]; then
+if [ -z "$find_path" ] || [ "${#command[@]}" -le 0 ]; then
   usage
   exit 1
 fi
@@ -30,19 +34,29 @@ fi
 # enable recursive globs
 shopt -s globstar
 
-SCRIPTS_PATH=$( cd "$(dirname "$SCRIPT_NAME")" || exit; pwd -P )
-SUCCESSES=()
-FAILURES=()
+successes=()
+failures=()
 
-for manifest_path in "$FIND_PATH"/**/Cargo.toml;
-  do if "$SCRIPTS_PATH"/is_contract.sh "$manifest_path"; then
-    echo Running: "$COMMAND" "$manifest_path";
-    $COMMAND "$manifest_path";
+# default to adding the argument as the last argument to the command
+arg_index=${#command[@]}
+# find the index of the argument placeholder "{}", if present
+for i in "${!command[@]}"; do
+  if [ "${command[$i]}" = "{}" ]; then
+    arg_index=$i
+    break
+  fi
+done
+
+for manifest_path in "$find_path"/**/Cargo.toml;
+  do if "$scripts_path"/is_contract.sh "$manifest_path"; then
+    command[$arg_index]="$manifest_path"
+    echo Running: "${command[@]}"
+    "${command[@]}"
 
     if [ $? -eq 0 ]; then
-      SUCCESSES+=("$manifest_path")
+      successes+=("$manifest_path")
     else
-      FAILURES+=("$manifest_path")
+      failures+=("$manifest_path")
     fi
   fi
 done
@@ -51,17 +65,17 @@ GREEN='\033[1;32m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
-printf "\nSucceeded: %s\n" ${#SUCCESSES[@]}
-for success in "${SUCCESSES[@]}"; do
+printf "\nSucceeded: %s\n" ${#successes[@]}
+for success in "${successes[@]}"; do
   printf "  ${GREEN}\u2713${NC} %s \n" "$success"
 done
 
-printf "\nFailed: %s\n" ${#FAILURES[@]}
-for failure in "${FAILURES[@]}"; do
+printf "\nFailed: %s\n" ${#failures[@]}
+for failure in "${failures[@]}"; do
   printf "  ${RED}\u2717${NC} %s \n" "$failure"
 done
 
-if [ ${#FAILURES[@]} -gt 0 ]; then
+if [ ${#failures[@]} -gt 0 ]; then
   exit 1
 else
   exit 0

--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -13,14 +13,16 @@ Returns 0 (success) if the command succeeds against *all* contract projects, if 
 
 OPTIONS
   -i, --ignore
-  Path to ignore when recursively finding contract projects
+  Path to ignore when recursively finding contract projects.
+  To ignore `integration-tests/erc20` then supply `erc20` as the argument.
 
   -p, --path
   Path to recursively find contract projects for which to execute the supplied command
 
 EXAMPLES
-   ${script_name} -path integration-tests -- cargo check --manifest-path
-   ${script_name} -path integration-tests -- cargo contract build --manifest-path {} --release
+   ${script_name} --path integration-tests -- cargo check --manifest-path
+   ${script_name} --path integration-tests -- cargo contract build --manifest-path {} --release
+   ${script_name} --path integration-tests --ignore erc20 -- cargo contract build --manifest-path {} --release
 
 EOF
 }
@@ -60,8 +62,6 @@ done
 
 command=("${@}")
 
-echo command "${command[@]}"
-
 if [ -z "$path" ] || [ "${#command[@]}" -le 0 ]; then
   usage
   exit 1
@@ -82,6 +82,11 @@ done
 
 for manifest_path in "$path"/**/Cargo.toml;
   do if "$scripts_path"/is_contract.sh "$manifest_path"; then
+    manifest_parent="$(dirname "$manifest_path" | cut -d'/' -f2-)"
+    if [[ "${ignore[*]}" =~ ${manifest_parent} ]]; then
+      echo "Ignoring $manifest_path"
+      continue
+    fi
     command[$arg_index]="$manifest_path"
     echo Running: "${command[@]}"
     "${command[@]}"

--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+script_name="${BASH_SOURCE[0]}"
+scripts_path=$( cd "$(dirname "$script_name")" || exit; pwd -P )
+
 function usage {
   cat << EOF
 Usage: ${script_name} [OPTION] --path PATH -- COMMAND [INITIAL-ARGS]
@@ -13,11 +16,10 @@ Returns 0 (success) if the command succeeds against *all* contract projects, if 
 
 OPTIONS
   -i, --ignore
-  Path to ignore when recursively finding contract projects.
-  To ignore `integration-tests/erc20` then supply `erc20` as the argument.
-
+      Path to ignore when recursively finding contract projects.
+      To ignore 'integration-tests/erc20' then supply 'erc20' as the argument.
   -p, --path
-  Path to recursively find contract projects for which to execute the supplied command
+      Path to recursively find contract projects for which to execute the supplied command
 
 EXAMPLES
    ${script_name} --path integration-tests -- cargo check --manifest-path
@@ -30,8 +32,6 @@ EOF
 # enable recursive globs
 shopt -s globstar
 
-script_name="${BASH_SOURCE[0]}"
-scripts_path=$( cd "$(dirname "$script_name")" || exit; pwd -P )
 command=( "${@:2}" )
 
 options=$(getopt -o p:i: --long path:,ignore: -- "$@")

--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -16,9 +16,36 @@ EOF
 shopt -s globstar
 
 SCRIPTS_PATH=$( cd "$(dirname "$SCRIPT_NAME")" || exit; pwd -P )
+SUCCESSES=()
+FAILURES=()
 
 for manifest_path in "$FIND_PATH"/**/Cargo.toml;
   do if "$SCRIPTS_PATH"/is_contract.sh "$manifest_path"; then
     echo Running: "${@:2}" "$manifest_path";
+    "${@:2}" "$manifest_path";
+
+    if [ $? -eq 0 ]; then
+      SUCCESSES+=("$manifest_path")
+    else
+      FAILURES+=("$manifest_path")
+    fi
   fi
 done
+
+echo ""
+echo "Succeeded:" ${#SUCCESSES[@]}
+for success in "${SUCCESSES[@]}"; do
+  echo "$success"
+done
+
+echo ""
+echo "Failed:" ${#FAILURES[@]}
+for failure in "${FAILURES[@]}"; do
+  echo "$failure"
+done
+
+if [ ${#FAILURES[@]} -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi

--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -1,16 +1,8 @@
 #!/bin/bash
 
-# enable recursive globs
-shopt -s globstar
-
-script_name="${BASH_SOURCE[0]}"
-scripts_path=$( cd "$(dirname "$script_name")" || exit; pwd -P )
-find_path=$1
-command=( "${@:2}" )
-
 function usage {
   cat << EOF
-Usage: ${script_name} FIND_PATH COMMAND [INITIAL-ARGS]
+Usage: ${script_name} [OPTION] --path PATH -- COMMAND [INITIAL-ARGS]
 
 Execute the supplied COMMAND with INITIAL-ARGS for all ink! contracts (recursively) found in the given path.
 The manifest path (full path to the Cargo.toml file) is passed either:
@@ -19,17 +11,58 @@ The manifest path (full path to the Cargo.toml file) is passed either:
 
 Returns 0 (success) if the command succeeds against *all* contract projects, if any fail returns 1 (failure).
 
-find_path
+OPTIONS
+  -i, --ignore
+  Path to ignore when recursively finding contract projects
+
+  -p, --path
   Path to recursively find contract projects for which to execute the supplied command
 
 EXAMPLES
-   ${script_name} integration-tests cargo check --manifest-path
-   ${script_name} integration-tests cargo contract build --manifest-path {} --release
+   ${script_name} -path integration-tests -- cargo check --manifest-path
+   ${script_name} -path integration-tests -- cargo contract build --manifest-path {} --release
 
 EOF
 }
 
-if [ -z "$find_path" ] || [ "${#command[@]}" -le 0 ]; then
+# enable recursive globs
+shopt -s globstar
+
+script_name="${BASH_SOURCE[0]}"
+scripts_path=$( cd "$(dirname "$script_name")" || exit; pwd -P )
+command=( "${@:2}" )
+
+options=$(getopt -o p:i: --long path:,ignore: -- "$@")
+[ $? -eq 0 ] || {
+    echo "Incorrect option provided"
+    usage
+    exit 1
+}
+eval set -- "$options"
+ignore=()
+while true; do
+    case "$1" in
+    -p|--path)
+        shift; # The arg is next in position args
+        path="$1"
+        ;;
+    -i|--ignore)
+        shift; # The arg is next in position args
+        ignore+=("$1")
+        ;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
+done
+
+command=("${@}")
+
+echo command "${command[@]}"
+
+if [ -z "$path" ] || [ "${#command[@]}" -le 0 ]; then
   usage
   exit 1
 fi
@@ -47,7 +80,7 @@ for i in "${!command[@]}"; do
   fi
 done
 
-for manifest_path in "$find_path"/**/Cargo.toml;
+for manifest_path in "$path"/**/Cargo.toml;
   do if "$scripts_path"/is_contract.sh "$manifest_path"; then
     command[$arg_index]="$manifest_path"
     echo Running: "${command[@]}"

--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -2,15 +2,30 @@
 
 SCRIPT_NAME="${BASH_SOURCE[0]}"
 FIND_PATH=$1
+COMMAND=${@:2}
 
 function usage {
   cat << EOF
-Usage: ${SCRIPT_NAME} cmd
+Usage: ${SCRIPT_NAME} FIND_PATH COMMAND [INITIAL-ARGS]
 
-TODO
+Execute the supplied COMMAND with INITIAL-ARGS for all ink! contracts (recursively) found in the given path.
+The manifest path (full path to the Cargo.toml file) is passed as the last argument to the supplied command.
+
+Returns 0 (success) if the command succeeds against *all* contract projects, if any fail returns 1 (failure).
+
+FIND_PATH
+  Path to recursively find contract projects for which to execute the supplied command
+
+EXAMPLES
+   ${SCRIPT_NAME} integration-tests cargo check --manifest-path
 
 EOF
 }
+
+if [ -z "$FIND_PATH" ] || [ -z "$COMMAND" ]; then
+  usage
+  exit 1
+fi
 
 # enable recursive globs
 shopt -s globstar
@@ -21,8 +36,8 @@ FAILURES=()
 
 for manifest_path in "$FIND_PATH"/**/Cargo.toml;
   do if "$SCRIPTS_PATH"/is_contract.sh "$manifest_path"; then
-    echo Running: "${@:2}" "$manifest_path";
-    "${@:2}" "$manifest_path";
+    echo Running: "$COMMAND" "$manifest_path";
+    $COMMAND "$manifest_path";
 
     if [ $? -eq 0 ]; then
       SUCCESSES+=("$manifest_path")

--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# enable recursive globs
+shopt -s globstar
+
 script_name="${BASH_SOURCE[0]}"
 scripts_path=$( cd "$(dirname "$script_name")" || exit; pwd -P )
 find_path=$1
@@ -30,9 +33,6 @@ if [ -z "$find_path" ] || [ "${#command[@]}" -le 0 ]; then
   usage
   exit 1
 fi
-
-# enable recursive globs
-shopt -s globstar
 
 successes=()
 failures=()

--- a/scripts/for_all_contracts_exec.sh
+++ b/scripts/for_all_contracts_exec.sh
@@ -32,16 +32,18 @@ for manifest_path in "$FIND_PATH"/**/Cargo.toml;
   fi
 done
 
-echo ""
-echo "Succeeded:" ${#SUCCESSES[@]}
+GREEN='\033[1;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+printf "\nSucceeded: %s\n" ${#SUCCESSES[@]}
 for success in "${SUCCESSES[@]}"; do
-  echo "$success"
+  printf "  ${GREEN}\u2713${NC} %s \n" "$success"
 done
 
-echo ""
-echo "Failed:" ${#FAILURES[@]}
+printf "\nFailed: %s\n" ${#FAILURES[@]}
 for failure in "${FAILURES[@]}"; do
-  echo "$failure"
+  printf "  ${RED}\u2717${NC} %s \n" "$failure"
 done
 
 if [ ${#FAILURES[@]} -gt 0 ]; then


### PR DESCRIPTION
#1893 is using `find` to execute a command recursively against all contract projects. However, `find` will return Success (exit code 0) even when any of the `-exec` commands fail. This means that CI will think the job has passed even if there was a failure.

This PR introduces a script `for_all_contracts_exec.sh` that will execute the given command against all contract projects recursively. 

It will run the command for *all* contract projects (not failing on the first error) and will accumulate errors and display them at the end. This allows seeing all errors at once to prevent having to fix one example at a time and rerunning the script.

```
Usage: scripts/for_all_contracts_exec.sh [OPTION] --path PATH -- COMMAND [INITIAL-ARGS]

Execute the supplied COMMAND with INITIAL-ARGS for all ink! contracts (recursively) found in the given path.
The manifest path (full path to the Cargo.toml file) is passed either:
  - in place of the "{}" placeholder in the command, if present
  - as the last argument to the command, if "{}" is not present

Returns 0 (success) if the command succeeds against *all* contract projects, if any fail returns 1 (failure).

OPTIONS
  -i, --ignore
      Path to ignore when recursively finding contract projects.
      To ignore 'integration-tests/erc20' then supply 'erc20' as the argument.
  -p, --path
      Path to recursively find contract projects for which to execute the supplied command

EXAMPLES
   scripts/for_all_contracts_exec.sh --path integration-tests -- cargo check --manifest-path
   scripts/for_all_contracts_exec.sh --path integration-tests -- cargo contract build --manifest-path {} --release
   scripts/for_all_contracts_exec.sh --path integration-tests --ignore erc20 -- cargo contract build --manifest-path {} --release
```