### PR TITLE
Pin `parity-scale-codec` to `3.6.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ quickcheck = { version = "1" }
 quickcheck_macros = { version = "1" }
 quote = { version = "1" }
 rlibc = { version = "1" }
-scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "=3.6.5", default-features = false, features = ["derive"] }
 scale-decode = { version = "0.9.0", default-features = false }
 scale-encode = { version = "0.5.0", default-features = false }
 scale-info = { version = "2.6", default-features = false }


### PR DESCRIPTION
`parity-scale-codec = 3.6.7` breaks the the `cargo clippy` run with error:

```
error[E0277]: the trait bound `MultiAddress<AccountId32, ()>: Encode` is not satisfied
  --> /Users/skyman/.cargo/registry/src/index.crates.io-6f17d22bba15001f/subxt-0.31.0/src/config/polkadot.rs:23:20
   |
23 |     type Address = MultiAddress<Self::AccountId, ()>;
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Encode` is not implemented for `MultiAddress<AccountId32, ()>`
   |
   = help: the trait `Encode` is implemented for `MultiAddress<AccountId, AccountIndex>`
note: required by a bound in `Config::Address`
  --> /Users/skyman/.cargo/registry/src/index.crates.io-6f17d22bba15001f/subxt-0.31.0/src/config/mod.rs:44:27
   |
44 |     type Address: Debug + Encode + From<Self::AccountId>;
   |                           ^^^^^^ required by this bound in `Config::Address`

    Checking ink_storage_traits v5.0.0-alpha (/Users/skyman/Projects/ink/crates/storage/traits)
```

Pinning the crate to the previous version fixes the issue.