### PR TITLE
Fix remaining unchecked arithmentic in examples

### DIFF
--- a/crates/ink/tests/ui/contract/pass/example-incrementer-works.rs
+++ b/crates/ink/tests/ui/contract/pass/example-incrementer-works.rs
@@ -14,7 +14,7 @@ mod incrementer {
 
         #[ink(message)]
         pub fn inc_by(&mut self, delta: i64) {
-            self.value.checked_add(delta).unwrap();
+            self.value = self.value.checked_add(delta).unwrap();
         }
 
         #[ink(message)]

--- a/crates/ink/tests/ui/contract/pass/example-incrementer-works.rs
+++ b/crates/ink/tests/ui/contract/pass/example-incrementer-works.rs
@@ -14,7 +14,7 @@ mod incrementer {
 
         #[ink(message)]
         pub fn inc_by(&mut self, delta: i64) {
-            self.value += delta;
+            self.value.checked_add(delta).unwrap();
         }
 
         #[ink(message)]

--- a/crates/ink/tests/ui/contract/pass/example-trait-incrementer-works.rs
+++ b/crates/ink/tests/ui/contract/pass/example-trait-incrementer-works.rs
@@ -35,7 +35,7 @@ mod incrementer {
 
         #[ink(message)]
         pub fn inc_by(&mut self, delta: i64) {
-            self.value.checked_add(delta).unwrap();
+            self.value = self.value.checked_add(delta).unwrap();
         }
     }
 

--- a/crates/ink/tests/ui/contract/pass/example-trait-incrementer-works.rs
+++ b/crates/ink/tests/ui/contract/pass/example-trait-incrementer-works.rs
@@ -35,7 +35,7 @@ mod incrementer {
 
         #[ink(message)]
         pub fn inc_by(&mut self, delta: i64) {
-            self.value += delta;
+            self.value.checked_add(delta).unwrap();
         }
     }
 

--- a/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/lib.rs
+++ b/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/lib.rs
@@ -23,7 +23,7 @@ pub mod incrementer {
         /// Increases the value of the incrementer by an amount.
         #[ink(message)]
         pub fn inc_by(&mut self, delta: u64) {
-            self.value.checked_add(delta).unwrap();
+            self.value = self.value.checked_add(delta).unwrap();
         }
     }
 

--- a/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/lib.rs
+++ b/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/lib.rs
@@ -23,7 +23,7 @@ pub mod incrementer {
         /// Increases the value of the incrementer by an amount.
         #[ink(message)]
         pub fn inc_by(&mut self, delta: u64) {
-            self.value += delta;
+            self.value.checked_add(delta).unwrap();
         }
     }
 

--- a/integration-tests/upgradeable-contracts/delegator/delegatee/lib.rs
+++ b/integration-tests/upgradeable-contracts/delegator/delegatee/lib.rs
@@ -30,7 +30,7 @@ pub mod delegatee {
         /// Increments the current value.
         #[ink(message)]
         pub fn inc(&mut self) {
-            self.counter += 2;
+            self.counter = self.counter.checked_add(2).unwrap();
         }
 
         /// Adds current value of counter to the `addresses`

--- a/integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/lib.rs
+++ b/integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/lib.rs
@@ -41,7 +41,7 @@ pub mod incrementer {
         /// We use a different step size (4) here than in the original `incrementer`.
         #[ink(message)]
         pub fn inc(&mut self) {
-            self.count += 4;
+            self.count = self.count.checked_add(4).unwrap();
             ink::env::debug_println!("The new count is {}, it was modified using the updated `new_incrementer` code.", self.count);
         }
 


### PR DESCRIPTION
Follow up to https://github.com/paritytech/ink/pull/1831, using checked arithmetic