### PR TITLE
Update `schnorrkel` to `0.11.2`

### DIFF
--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -44,7 +44,7 @@ blake2 = { workspace = true, optional = true }
 secp256k1 = { workspace = true, features = ["recovery", "global-context"], optional = true }
 
 # schnorrkel for the off-chain environment.
-schnorrkel = { version = "0.11.1", optional = true }
+schnorrkel = { version = "0.11.0", optional = true }
 
 # Only used in the off-chain environment.
 #

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -44,7 +44,7 @@ blake2 = { workspace = true, optional = true }
 secp256k1 = { workspace = true, features = ["recovery", "global-context"], optional = true }
 
 # schnorrkel for the off-chain environment.
-schnorrkel = { version = "0.11.0", optional = true }
+schnorrkel = { version = "0.11.2", optional = true }
 
 # Only used in the off-chain environment.
 #


### PR DESCRIPTION
https://crates.io/crates/schnorrkel/0.11.1 has been yanked, initially I downgraded to `0.11.0`, but since I opened this PR a new version `0.11.2` has been released so have upgraded to that :see_no_evil: 