### PR TITLE
update ink! attribute argument syntax docs and simplify ink! attribute meta parsing implementation in ink_ir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Changed
+- Update ink! attribute argument syntax docs and simplify ink! attribute meta parsing implementation in ink_ir - [#1927](https://github.com/paritytech/ink/pull/1927)
 - Make `set_code_hash` generic - [#1906](https://github.com/paritytech/ink/pull/1906)
 
 ## Version 5.0.0-alpha

--- a/crates/ink/ir/src/ast/mod.rs
+++ b/crates/ink/ir/src/ast/mod.rs
@@ -12,17 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Types and abstractions for ink! definitions that require custom syntax.
+//! Types and abstractions for ink! definitions that require custom
+//! [`syn::parse::Parse`] implementations.
 //!
 //! # Note
 //!
-//! In general we try not to require any sort of custom non-standard Rust
-//! syntax.
+//! In general we do not require any sort of custom non-standard Rust syntax.
 //!
-//! At the time of this writing we currently only use this for the argument
-//! parsing of ink! configuration header `#[ink(env = my::env::Types, ...)]`
-//! in order to be able to parse identifiers in `name = value` segments for
-//! the `value` part.
+//! However, because the Rust attribute grammar is very flexible,
+//! custom [`syn::parse::Parse`] implementations are typically required
+//! for parsing structured arguments from attribute syntax that doesn't
+//! exactly match the
+//! ["meta item" attribute syntax](https://doc.rust-lang.org/reference/attributes.html#meta-item-attribute-syntax)
+//!  used by most
+//! ["built-in" Rust attributes](https://doc.rust-lang.org/reference/attributes.html#built-in-attributes-index)
+//! for which [`syn::Meta`] (and its related variant types) can be used directly.
+//!
+//! At the time of this writing, ink! attribute argument syntax deviates from
+//! ["meta item" attribute syntax](https://doc.rust-lang.org/reference/attributes.html#meta-item-attribute-syntax)
+//! by:
+//! - allowing the `impl` keyword in "meta item" paths
+//! (i.e. `#[ink(impl)]` which is a deviation from the
+//! [simple path](https://doc.rust-lang.org/reference/paths.html#simple-paths)
+//! grammar).
+//! - allowing the `@` symbol as a `value` in `name-value` pairs
+//! (i.e. `#[ink(selector = @)]` which is a deviation from the
+//! [expression](https://doc.rust-lang.org/reference/expressions.html)
+//! grammar followed by the `value` part).
+//!
+//! NOTE: Underscore (`_`) values in `name-value` pairs
+//! (e.g. `#[ink(selector = _)]`) are technically allowed by
+//! the "meta item" attribute syntax as they can be interpreted as
+//! [underscore expressions](https://doc.rust-lang.org/reference/expressions/underscore-expr.html)
+//! (same for path values - e.g `#[ink(env = my::env::Types)]` -
+//! which are valid
+//! [path expressions](https://doc.rust-lang.org/reference/expressions/path-expr.html)
+//! in "meta item" attribute syntax).
 
 mod attr_args;
 mod meta;


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

## Description

- Updates ink! attribute argument syntax documentation in ink_ir's ast module to accurately describe current deviations from [Rust "meta item" attribute syntax](https://doc.rust-lang.org/reference/attributes.html#meta-item-attribute-syntax).
- Simplifies ink! attribute meta parsing implementation in ink_ir's ast::meta module by removing unnecessary custom utilities while maintaining support for parsing the described ink! attribute argument syntax.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
