### PR TITLE
Release `5.0.0-alpha`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,62 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Stabilize `call_runtime` ‒ [#1749](https://github.com/paritytech/ink/pull/1749)
-- Make E2E testcases generic over `E2EBackend` trait - [#1867](https://github.com/paritytech/ink/pull/1867)
-- Modify static buffer size via environmental variables - [#1869](https://github.com/paritytech/ink/pull/1869)
+
+## Version 5.0.0-alpha
+
+The preview release of the ink! 5.0.0 release.
+This release addresses the majority of issues raised in the OpenZeppelin audit
+in particular we addressed the proxy selector clashing attack.
+As of this release, ink! only allows exactly one other message with a well-known reserved selector to be defined.
+You can read more about the change in the [PR](https://github.com/paritytech/ink/pull/1708)
+
+There are also other notable changes:
+
+- Rework of event definitions.
+- Updated upgradeable contract example illustrating `delegate_call`
+- Removal of unchecked arithmetic. `cargo-contract` will fail compiling the contract with raw arithmetic operations.
+- Introduction of an alternative off-chain E2E testing backend, drink!
+**Big thanks to @pmikolajczyk41 for this massive contribution!**
+
+You can see a more detailed log of changes below:
+
+### Added
+- [Drink backend]: allow for arbitrary runtime - [#1892](https://github.com/paritytech/ink/pull/1892)
+- [Drink backend]: support runtime call - [#1891](https://github.com/paritytech/ink/pull/1891)
+- Reexport `scale` dependencies, introduce `#[ink::scale_derive]` - [#1890](https://github.com/paritytech/ink/pull/1890)
+- Upgradeable contracts example - [#1889](https://github.com/paritytech/ink/pull/1889)
 - Persist static buffer size in metadata - [#1880](https://github.com/paritytech/ink/pull/1880)
-- Add backend choice to the E2E testcase configuration ‒ [#1864](https://github.com/paritytech/ink/pull/1864)
+- Modify static buffer size via environmental variables - [#1869](https://github.com/paritytech/ink/pull/1869)
+- [Drink backend]: Make tests generic `E2EBackend` trait - [#1867](https://github.com/paritytech/ink/pull/1867)
+- [Drink backend]: Backend choice  ‒ [#1864](https://github.com/paritytech/ink/pull/1864)
+- [Drink backend]: Backend traits - [#1857](https://github.com/paritytech/ink/pull/1857)
+- [Drink backend]: Abstract error and result structs - [#1844](https://github.com/paritytech/ink/pull/1844)
+- Added `sr25519_verify` function to `ink_env` [#1840](https://github.com/paritytech/ink/pull/1840)
+- Warn when primitive number is annotated as event topic - [#1837](https://github.com/paritytech/ink/pull/1837)
+- Events `2.0` - [#1827](https://github.com/paritytech/ink/pull/1810)
+- Add `set_block_number` to off-chain test api `Engine` - [#1806](https://github.com/paritytech/ink/pull/1806)
+- Stabilize `call_runtime` ‒ [#1749](https://github.com/paritytech/ink/pull/1749)
+- Schema generation - [#1765](https://github.com/paritytech/ink/pull/1765)
+- Restrict wildcard selectors to have exactly one other message - [#1708](https://github.com/paritytech/ink/pull/1708)
 
 ### Changed
 - Reexport `scale` dependencies, introduce `#[ink::scale_derive]` ‒ [#1890](https://github.com/paritytech/ink/pull/1890)
-
-### Added
-- Schema generation - [#1765](https://github.com/paritytech/ink/pull/1765)
-- Add `set_block_number` to off-chain test api `Engine` - [#1806](https://github.com/paritytech/ink/pull/1806)
-- Added `sr25519_verify` function to `ink_env` [#1840](https://github.com/paritytech/ink/pull/1840)
-
-### Changed
+- `[ink_e2e]` build contracts at runtime instead of during codegen - [#1881](https://github.com/paritytech/ink/pull/1881)
+- Use of workspace dependencies and properties - [#1835](https://github.com/paritytech/ink/pull/1835)
+- Remove of unchecked arithmetic - [#1831](https://github.com/paritytech/ink/pull/1831)
+- E2E crate refactoring - [#1830](https://github.com/paritytech/ink/pull/1830)
+- Use `decode_all`` for decoding cross contract call result - [#1810](https://github.com/paritytech/ink/pull/1810)
 - E2E: improve call API, remove `build_message` + callback - [#1782](https://github.com/paritytech/ink/pull/1782)
+
+### Fixed
+- Enable Rust >= `1.70`, update `subxt` and `contract-build` - [#1855](https://github.com/paritytech/ink/pull/1855)
+- Fix unsupported `--ws-port` argument - [#1850](https://github.com/paritytech/ink/pull/1850)
+
+## 4.3.0
+
+### Fixed
+
+- Fix E2E tests for newer rust toolchain & contracts node - #[1884](https://github.com/paritytech/ink/pull/1884)
 
 ## Version 4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ You can read more about the change in the [PR](https://github.com/paritytech/ink
 
 There are also other notable changes:
 
-- Rework of event definitions.
+- Rework of event definitions - [#1827](https://github.com/paritytech/ink/pull/1708).
 - Updated upgradeable contract example illustrating `delegate_call`
 - Removal of unchecked arithmetic. `cargo-contract` will fail compiling the contract with raw arithmetic operations.
 - Introduction of an alternative off-chain E2E testing backend, drink!
@@ -52,15 +52,13 @@ You can see a more detailed log of changes below:
 - Use `decode_all`` for decoding cross contract call result - [#1810](https://github.com/paritytech/ink/pull/1810)
 - E2E: improve call API, remove `build_message` + callback - [#1782](https://github.com/paritytech/ink/pull/1782)
 
-### Fixed
-- Enable Rust >= `1.70`, update `subxt` and `contract-build` - [#1855](https://github.com/paritytech/ink/pull/1855)
-- Fix unsupported `--ws-port` argument - [#1850](https://github.com/paritytech/ink/pull/1850)
-
 ## 4.3.0
 
 ### Fixed
 
 - Fix E2E tests for newer rust toolchain & contracts node - #[1884](https://github.com/paritytech/ink/pull/1884)
+- Enable Rust >= `1.70`, update `subxt` and `contract-build` - [#1855](https://github.com/paritytech/ink/pull/1855)
+- Fix unsupported `--ws-port` argument - [#1850](https://github.com/paritytech/ink/pull/1850)
 
 ## Version 4.2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ quickcheck = { version = "1" }
 quickcheck_macros = { version = "1" }
 quote = { version = "1" }
 rlibc = { version = "1" }
-scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "3.6", default-features = false, features = ["derive"] }
 scale-decode = { version = "0.9.0", default-features = false }
 scale-encode = { version = "0.5.0", default-features = false }
 scale-info = { version = "2.6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ homepage = "https://www.parity.io/"
 keywords = ["wasm", "parity", "webassembly", "blockchain", "edsl"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/ink"
-version = "4.2.0"
+version = "5.0.0-alpha"
 
 [workspace.dependencies]
 arrayref = { version = "0.3" }
@@ -87,19 +87,19 @@ sp-runtime = { version = "25.0.0", default-features = false }
 sp-weights = { version = "21.0.0", default-features = false }
 
 # Local dependencies
-ink = { version = "=4.2.0", path = "crates/ink", default-features = false }
-ink_allocator = { version = "=4.2.0", path = "crates/allocator", default-features = false }
-ink_codegen = { version = "=4.2.0", path = "crates/ink/codegen", default-features = false }
-ink_e2e_macro = { version = "=4.2.0", path = "crates/e2e/macro", default-features = false }
-ink_engine = { version = "=4.2.0", path = "crates/engine", default-features = false }
-ink_env = { version = "=4.2.0", path = "crates/env", default-features = false }
-ink_ir = { version = "=4.2.0", path = "crates/ink/ir", default-features = false }
-ink_macro = { version = "=4.2.0", path = "crates/ink/macro", default-features = false }
-ink_metadata = { version = "=4.2.0", path = "crates/metadata", default-features = false }
-ink_prelude = { version = "=4.2.0", path = "crates/prelude", default-features = false }
-ink_primitives = { version = "=4.2.0", path = "crates/primitives", default-features = false }
-ink_storage = { version = "=4.2.0", path = "crates/storage", default-features = false }
-ink_storage_traits = { version = "=4.2.0", path = "crates/storage/traits", default-features = false }
+ink = { version = "=5.0.0-alpha", path = "crates/ink", default-features = false }
+ink_allocator = { version = "=5.0.0-alpha", path = "crates/allocator", default-features = false }
+ink_codegen = { version = "=5.0.0-alpha", path = "crates/ink/codegen", default-features = false }
+ink_e2e_macro = { version = "=5.0.0-alpha", path = "crates/e2e/macro", default-features = false }
+ink_engine = { version = "=5.0.0-alpha", path = "crates/engine", default-features = false }
+ink_env = { version = "=5.0.0-alpha", path = "crates/env", default-features = false }
+ink_ir = { version = "=5.0.0-alpha", path = "crates/ink/ir", default-features = false }
+ink_macro = { version = "=5.0.0-alpha", path = "crates/ink/macro", default-features = false }
+ink_metadata = { version = "=5.0.0-alpha", path = "crates/metadata", default-features = false }
+ink_prelude = { version = "=5.0.0-alpha", path = "crates/prelude", default-features = false }
+ink_primitives = { version = "=5.0.0-alpha", path = "crates/primitives", default-features = false }
+ink_storage = { version = "=5.0.0-alpha", path = "crates/storage", default-features = false }
+ink_storage_traits = { version = "=5.0.0-alpha", path = "crates/storage/traits", default-features = false }
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ cargo_metadata = { version = "0.17.0" }
 cfg-if = { version = "1.0" }
 contract-build = { version = "3.2.0" }
 derive_more = { version = "0.99.17", default-features = false }
-drink = { version = "=0.1.6" }
+drink = { version = "=0.1.7" }
 either = { version = "1.5", default-features = false }
 funty = { version = "2.0.0" }
 heck = { version = "0.4.0" }

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -55,7 +55,7 @@ scale-encode = { workspace = true, optional = true }
 scale-info = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
-ink = { workspace = true }
+ink = { path = "../ink" }
 
 [features]
 default = ["std"]

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -19,7 +19,7 @@ name = "ink_codegen"
 
 [dependencies]
 ink_primitives = { workspace = true }
-ir = { version = "=4.2.0", package = "ink_ir", path = "../ir", default-features = false }
+ir = { version = "=5.0.0-alpha", package = "ink_ir", path = "../ir", default-features = false }
 quote = { workspace = true }
 syn = { workspace = true, features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = { workspace = true }

--- a/crates/ink/macro/Cargo.toml
+++ b/crates/ink/macro/Cargo.toml
@@ -27,7 +27,7 @@ quote = { workspace = true }
 
 [dev-dependencies]
 ink_env = { workspace = true, default-features = true }
-ink = { workspace = true, default-features = true }
+ink = { path = "..", default-features = true }
 ink_metadata = { workspace = true, default-features = true }
 ink_prelude = { workspace = true, default-features = true }
 ink_storage = { workspace = true, default-features = true }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -32,7 +32,7 @@ quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
 itertools = { workspace = true, default-features = true }
 
-ink = { workspace = true }
+ink = { path = "../ink"}
 
 [features]
 default = ["std"]

--- a/integration-tests/basic-contract-caller/Cargo.toml
+++ b/integration-tests/basic-contract-caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basic-contract-caller"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/basic-contract-caller/other-contract/Cargo.toml
+++ b/integration-tests/basic-contract-caller/other-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "other-contract"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/call-builder-return-value/Cargo.toml
+++ b/integration-tests/call-builder-return-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder_return_value"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-terminate/Cargo.toml
+++ b/integration-tests/contract-terminate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_terminate"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-transfer/Cargo.toml
+++ b/integration-tests/contract-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_transfer"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/custom-allocator/Cargo.toml
+++ b/integration-tests/custom-allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom-allocator"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/custom-environment/Cargo.toml
+++ b/integration-tests/custom-environment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom-environment"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/dns/Cargo.toml
+++ b/integration-tests/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e2e_call_runtime"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/e2e-runtime-only-backend/Cargo.toml
+++ b/integration-tests/e2e-runtime-only-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e2e-runtime-only-backend"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc1155/Cargo.toml
+++ b/integration-tests/erc1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc1155"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc20/Cargo.toml
+++ b/integration-tests/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc20"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc721/Cargo.toml
+++ b/integration-tests/erc721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc721"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/events/Cargo.toml
+++ b/integration-tests/events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "events"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/flipper/Cargo.toml
+++ b/integration-tests/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/incrementer/Cargo.toml
+++ b/integration-tests/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder_delegate"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constructors_return_value"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_ref"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_flipper"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/mapping-integration-tests/Cargo.toml
+++ b/integration-tests/mapping-integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mapping-integration-tests"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/mother/Cargo.toml
+++ b/integration-tests/mother/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mother"
 description = "Mother of all contracts"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/multi-contract-caller/Cargo.toml
+++ b/integration-tests/multi-contract-caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-contract-caller"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/multi-contract-caller/accumulator/Cargo.toml
+++ b/integration-tests/multi-contract-caller/accumulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulator"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi-contract-caller/adder/Cargo.toml
+++ b/integration-tests/multi-contract-caller/adder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adder"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi-contract-caller/subber/Cargo.toml
+++ b/integration-tests/multi-contract-caller/subber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subber"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multisig/Cargo.toml
+++ b/integration-tests/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/payment-channel/Cargo.toml
+++ b/integration-tests/payment-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payment_channel"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/psp22-extension/Cargo.toml
+++ b/integration-tests/psp22-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_extension"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/rand-extension/Cargo.toml
+++ b/integration-tests/rand-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_extension"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/static-buffer/Cargo.toml
+++ b/integration-tests/static-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "static-buffer"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-erc20/Cargo.toml
+++ b/integration-tests/trait-erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_erc20"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-flipper/Cargo.toml
+++ b/integration-tests/trait-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_flipper"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-incrementer/Cargo.toml
+++ b/integration-tests/trait-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-incrementer/traits/Cargo.toml
+++ b/integration-tests/trait-incrementer/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traits"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/delegator/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/delegator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegator"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/delegator/delegatee/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/delegator/delegatee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegatee"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated-incrementer"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_linting"
-version = "4.2.0"
+version = "5.0.0-alpha"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false


### PR DESCRIPTION
As part of the release I had to modify cargo files of `ink_env`, `ink_macro` and `ink_storage` crates, specifically replacing `ink` workspace dependency with a path one. 
It turns out that using workspace dependencies breaks the publishing process (see https://github.com/rust-lang/cargo/issues/1169). 
It was unfortunate that this only appeared when half of the crates have already been published, so I had to quickly patch the fixes in the release branch.