### PR TITLE
Remove scale deps from integration-tests

### DIFF
--- a/integration-tests/events/Cargo.toml
+++ b/integration-tests/events/Cargo.toml
@@ -7,8 +7,6 @@ publish = false
 
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 event-def = { path = "event-def", default-features = false }
 event-def2 = { path = "event-def2", default-features = false }

--- a/integration-tests/events/event-def-unused/Cargo.toml
+++ b/integration-tests/events/event-def-unused/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2021"
 
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [features]
 default = ["std"]

--- a/integration-tests/events/event-def/Cargo.toml
+++ b/integration-tests/events/event-def/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2021"
 
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [features]
 default = ["std"]

--- a/integration-tests/events/event-def2/Cargo.toml
+++ b/integration-tests/events/event-def2/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2021"
 
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [features]
 default = ["std"]

--- a/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
@@ -7,9 +7,6 @@ edition = "2021"
 [dependencies]
 ink = { path = "../../../crates/ink", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
-
 integration_flipper = { path = "../integration-flipper", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]

--- a/integration-tests/sr25519-verification/Cargo.toml
+++ b/integration-tests/sr25519-verification/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
-
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }
 

--- a/integration-tests/trait-incrementer/Cargo.toml
+++ b/integration-tests/trait-incrementer/Cargo.toml
@@ -8,8 +8,6 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
 traits = { path = "./traits", default-features = false }
 
 [lib]

--- a/integration-tests/wildcard-selector/Cargo.toml
+++ b/integration-tests/wildcard-selector/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [dependencies]
 ink = { path = "../../crates/ink", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
-
 [dev-dependencies]
 ink_e2e = { path = "../../crates/e2e" }
 


### PR DESCRIPTION
## Summary
Closes #_

- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

Remove scale dependencies from integration-tests

## Description
Cleaning up the `integration-tests` `scale` and `scale-info` dependencies

## Checklist before requesting a review
- [y] My code follows the style guidelines of this project
- [n] I have added an entry to `CHANGELOG.md`
- [y] I have commented my code, particularly in hard-to-understand areas
- [n] I have added tests that prove my fix is effective or that my feature works
- [y] Any dependent changes have been merged and published in downstream modules
