### PR TITLE
Make `set_code_hash` generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+- Make `set_code_hash` generic - [#1906](https://github.com/paritytech/ink/pull/1906)
+
 ## Version 5.0.0-alpha
 
 The preview release of the ink! 5.0.0 release.

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -752,19 +752,7 @@ where
 /// Please refer to the
 /// [Open Zeppelin docs](https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable#modifying-your-contracts)
 /// for more details and examples.
-pub fn set_code_hash(code_hash: &[u8; 32]) -> Result<()> {
-    <EnvInstance as OnInstance>::on_instance(|instance| instance.set_code_hash(code_hash))
-}
-
-/// Replace the contract code at the specified address with new code.
-///
-/// # Compatibility
-///
-/// This is new version of the existing [`set_code_hash`] function. We plan to place the
-/// old function with this in the next `MAJOR` release.
-///
-/// See the original [`set_code_hash`] function for full details.
-pub fn set_code_hash2<E>(code_hash: &E::Hash) -> Result<()>
+pub fn set_code_hash<E>(code_hash: &E::Hash) -> Result<()>
 where
     E: Environment,
 {

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -1106,7 +1106,7 @@ where
     ///
     /// For more details visit: [`ink_env::set_code_hash`]
     pub fn set_code_hash(self, code_hash: &E::Hash) -> Result<()> {
-        ink_env::set_code_hash2::<E>(code_hash)
+        ink_env::set_code_hash::<E>(code_hash)
     }
 
     pub fn call_runtime<Call: scale::Encode>(self, call: &Call) -> Result<()> {

--- a/integration-tests/upgradeable-contracts/set-code-hash/lib.rs
+++ b/integration-tests/upgradeable-contracts/set-code-hash/lib.rs
@@ -57,8 +57,8 @@ pub mod incrementer {
         ///
         /// In a production contract you would do some authorization here!
         #[ink(message)]
-        pub fn set_code(&mut self, code_hash: [u8; 32]) {
-            ink::env::set_code_hash(&code_hash).unwrap_or_else(|err| {
+        pub fn set_code(&mut self, code_hash: Hash) {
+            self.env().set_code_hash(&code_hash).unwrap_or_else(|err| {
                 panic!("Failed to `set_code_hash` to {code_hash:?} due to {err:?}")
             });
             ink::env::debug_println!("Switched code hash to {:?}.", code_hash);


### PR DESCRIPTION
**Breaking Change**

Follow up to https://github.com/paritytech/ink/pull/1698. Replaces the existing `set_code_hash` impl with `set_code_hash2` which was introduced in #1698 to make the code hash generic from the `Environment` trait, instead of the concrete `[u8; 32]`



