### PR TITLE
`[ink_e2e]` determine contracts node executable at runtime

### DIFF
--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -36,6 +36,7 @@ subxt = { workspace = true }
 subxt-metadata = { workspace = true, optional = true }
 subxt-signer = { workspace = true, features = ["subxt", "sr25519"] }
 wasm-instrument = { workspace = true }
+which = { workspace = true }
 
 # Substrate
 pallet-contracts-primitives = { workspace = true }

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -26,7 +26,6 @@ serde_json = { workspace = true }
 syn = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-which = { workspace = true }
 
 [features]
 drink = []

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -20,8 +20,6 @@ use derive_more::From;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
-const DEFAULT_CONTRACTS_NODE: &str = "substrate-contracts-node";
-
 /// Generates code for the `[ink::e2e_test]` macro.
 #[derive(From)]
 pub struct InkE2ETest {
@@ -113,26 +111,10 @@ impl InkE2ETest {
 }
 
 fn build_full_client(environment: &syn::Path, contracts: TokenStream2) -> TokenStream2 {
-    // Use the user supplied `CONTRACTS_NODE` or default to `DEFAULT_CONTRACTS_NODE`.
-    let contracts_node: &'static str =
-        option_env!("CONTRACTS_NODE").unwrap_or(DEFAULT_CONTRACTS_NODE);
-
-    // Check the specified contracts node.
-    if which::which(contracts_node).is_err() {
-        if contracts_node == DEFAULT_CONTRACTS_NODE {
-            panic!(
-                "The '{DEFAULT_CONTRACTS_NODE}' executable was not found. Install '{DEFAULT_CONTRACTS_NODE}' on the PATH, \
-                    or specify the `CONTRACTS_NODE` environment variable.",
-            )
-        } else {
-            panic!("The contracts node executable '{contracts_node}' was not found.")
-        }
-    }
-
     quote! {
         // Spawn a contracts node process just for this test.
         let node_proc = ::ink_e2e::TestNodeProcess::<::ink_e2e::PolkadotConfig>
-            ::build(#contracts_node)
+            ::build_with_env_or_default()
             .spawn()
             .await
             .unwrap_or_else(|err|

--- a/crates/e2e/src/node_proc.rs
+++ b/crates/e2e/src/node_proc.rs
@@ -58,6 +58,29 @@ where
         TestNodeProcessBuilder::new(program)
     }
 
+    /// Construct a builder for spawning a test node process, using the environment
+    /// variable `CONTRACTS_NODE`, otherwise using the default contracts node.
+    pub fn build_with_env_or_default() -> TestNodeProcessBuilder<R> {
+        const DEFAULT_CONTRACTS_NODE: &str = "substrate-contracts-node";
+
+        // Use the user supplied `CONTRACTS_NODE` or default to `DEFAULT_CONTRACTS_NODE`.
+        let contracts_node =
+            std::env::var("CONTRACTS_NODE").unwrap_or(DEFAULT_CONTRACTS_NODE.to_owned());
+
+        // Check the specified contracts node.
+        if which::which(&contracts_node).is_err() {
+            if contracts_node == DEFAULT_CONTRACTS_NODE {
+                panic!(
+                    "The '{DEFAULT_CONTRACTS_NODE}' executable was not found. Install '{DEFAULT_CONTRACTS_NODE}' on the PATH, \
+                    or specify the `CONTRACTS_NODE` environment variable.",
+                )
+            } else {
+                panic!("The contracts node executable '{contracts_node}' was not found.")
+            }
+        }
+        Self::build(contracts_node)
+    }
+
     /// Attempt to kill the running substrate process.
     pub fn kill(&mut self) -> Result<(), String> {
         tracing::info!("Killing node process {}", self.proc.id());


### PR DESCRIPTION
Moves the detection of the contracts node to spawn for the E2E tests from codegen time to runtime.

This means better error messages, and also if the environment var changes between runs then it can be updated on the next run.