### PR TITLE
:t-rex: remove `RUSTFLAGS` for `examples-contract-build`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -244,7 +244,7 @@ test:
       artifacts:                   false
   variables:
       # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
-      RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc"
+      RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code"
       # Since we run the tests with `--all-features` this implies the feature
       # `ink-fuzz-tests` as well -- i.e. the fuzz tests are run.
       # There's no way to disable a single feature while enabling all features
@@ -347,7 +347,7 @@ examples-test:
       artifacts:                   false
   variables:
     # Fix linking of `linkme`: https://github.com/dtolnay/linkme/issues/49
-    RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc"
+    RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code"
   script:
     # run all tests with --all-features, which will run the e2e-tests feature if present
     - scripts/for_all_contracts_exec.sh 
@@ -364,7 +364,7 @@ examples-contract-build:
   <<:                              *test-refs
   variables:
     # Fix for linking of `linkme` for `cargo contract build`: https://github.com/dtolnay/linkme/issues/49
-    RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc"
+    RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code"
   script:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,6 +243,8 @@ test:
     - job:                         check-std
       artifacts:                   false
   variables:
+      # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
+      RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc"
       # Since we run the tests with `--all-features` this implies the feature
       # `ink-fuzz-tests` as well -- i.e. the fuzz tests are run.
       # There's no way to disable a single feature while enabling all features
@@ -343,6 +345,9 @@ examples-test:
   needs:
     - job:                         clippy-std
       artifacts:                   false
+  variables:
+    # Fix linking of `linkme`: https://github.com/dtolnay/linkme/issues/49
+    RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc"
   script:
     # run all tests with --all-features, which will run the e2e-tests feature if present
     - scripts/for_all_contracts_exec.sh 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -243,8 +243,6 @@ test:
     - job:                         check-std
       artifacts:                   false
   variables:
-      # Fix for linking of `linkme` for `cargo test`: https://github.com/dtolnay/linkme/issues/49
-      RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code"
       # Since we run the tests with `--all-features` this implies the feature
       # `ink-fuzz-tests` as well -- i.e. the fuzz tests are run.
       # There's no way to disable a single feature while enabling all features
@@ -345,9 +343,6 @@ examples-test:
   needs:
     - job:                         clippy-std
       artifacts:                   false
-  variables:
-    # Fix linking of `linkme`: https://github.com/dtolnay/linkme/issues/49
-    RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code"
   script:
     # run all tests with --all-features, which will run the e2e-tests feature if present
     - scripts/for_all_contracts_exec.sh 
@@ -362,9 +357,6 @@ examples-contract-build:
   stage:                           examples
   <<:                              *docker-env
   <<:                              *test-refs
-  variables:
-    # Fix for linking of `linkme` for `cargo contract build`: https://github.com/dtolnay/linkme/issues/49
-    RUSTFLAGS: "-Clink-arg=-z -Clink-arg=nostart-stop-gc -Clink-dead-code"
   script:
     - rustup component add rust-src --toolchain stable
     - cargo contract -V


### PR DESCRIPTION
[Latest CI image](https://hub.docker.com/layers/paritytech/ci-unified/latest/images/sha256-425118b2700387f330f19ded56f03e4493ba1f61630d665b6a7c743839c7de27?context=explore) should bring in https://github.com/paritytech/cargo-contract/pull/1344/ which adds `-Clink-dead-code` to the metadata gen `RUSTFLAGS`. CI should be fixed.

The `RUSTFLAGS` remain set for the `test` and `examples-test` steps because those are not using `cargo-contract` directly but building via the `contract-build` dependency which has not yet been released with the fix from https://github.com/paritytech/cargo-contract/pull/1344