### PR TITLE
Update to subxt `0.32.1`, use account_nonce API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,9 @@ serde_json = { version = "1.0.81" }
 sha2 = { version = "0.10" }
 sha3 = { version = "0.10" }
 static_assertions = { version = "1.1" }
-subxt = { version = "0.32.0" }
-subxt-metadata = { version = "0.32.0" }
-subxt-signer = { version = "0.32.0" }
+subxt = { version = "0.32.1" }
+subxt-metadata = { version = "0.32.1" }
+subxt-signer = { version = "0.32.1" }
 syn = { version = "2" }
 synstructure = { version = "0.13.0" }
 tokio = { version = "1.18.2" }

--- a/crates/e2e/src/xts.rs
+++ b/crates/e2e/src/xts.rs
@@ -373,9 +373,6 @@ where
     }
 
     /// Return the account nonce at the *best* block for an account ID.
-    ///
-    /// Replace this with the new `account_id` query available in the next `subxt`
-    /// release.
     async fn get_account_nonce(
         &self,
         account_id: &C::AccountId,

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -10,7 +10,7 @@ ink = { path = "../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }
-subxt = { version = "0.32.0", default-features = false }
+subxt = { version = "0.32.1", default-features = false }
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
Uses new account nonce API introduced in 0.32.1: https://github.com/paritytech/subxt/pull/1192