### PR TITLE
E2E: Clean config parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 - Make `set_code_hash` generic - [#1906](https://github.com/paritytech/ink/pull/1906)
+- Clean E2E configuration parsing - [#1922](https://github.com/paritytech/ink/pull/1922)
 
 ## Version 5.0.0-alpha
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ blake2 = { version = "0.10" }
 cargo_metadata = { version = "0.18.0" }
 cfg-if = { version = "1.0" }
 contract-build = { version = "3.2.0" }
+darling = { version = "0.20.3" }
 derive_more = { version = "0.99.17", default-features = false }
 drink = { version = "=0.1.9" }
 either = { version = "1.5", default-features = false }

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -19,6 +19,7 @@ name = "ink_e2e_macro"
 proc-macro = true
 
 [dependencies]
+darling = { workspace = true }
 ink_ir = { workspace = true, default-features = true }
 derive_more = { workspace = true, default-features = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ink_ir::{
-    ast,
-    format_err_spanned,
-    utils::duplicate_config_err,
-};
-
 /// The type of the architecture that should be used to run test.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default, darling::FromMeta)]
 pub enum Backend {
     /// The standard approach with running dedicated single-node blockchain in a
     /// background process.
@@ -33,166 +27,37 @@ pub enum Backend {
     RuntimeOnly,
 }
 
-impl TryFrom<syn::LitStr> for Backend {
-    type Error = syn::Error;
-
-    fn try_from(value: syn::LitStr) -> Result<Self, Self::Error> {
-        match value.value().as_str() {
-            "full" => Ok(Self::Full),
-            #[cfg(any(test, feature = "drink"))]
-            "runtime_only" | "runtime-only" => Ok(Self::RuntimeOnly),
-            #[cfg(not(any(test, feature = "drink")))]
-            "runtime_only" | "runtime-only" => Err(
-                format_err_spanned!(
-                    value,
-                    "the `runtime-only` backend is not available because the `drink` feature is not enabled",
-                )
-            ),
-            _ => {
-                Err(format_err_spanned!(
-                    value,
-                    "unknown backend `{}` for ink! E2E test configuration argument",
-                    value.value()
-                ))
-            }
-        }
-    }
-}
-
 /// The End-to-End test configuration.
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq, darling::FromMeta)]
 pub struct E2EConfig {
     /// Additional contracts that have to be built before executing the test.
-    additional_contracts: Vec<String>,
+    #[darling(default)]
+    additional_contracts: String,
     /// The [`Environment`](https://docs.rs/ink_env/4.1.0/ink_env/trait.Environment.html) to use
     /// during test execution.
     ///
     /// If no `Environment` is specified, the
     /// [`DefaultEnvironment`](https://docs.rs/ink_env/4.1.0/ink_env/enum.DefaultEnvironment.html)
     /// will be used.
+    #[darling(default)]
     environment: Option<syn::Path>,
     /// The type of the architecture that should be used to run test.
+    #[darling(default)]
     backend: Backend,
-    /// The runtime to use for the runtime-only test.
+    /// The runtime to use for the runtime_only test.
     #[cfg(any(test, feature = "drink"))]
+    #[darling(default)]
     runtime: Option<syn::Path>,
-}
-
-impl TryFrom<ast::AttributeArgs> for E2EConfig {
-    type Error = syn::Error;
-
-    fn try_from(args: ast::AttributeArgs) -> Result<Self, Self::Error> {
-        let mut additional_contracts: Option<(syn::LitStr, ast::MetaNameValue)> = None;
-        let mut environment: Option<(syn::Path, ast::MetaNameValue)> = None;
-        let mut backend: Option<(syn::LitStr, ast::MetaNameValue)> = None;
-        #[cfg(any(test, feature = "drink"))]
-        let mut runtime: Option<(syn::Path, ast::MetaNameValue)> = None;
-
-        for arg in args.into_iter() {
-            if arg.name.is_ident("additional_contracts") {
-                if let Some((_, ast)) = additional_contracts {
-                    return Err(duplicate_config_err(
-                        ast,
-                        arg,
-                        "additional_contracts",
-                        "E2E test",
-                    ))
-                }
-                if let ast::MetaValue::Lit(syn::Lit::Str(lit_str)) = &arg.value {
-                    additional_contracts = Some((lit_str.clone(), arg))
-                } else {
-                    return Err(format_err_spanned!(
-                        arg,
-                        "expected a string literal for `additional_contracts` ink! E2E test configuration argument",
-                    ));
-                }
-            } else if arg.name.is_ident("environment") {
-                if let Some((_, ast)) = environment {
-                    return Err(duplicate_config_err(ast, arg, "environment", "E2E test"))
-                }
-                if let ast::MetaValue::Path(path) = &arg.value {
-                    environment = Some((path.clone(), arg))
-                } else {
-                    return Err(format_err_spanned!(
-                        arg,
-                        "expected a path for `environment` ink! E2E test configuration argument",
-                    ));
-                }
-            } else if arg.name.is_ident("backend") {
-                if let Some((_, ast)) = backend {
-                    return Err(duplicate_config_err(ast, arg, "backend", "E2E test"))
-                }
-                if let ast::MetaValue::Lit(syn::Lit::Str(lit_str)) = &arg.value {
-                    backend = Some((lit_str.clone(), arg))
-                } else {
-                    return Err(format_err_spanned!(
-                        arg,
-                        "expected a string literal for `backend` ink! E2E test configuration argument",
-                    ));
-                }
-            } else if arg.name.is_ident("runtime") {
-                #[cfg(any(test, feature = "drink"))]
-                {
-                    if let Some((_, ast)) = runtime {
-                        return Err(duplicate_config_err(ast, arg, "runtime", "E2E test"))
-                    }
-                    if let ast::MetaValue::Path(path) = &arg.value {
-                        runtime = Some((path.clone(), arg))
-                    } else {
-                        return Err(format_err_spanned!(
-                        arg,
-                        "expected a path for `runtime` ink! E2E test configuration argument",
-                    ));
-                    }
-                }
-                #[cfg(not(any(test, feature = "drink")))]
-                {
-                    return Err(format_err_spanned!(
-                        arg,
-                        "the `runtime` ink! E2E test configuration argument is not available because the `drink` feature is not enabled",
-                    ));
-                }
-            } else {
-                return Err(format_err_spanned!(
-                    arg,
-                    "encountered unknown or unsupported ink! configuration argument",
-                ))
-            }
-        }
-        let additional_contracts = additional_contracts
-            .map(|(value, _)| value.value().split(' ').map(String::from).collect())
-            .unwrap_or_else(Vec::new);
-        let environment = environment.map(|(path, _)| path);
-        let backend = backend
-            .map(|(b, _)| Backend::try_from(b))
-            .transpose()?
-            .unwrap_or_default();
-
-        #[cfg(any(test, feature = "drink"))]
-        {
-            if backend == Backend::Full && runtime.is_some() {
-                return Err(format_err_spanned!(
-                    runtime.unwrap().1,
-                    "ink! E2E test `runtime` configuration argument is available for `runtime-only` backend only",
-                ));
-            }
-        }
-
-        Ok(E2EConfig {
-            additional_contracts,
-            environment,
-            backend,
-            #[cfg(any(test, feature = "drink"))]
-            runtime: runtime.map(|(path, _)| path),
-        })
-    }
 }
 
 impl E2EConfig {
     /// Returns a vector of additional contracts that have to be built
     /// and imported before executing the test.
     pub fn additional_contracts(&self) -> Vec<String> {
-        self.additional_contracts.clone()
+        self.additional_contracts
+            .split(' ')
+            .map(String::from)
+            .collect()
     }
 
     /// Custom environment for the contracts, if specified.
@@ -205,7 +70,7 @@ impl E2EConfig {
         self.backend
     }
 
-    /// The runtime to use for the runtime-only test.
+    /// The runtime to use for the runtime_only test.
     #[cfg(any(test, feature = "drink"))]
     pub fn runtime(&self) -> Option<syn::Path> {
         self.runtime.clone()
@@ -215,15 +80,18 @@ impl E2EConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use darling::{
+        ast::NestedMeta,
+        FromMeta,
+    };
+    use proc_macro2::TokenStream;
+    use quote::quote;
 
     /// Asserts that the given input configuration attribute argument are converted
     /// into the expected ink! configuration or yields the expected error message.
-    fn assert_try_from(
-        input: ast::AttributeArgs,
-        expected: Result<E2EConfig, &'static str>,
-    ) {
+    fn assert_try_from(input: TokenStream, expected: Result<E2EConfig, &'static str>) {
         assert_eq!(
-            <E2EConfig as TryFrom<ast::AttributeArgs>>::try_from(input)
+            E2EConfig::from_list(&NestedMeta::parse_meta_list(input.into()).unwrap())
                 .map_err(|err| err.to_string()),
             expected.map_err(ToString::to_string),
         );
@@ -231,58 +99,54 @@ mod tests {
 
     #[test]
     fn empty_config_works() {
-        assert_try_from(syn::parse_quote! {}, Ok(E2EConfig::default()))
+        assert_try_from(quote! {}, Ok(E2EConfig::default()))
     }
 
     #[test]
     fn unknown_arg_fails() {
         assert_try_from(
-            syn::parse_quote! { unknown = argument },
-            Err("encountered unknown or unsupported ink! configuration argument"),
+            quote! { unknown = argument },
+            Err("Unknown field: `unknown`"),
         );
     }
 
     #[test]
     fn duplicate_additional_contracts_fails() {
         assert_try_from(
-            syn::parse_quote! {
+            quote! {
                 additional_contracts = "adder/Cargo.toml",
                 additional_contracts = "adder/Cargo.toml",
             },
-            Err(
-                "encountered duplicate ink! E2E test `additional_contracts` configuration argument",
-            ),
+            Err("Duplicate field `additional_contracts`"),
         );
     }
 
     #[test]
     fn duplicate_environment_fails() {
         assert_try_from(
-            syn::parse_quote! {
+            quote! {
                 environment = crate::CustomEnvironment,
                 environment = crate::CustomEnvironment,
             },
-            Err(
-                "encountered duplicate ink! E2E test `environment` configuration argument",
-            ),
-        );
-    }
-
-    #[test]
-    fn environment_as_literal_fails() {
-        assert_try_from(
-            syn::parse_quote! {
-                environment = "crate::CustomEnvironment",
-            },
-            Err("expected a path for `environment` ink! E2E test configuration argument"),
+            Err("Duplicate field `environment`"),
         );
     }
 
     #[test]
     fn specifying_environment_works() {
         assert_try_from(
-            syn::parse_quote! {
+            quote! {
                 environment = crate::CustomEnvironment,
+            },
+            Ok(E2EConfig {
+                environment: Some(syn::parse_quote! { crate::CustomEnvironment }),
+                ..Default::default()
+            }),
+        );
+
+        assert_try_from(
+            quote! {
+                environment = "crate::CustomEnvironment",
             },
             Ok(E2EConfig {
                 environment: Some(syn::parse_quote! { crate::CustomEnvironment }),
@@ -294,26 +158,26 @@ mod tests {
     #[test]
     fn backend_must_be_literal() {
         assert_try_from(
-            syn::parse_quote! { backend = full },
-            Err("expected a string literal for `backend` ink! E2E test configuration argument"),
+            quote! { backend = full },
+            Err("Unexpected literal type `path` at backend"),
         );
     }
 
     #[test]
     fn duplicate_backend_fails() {
         assert_try_from(
-            syn::parse_quote! {
+            quote! {
                 backend = "full",
-                backend = "runtime-only",
+                backend = "runtime_only",
             },
-            Err("encountered duplicate ink! E2E test `backend` configuration argument"),
+            Err("Duplicate field `backend`"),
         );
     }
 
     #[test]
     fn specifying_backend_works() {
         assert_try_from(
-            syn::parse_quote! { backend = "runtime-only" },
+            quote! { backend = "runtime_only" },
             Ok(E2EConfig {
                 backend: Backend::RuntimeOnly,
                 ..Default::default()
@@ -322,41 +186,34 @@ mod tests {
     }
 
     #[test]
-    fn runtime_must_be_path() {
-        assert_try_from(
-            syn::parse_quote! { runtime = "MinimalRuntime" },
-            Err("expected a path for `runtime` ink! E2E test configuration argument"),
-        );
-    }
-
-    #[test]
     fn duplicate_runtime_fails() {
         assert_try_from(
-            syn::parse_quote! {
+            quote! {
                 runtime = ::drink::MinimalRuntime,
                 runtime = ::drink::MaximalRuntime,
             },
-            Err("encountered duplicate ink! E2E test `runtime` configuration argument"),
-        );
-    }
-
-    #[test]
-    fn runtime_is_for_runtime_only_backend_only() {
-        assert_try_from(
-            syn::parse_quote! {
-                backend = "full",
-                runtime = ::drink::MinimalRuntime
-            },
-            Err("ink! E2E test `runtime` configuration argument is available for `runtime-only` backend only"),
+            Err("Duplicate field `runtime`"),
         );
     }
 
     #[test]
     fn specifying_runtime_works() {
         assert_try_from(
-            syn::parse_quote! {
-                backend = "runtime-only",
+            quote! {
+                backend = "runtime_only",
                 runtime = ::drink::MinimalRuntime
+            },
+            Ok(E2EConfig {
+                backend: Backend::RuntimeOnly,
+                runtime: Some(syn::parse_quote! { ::drink::MinimalRuntime }),
+                ..Default::default()
+            }),
+        );
+
+        assert_try_from(
+            quote! {
+                backend = "runtime_only",
+                runtime = "::drink::MinimalRuntime"
             },
             Ok(E2EConfig {
                 backend: Backend::RuntimeOnly,
@@ -369,17 +226,14 @@ mod tests {
     #[test]
     fn full_config_works() {
         assert_try_from(
-            syn::parse_quote! {
+            quote! {
                 additional_contracts = "adder/Cargo.toml flipper/Cargo.toml",
                 environment = crate::CustomEnvironment,
-                backend = "runtime-only",
+                backend = "runtime_only",
                 runtime = ::drink::MinimalRuntime,
             },
             Ok(E2EConfig {
-                additional_contracts: vec![
-                    "adder/Cargo.toml".into(),
-                    "flipper/Cargo.toml".into(),
-                ],
+                additional_contracts: "adder/Cargo.toml flipper/Cargo.toml".to_string(),
                 environment: Some(syn::parse_quote! { crate::CustomEnvironment }),
                 backend: Backend::RuntimeOnly,
                 runtime: Some(syn::parse_quote! { ::drink::MinimalRuntime }),

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -56,7 +56,13 @@ impl E2EConfig {
     pub fn additional_contracts(&self) -> Vec<String> {
         self.additional_contracts
             .split(' ')
-            .map(String::from)
+            .filter_map(|s| {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s.to_owned())
+                }
+            })
             .collect()
     }
 

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -44,7 +44,7 @@ pub struct E2EConfig {
     /// The type of the architecture that should be used to run test.
     #[darling(default)]
     backend: Backend,
-    /// The runtime to use for the runtime_only test.
+    /// The runtime to use for the runtime only test.
     #[cfg(any(test, feature = "drink"))]
     #[darling(default)]
     runtime: Option<syn::Path>,

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -70,7 +70,7 @@ impl E2EConfig {
         self.backend
     }
 
-    /// The runtime to use for the runtime_only test.
+    /// The runtime to use for the runtime only test.
     #[cfg(any(test, feature = "drink"))]
     pub fn runtime(&self) -> Option<syn::Path> {
         self.runtime.clone()
@@ -84,7 +84,6 @@ mod tests {
         ast::NestedMeta,
         FromMeta,
     };
-    use proc_macro2::TokenStream;
     use quote::quote;
 
     #[test]
@@ -96,8 +95,7 @@ mod tests {
             runtime = ::drink::MinimalRuntime,
         };
         let config =
-            E2EConfig::from_list(&NestedMeta::parse_meta_list(input.into()).unwrap())
-                .unwrap();
+            E2EConfig::from_list(&NestedMeta::parse_meta_list(input).unwrap()).unwrap();
 
         assert_eq!(
             config.additional_contracts(),

--- a/crates/e2e/macro/src/ir.rs
+++ b/crates/e2e/macro/src/ir.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    config::E2EConfig,
-    ir,
+use crate::config::E2EConfig;
+use darling::{
+    ast::NestedMeta,
+    FromMeta,
 };
 use proc_macro2::TokenStream as TokenStream2;
 
@@ -37,8 +38,7 @@ impl InkE2ETest {
     /// Returns `Ok` if the test matches all requirements for an
     /// ink! E2E test definition.
     pub fn new(attrs: TokenStream2, input: TokenStream2) -> Result<Self, syn::Error> {
-        let config = syn::parse2::<ink_ir::ast::AttributeArgs>(attrs)?;
-        let e2e_config = ir::E2EConfig::try_from(config)?;
+        let e2e_config = E2EConfig::from_list(&NestedMeta::parse_meta_list(attrs)?)?;
         let item_fn = syn::parse2::<syn::ItemFn>(input)?;
         let e2e_fn = E2EFn::from(item_fn);
         Ok(Self {

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -547,7 +547,7 @@ where
             .call(
                 subxt::utils::MultiAddress::Id(account_id.clone()),
                 value,
-                dry_run.exec_result.gas_required.into(),
+                (dry_run.exec_result.gas_required + 1000000.into()).into(),
                 storage_deposit_limit,
                 exec_input,
                 caller,

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -547,7 +547,7 @@ where
             .call(
                 subxt::utils::MultiAddress::Id(account_id.clone()),
                 value,
-                (dry_run.exec_result.gas_required + 1000000.into()).into(),
+                dry_run.exec_result.gas_required.into(),
                 storage_deposit_limit,
                 exec_input,
                 caller,

--- a/integration-tests/e2e-runtime-only-backend/lib.rs
+++ b/integration-tests/e2e-runtime-only-backend/lib.rs
@@ -84,7 +84,7 @@ pub mod flipper {
         /// - flip the flipper
         /// - get the flipper's value
         /// - assert that the value is `true`
-        #[ink_e2e::test(backend = "runtime-only")]
+        #[ink_e2e::test(backend = "runtime_only")]
         async fn it_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // given
             const INITIAL_VALUE: bool = false;
@@ -115,7 +115,7 @@ pub mod flipper {
         /// - transfer some funds to the contract using runtime call
         /// - get the contract's balance again
         /// - assert that the contract's balance increased by the transferred amount
-        #[ink_e2e::test(backend = "runtime-only")]
+        #[ink_e2e::test(backend = "runtime_only")]
         async fn runtime_call_works() -> E2EResult<()> {
             // given
             let contract = deploy(&mut client, false).await.expect("deploy failed");
@@ -151,7 +151,7 @@ pub mod flipper {
         }
 
         /// Just instantiate a contract using non-default runtime.
-        #[ink_e2e::test(backend = "runtime-only", runtime = ink_e2e::MinimalRuntime)]
+        #[ink_e2e::test(backend = "runtime_only", runtime = ink_e2e::MinimalRuntime)]
         async fn custom_runtime<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             client
                 .instantiate(


### PR DESCRIPTION
- [y] y/n | Does it introduce breaking changes? (although an extremely cosmetic one)
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

## Description
Instead of parsing e2e configuration arguments, checking for errors and handling all situations manually, we can use `darling` library that is dedicated for exactly such boilerplate.

I have removed most of the testcases (leaving only the positive scenario) - they seem to be completely unnecessary now, since all the error detection and handling is now outsourced. We may however bring them back (preferably in another PR) as UI tests for e2e crate.

The only breaking change is that we won't accept `runtime-only` literal (only `runtime_only` is now valid). Additionally, we accept path arguments (like `runtime`) both in raw form and as literals (default in `darling`).

Note: we had to change `additional_contracts` field type from `Vec<String>` to `String`, since `darling` doesn't support parsing `Vec<String>` in the intended way (only by multiple argument occurrences). However, this is not visible from outside struct internal implementation.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
