### PR TITLE
Default accounts in integration test implementation

### DIFF
--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "ink_env"
 version.workspace = true
-authors = [
-    "Parity Technologies <admin@parity.io>",
-    "Robin Freyler <robin@parity.io>",
-]
+authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
 edition.workspace = true
 rust-version = "1.68"
 
@@ -44,10 +41,7 @@ sha3 = { workspace = true, optional = true }
 blake2 = { workspace = true, optional = true }
 
 # ECDSA for the off-chain environment.
-secp256k1 = { workspace = true, features = [
-    "recovery",
-    "global-context",
-], optional = true }
+secp256k1 = { workspace = true, features = ["recovery", "global-context"], optional = true }
 
 # schnorrkel for the off-chain environment.
 schnorrkel = { version = "0.11.2", optional = true }
@@ -59,20 +53,7 @@ schnorrkel = { version = "0.11.2", optional = true }
 scale-decode = { workspace = true, optional = true }
 scale-encode = { workspace = true, optional = true }
 scale-info = { workspace = true, features = ["derive"], optional = true }
-
-[dependencies.lazy_static]
-version = "1.4.0"
-
-[dependencies.sp-core]
-version = "21.0.0"
-
-[dependencies.strum]
-version = "0.24.1"
-features = ["derive"]
-default-features = false
-
-[dependencies.sp-runtime]
-version = "24.0.0"
+sp-keyring = { workspace = true }
 
 [dev-dependencies]
 ink = { path = "../ink" }

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "ink_env"
 version.workspace = true
-authors = ["Parity Technologies <admin@parity.io>", "Robin Freyler <robin@parity.io>"]
+authors = [
+    "Parity Technologies <admin@parity.io>",
+    "Robin Freyler <robin@parity.io>",
+]
 edition.workspace = true
 rust-version = "1.68"
 
@@ -41,7 +44,10 @@ sha3 = { workspace = true, optional = true }
 blake2 = { workspace = true, optional = true }
 
 # ECDSA for the off-chain environment.
-secp256k1 = { workspace = true, features = ["recovery", "global-context"], optional = true }
+secp256k1 = { workspace = true, features = [
+    "recovery",
+    "global-context",
+], optional = true }
 
 # schnorrkel for the off-chain environment.
 schnorrkel = { version = "0.11.2", optional = true }
@@ -53,6 +59,17 @@ schnorrkel = { version = "0.11.2", optional = true }
 scale-decode = { workspace = true, optional = true }
 scale-encode = { workspace = true, optional = true }
 scale-info = { workspace = true, features = ["derive"], optional = true }
+
+[dependencies.lazy_static]
+version = "1.4.0"
+
+[dependencies.sp-core]
+version = "21.0.0"
+
+[dependencies.strum]
+version = "0.24.1"
+features = ["derive"]
+default-features = false
 
 [dev-dependencies]
 ink = { path = "../ink" }

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -71,6 +71,9 @@ version = "0.24.1"
 features = ["derive"]
 default-features = false
 
+[dependencies.sp-runtime]
+version = "24.0.0"
+
 [dev-dependencies]
 ink = { path = "../ink" }
 

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -24,7 +24,6 @@ use crate::{
 };
 use core::fmt::Debug;
 use ink_engine::test_api::RecordedDebugMessages;
-pub use sp_keyring::AccountKeyring;
 use std::panic::UnwindSafe;
 
 pub use super::call_data::CallData;
@@ -52,11 +51,13 @@ pub struct EmittedEvent {
 /// - If the underlying `account` type does not match.
 /// - If the underlying `new_balance` type does not match.
 pub fn set_account_balance<T>(account_id: T::AccountId, new_balance: T::Balance)
-    where T: Environment<Balance = u128>
+where
+    T: Environment<Balance = u128>, // Just temporary for the MVP!
 {
-    // Just temporary for the MVP!
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance.engine.set_balance(scale::Encode::encode(&account_id), new_balance);
+        instance
+            .engine
+            .set_balance(scale::Encode::encode(&account_id), new_balance);
     })
 }
 
@@ -73,18 +74,27 @@ pub fn set_account_balance<T>(account_id: T::AccountId, new_balance: T::Balance)
 /// - If `account` does not exist.
 /// - If the underlying `account` type does not match.
 pub fn get_account_balance<T>(account_id: T::AccountId) -> Result<T::Balance>
-    where
-        T: Environment<Balance = u128> // Just temporary for the MVP!
+where
+    T: Environment<Balance = u128>, // Just temporary for the MVP!
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance.engine.get_balance(scale::Encode::encode(&account_id)).map_err(Into::into)
+        instance
+            .engine
+            .get_balance(scale::Encode::encode(&account_id))
+            .map_err(Into::into)
     })
 }
 
 /// Registers a new chain extension.
-pub fn register_chain_extension<E>(extension: E) where E: ink_engine::ChainExtension + 'static {
+pub fn register_chain_extension<E>(extension: E)
+where
+    E: ink_engine::ChainExtension + 'static,
+{
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance.engine.chain_extension_handler.register(Box::new(extension));
+        instance
+            .engine
+            .chain_extension_handler
+            .register(Box::new(extension));
     })
 }
 
@@ -103,11 +113,16 @@ pub fn recorded_debug_messages() -> RecordedDebugMessages {
 /// runs, because lazy storage structures automatically clear their associated cells when
 /// they are dropped.
 pub fn set_clear_storage_disabled(_disable: bool) {
-    unimplemented!("off-chain environment does not yet support `set_clear_storage_disabled`");
+    unimplemented!(
+        "off-chain environment does not yet support `set_clear_storage_disabled`"
+    );
 }
 
 /// Advances the chain by a single block.
-pub fn advance_block<T>() where T: Environment {
+pub fn advance_block<T>()
+where
+    T: Environment,
+{
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.advance_block();
     })
@@ -115,7 +130,9 @@ pub fn advance_block<T>() where T: Environment {
 
 /// Sets a caller for the next call.
 pub fn set_caller<T>(caller: T::AccountId)
-    where T: Environment, <T as Environment>::AccountId: From<[u8; 32]>
+where
+    T: Environment,
+    <T as Environment>::AccountId: From<[u8; 32]>,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.set_caller(scale::Encode::encode(&caller));
@@ -124,7 +141,9 @@ pub fn set_caller<T>(caller: T::AccountId)
 
 /// Sets the callee for the next call.
 pub fn set_callee<T>(callee: T::AccountId)
-    where T: Environment, <T as Environment>::AccountId: From<[u8; 32]>
+where
+    T: Environment,
+    <T as Environment>::AccountId: From<[u8; 32]>,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.set_callee(scale::Encode::encode(&callee));
@@ -133,38 +152,53 @@ pub fn set_callee<T>(callee: T::AccountId)
 
 /// Sets an account as a contract
 pub fn set_contract<T>(contract: T::AccountId)
-    where T: Environment, <T as Environment>::AccountId: From<[u8; 32]>
+where
+    T: Environment,
+    <T as Environment>::AccountId: From<[u8; 32]>,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance.engine.set_contract(scale::Encode::encode(&contract));
+        instance
+            .engine
+            .set_contract(scale::Encode::encode(&contract));
     })
 }
 
 /// Returns a boolean to indicate whether an account is a contract
 pub fn is_contract<T>(contract: T::AccountId) -> bool
-    where T: Environment, <T as Environment>::AccountId: From<[u8; 32]>
+where
+    T: Environment,
+    <T as Environment>::AccountId: From<[u8; 32]>,
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance.engine.is_contract(scale::Encode::encode(&contract))
+        instance
+            .engine
+            .is_contract(scale::Encode::encode(&contract))
     })
 }
 
 /// Gets the currently set callee.
 ///
 /// This is account id of the currently executing contract.
-pub fn callee<T>() -> T::AccountId where T: Environment {
+pub fn callee<T>() -> T::AccountId
+where
+    T: Environment,
+{
     <EnvInstance as OnInstance>::on_instance(|instance| {
         let callee = instance.engine.get_callee();
-        scale::Decode
-            ::decode(&mut &callee[..])
+        scale::Decode::decode(&mut &callee[..])
             .unwrap_or_else(|err| panic!("encoding failed: {err}"))
     })
 }
 
 /// Returns the total number of reads and writes of the contract's storage.
-pub fn get_contract_storage_rw<T>(account_id: &T::AccountId) -> (usize, usize) where T: Environment {
+pub fn get_contract_storage_rw<T>(account_id: &T::AccountId) -> (usize, usize)
+where
+    T: Environment,
+{
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance.engine.get_contract_storage_rw(scale::Encode::encode(&account_id))
+        instance
+            .engine
+            .get_contract_storage_rw(scale::Encode::encode(&account_id))
     })
 }
 
@@ -172,8 +206,10 @@ pub fn get_contract_storage_rw<T>(account_id: &T::AccountId) -> (usize, usize) w
 ///
 /// Please note that the acting accounts should be set with [`set_caller()`] and
 /// [`set_callee()`] beforehand.
-pub fn set_value_transferred<T>(value: T::Balance) where T: Environment<Balance = u128> {
-    // Just temporary for the MVP!
+pub fn set_value_transferred<T>(value: T::Balance)
+where
+    T: Environment<Balance = u128>, // Just temporary for the MVP!
+{
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.set_value_transferred(value);
     })
@@ -183,22 +219,37 @@ pub fn set_value_transferred<T>(value: T::Balance) where T: Environment<Balance 
 ///
 /// Please note that the acting accounts should be set with [`set_caller()`] and
 /// [`set_callee()`] beforehand.
-pub fn transfer_in<T>(value: T::Balance) where T: Environment<Balance = u128> {
-    // Just temporary for the MVP!
+pub fn transfer_in<T>(value: T::Balance)
+where
+    T: Environment<Balance = u128>, // Just temporary for the MVP!
+{
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        let caller = instance.engine.exec_context.caller
+        let caller = instance
+            .engine
+            .exec_context
+            .caller
             .as_ref()
             .expect("no caller has been set")
             .as_bytes()
             .to_vec();
 
-        let caller_old_balance = instance.engine.get_balance(caller.clone()).unwrap_or_default();
+        let caller_old_balance = instance
+            .engine
+            .get_balance(caller.clone())
+            .unwrap_or_default();
 
         let callee = instance.engine.get_callee();
-        let contract_old_balance = instance.engine.get_balance(callee.clone()).unwrap_or_default();
+        let contract_old_balance = instance
+            .engine
+            .get_balance(callee.clone())
+            .unwrap_or_default();
 
-        instance.engine.set_balance(caller, caller_old_balance - value);
-        instance.engine.set_balance(callee, contract_old_balance + value);
+        instance
+            .engine
+            .set_balance(caller, caller_old_balance - value);
+        instance
+            .engine
+            .set_balance(callee, contract_old_balance + value);
         instance.engine.set_value_transferred(value);
     });
 }
@@ -206,23 +257,33 @@ pub fn transfer_in<T>(value: T::Balance) where T: Environment<Balance = u128> {
 /// Returns the amount of storage cells used by the account `account_id`.
 ///
 /// Returns `None` if the `account_id` is non-existent.
-pub fn count_used_storage_cells<T>(account_id: &T::AccountId) -> Result<usize> where T: Environment {
+pub fn count_used_storage_cells<T>(account_id: &T::AccountId) -> Result<usize>
+where
+    T: Environment,
+{
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance.engine
+        instance
+            .engine
             .count_used_storage_cells(&scale::Encode::encode(&account_id))
             .map_err(Into::into)
     })
 }
 
 /// Sets the block timestamp for the next [`advance_block`] invocation.
-pub fn set_block_timestamp<T>(value: T::Timestamp) where T: Environment<Timestamp = u64> {
+pub fn set_block_timestamp<T>(value: T::Timestamp)
+where
+    T: Environment<Timestamp = u64>,
+{
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.set_block_timestamp(value);
     })
 }
 
 /// Sets the block number for the next [`advance_block`] invocation.
-pub fn set_block_number<T>(value: T::BlockNumber) where T: Environment<BlockNumber = u32> {
+pub fn set_block_number<T>(value: T::BlockNumber)
+where
+    T: Environment<BlockNumber = u32>,
+{
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.set_block_number(value);
     })
@@ -231,10 +292,10 @@ pub fn set_block_number<T>(value: T::BlockNumber) where T: Environment<BlockNumb
 /// Runs the given closure test function with the default configuration
 /// for the off-chain environment.
 pub fn run_test<T, F>(f: F) -> Result<()>
-    where
-        T: Environment,
-        F: FnOnce(DefaultAccounts<T>) -> Result<()>,
-        <T as Environment>::AccountId: From<[u8; 32]>
+where
+    T: Environment,
+    F: FnOnce(DefaultAccounts<T>) -> Result<()>,
+    <T as Environment>::AccountId: From<[u8; 32]>,
 {
     let default_accounts = default_accounts::<T>();
     <EnvInstance as OnInstance>::on_instance(|instance| {
@@ -248,11 +309,27 @@ pub fn run_test<T, F>(f: F) -> Result<()>
         let substantial = 1_000_000;
         let some = 1_000;
         instance.engine.set_balance(encoded_alice, substantial);
-        instance.engine.set_balance(scale::Encode::encode(&default_accounts.bob), some);
-        instance.engine.set_balance(scale::Encode::encode(&default_accounts.charlie), some);
-        instance.engine.set_balance(scale::Encode::encode(&default_accounts.dave), 0);
-        instance.engine.set_balance(scale::Encode::encode(&default_accounts.eve), 0);
-        instance.engine.set_balance(scale::Encode::encode(&default_accounts.ferdie), 0);
+        instance
+            .engine
+            .set_balance(scale::Encode::encode(&default_accounts.bob), some);
+        instance
+            .engine
+            .set_balance(scale::Encode::encode(&default_accounts.charlie), some);
+        instance
+            .engine
+            .set_balance(scale::Encode::encode(&default_accounts.dave), 0);
+        instance
+            .engine
+            .set_balance(scale::Encode::encode(&default_accounts.eve), 0);
+        instance
+            .engine
+            .set_balance(scale::Encode::encode(&default_accounts.ferdie), 0);
+        instance
+            .engine
+            .set_balance(scale::Encode::encode(&default_accounts.one), 0);
+        instance
+            .engine
+            .set_balance(scale::Encode::encode(&default_accounts.two), 0);
     });
     f(default_accounts)
 }
@@ -260,7 +337,9 @@ pub fn run_test<T, F>(f: F) -> Result<()>
 /// Returns the default accounts for testing purposes:
 /// Alice, Bob, Charlie, Dave, Eve, Ferdie, One and Two.
 pub fn default_accounts<T>() -> DefaultAccounts<T>
-    where T: Environment, <T as Environment>::AccountId: From<[u8; 32]>
+where
+    T: Environment,
+    <T as Environment>::AccountId: From<[u8; 32]>,
 {
     DefaultAccounts {
         alice: T::AccountId::from(sp_keyring::sr25519::Keyring::Alice.to_raw_public()),
@@ -275,7 +354,10 @@ pub fn default_accounts<T>() -> DefaultAccounts<T>
 }
 
 /// The default accounts.
-pub struct DefaultAccounts<T> where T: Environment {
+pub struct DefaultAccounts<T>
+where
+    T: Environment,
+{
     /// The predefined `ALICE` account holding substantial amounts of value.
     pub alice: T::AccountId,
     /// The predefined `BOB` account holding some amounts of value.
@@ -297,7 +379,8 @@ pub struct DefaultAccounts<T> where T: Environment {
 /// Returns the recorded emitted events in order.
 pub fn recorded_events() -> impl Iterator<Item = EmittedEvent> {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance.engine
+        instance
+            .engine
             .get_emitted_events()
             .map(|evt: ink_engine::test_api::EmittedEvent| evt.into())
     })
@@ -328,24 +411,24 @@ pub fn recorded_events() -> impl Iterator<Item = EmittedEvent> {
 pub fn assert_contract_termination<T, F>(
     should_terminate: F,
     expected_beneficiary: T::AccountId,
-    expected_value_transferred_to_beneficiary: T::Balance
-)
-    where
-        T: Environment,
-        F: FnMut() + UnwindSafe,
-        <T as Environment>::AccountId: Debug,
-        <T as Environment>::Balance: Debug
+    expected_value_transferred_to_beneficiary: T::Balance,
+) where
+    T: Environment,
+    F: FnMut() + UnwindSafe,
+    <T as Environment>::AccountId: Debug,
+    <T as Environment>::Balance: Debug,
 {
-    let value_any = ::std::panic
-        ::catch_unwind(should_terminate)
+    let value_any = ::std::panic::catch_unwind(should_terminate)
         .expect_err("contract did not terminate");
-    let encoded_input = value_any.downcast_ref::<Vec<u8>>().expect("panic object can not be cast");
-    let (value_transferred, encoded_beneficiary): (T::Balance, Vec<u8>) = scale::Decode
-        ::decode(&mut &encoded_input[..])
-        .unwrap_or_else(|err| panic!("input can not be decoded: {err}"));
-    let beneficiary = <T::AccountId as scale::Decode>
-        ::decode(&mut &encoded_beneficiary[..])
-        .unwrap_or_else(|err| panic!("input can not be decoded: {err}"));
+    let encoded_input = value_any
+        .downcast_ref::<Vec<u8>>()
+        .expect("panic object can not be cast");
+    let (value_transferred, encoded_beneficiary): (T::Balance, Vec<u8>) =
+        scale::Decode::decode(&mut &encoded_input[..])
+            .unwrap_or_else(|err| panic!("input can not be decoded: {err}"));
+    let beneficiary =
+        <T::AccountId as scale::Decode>::decode(&mut &encoded_beneficiary[..])
+            .unwrap_or_else(|err| panic!("input can not be decoded: {err}"));
     assert_eq!(value_transferred, expected_value_transferred_to_beneficiary);
     assert_eq!(beneficiary, expected_beneficiary);
 }
@@ -354,10 +437,8 @@ pub fn assert_contract_termination<T, F>(
 /// environment.
 #[macro_export]
 macro_rules! pay_with_call {
-    ($contract:ident.$message:ident($($params:expr),*), $amount:expr) => {
-        {
+    ($contract:ident . $message:ident ( $( $params:expr ),* ) , $amount:expr) => {{
         $crate::test::transfer_in::<Environment>($amount);
         $contract.$message($ ($params) ,*)
-        }
-    };
+    }}
 }

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -16,17 +16,10 @@
 
 use super::{EnvInstance, OnInstance};
 use crate::{Environment, Result};
-use core::{fmt::Debug, ops::Deref};
+use core::fmt::Debug;
 use ink_engine::test_api::RecordedDebugMessages;
-use lazy_static::lazy_static;
-pub use sp_core::sr25519;
-use sp_core::{
-    sr25519::{Pair, Public},
-    ByteArray, Pair as PairT, H256,
-};
-use sp_runtime::AccountId32;
-use std::{collections::HashMap, panic::UnwindSafe};
-use strum::{Display, EnumIter, IntoEnumIterator};
+pub use sp_keyring::AccountKeyring;
+use std::panic::UnwindSafe;
 
 pub use super::call_data::CallData;
 pub use ink_engine::ChainExtension;
@@ -338,24 +331,17 @@ where
     <T as Environment>::AccountId: From<[u8; 32]>,
 {
     DefaultAccounts {
-        alice: T::AccountId::from(Keyring::Alice.to_raw_public()),
-        bob: T::AccountId::from(Keyring::Bob.to_raw_public()),
-        charlie: T::AccountId::from(Keyring::Charlie.to_raw_public()),
-        dave: T::AccountId::from(Keyring::Dave.to_raw_public()),
-        eve: T::AccountId::from(Keyring::Eve.to_raw_public()),
-        ferdie: T::AccountId::from(Keyring::Ferdie.to_raw_public()),
-        one: T::AccountId::from(Keyring::One.to_raw_public()),
-        two: T::AccountId::from(Keyring::Two.to_raw_public()),
+        alice: T::AccountId::from(sp_keyring::sr25519::Keyring::Alice.to_raw_public()),
+        bob: T::AccountId::from(sp_keyring::sr25519::Keyring::Bob.to_raw_public()),
+        charlie: T::AccountId::from(
+            sp_keyring::sr25519::Keyring::Charlie.to_raw_public(),
+        ),
+        dave: T::AccountId::from(sp_keyring::sr25519::Keyring::Dave.to_raw_public()),
+        eve: T::AccountId::from(sp_keyring::sr25519::Keyring::Eve.to_raw_public()),
+        ferdie: T::AccountId::from(sp_keyring::sr25519::Keyring::Ferdie.to_raw_public()),
+        one: T::AccountId::from(sp_keyring::sr25519::Keyring::One.to_raw_public()),
+        two: T::AccountId::from(sp_keyring::sr25519::Keyring::Two.to_raw_public()),
     }
-}
-
-lazy_static! {
-    static ref PRIVATE_KEYS: HashMap<Keyring, Pair> =
-        Keyring::iter().map(|i| (i, i.pair())).collect();
-    static ref PUBLIC_KEYS: HashMap<Keyring, Public> = PRIVATE_KEYS
-        .iter()
-        .map(|(&name, pair)| (name, pair.public()))
-        .collect();
 }
 
 /// A custom error type representing a failure to parse a keyring.
@@ -365,195 +351,6 @@ pub struct ParseKeyringError;
 impl std::fmt::Display for ParseKeyringError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ParseKeyringError")
-    }
-}
-
-/// Set of test accounts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumIter)]
-pub enum Keyring {
-    /// The predefined `ALICE` keyring
-    Alice,
-    /// The predefined `Bob` keyring
-    Bob,
-    /// The predefined `Charlie` keyring
-    Charlie,
-    /// The predefined `Dave` keyring
-    Dave,
-    /// The predefined `Eve` keyring
-    Eve,
-    /// The predefined `Ferdie` keyring
-    Ferdie,
-    /// The predefined `One` keyring
-    One,
-    /// The predefined `Two` keyring
-    Two,
-}
-
-impl Keyring {
-    /// Creates a `Keyring` from a `Public`.
-    pub fn from_public(who: &Public) -> Option<Keyring> {
-        Self::iter().find(|&k| &Public::from(k) == who)
-    }
-
-    /// Creates a `Keyring` from an `AccountId32`.
-    pub fn from_account_id(who: &AccountId32) -> Option<Keyring> {
-        Self::iter().find(|&k| &k.to_account_id() == who)
-    }
-
-    /// Creates a `Keyring` from a raw public key in the form of a 32-byte array.
-    pub fn from_raw_public(who: [u8; 32]) -> Option<Keyring> {
-        Self::from_public(&Public::from_raw(who))
-    }
-
-    /// Converts the public key of the `Keyring` into a 32-byte array.
-    pub fn to_raw_public(self) -> [u8; 32] {
-        *Public::from(self).as_array_ref()
-    }
-
-    /// Creates a `Keyring` from a public key in `H256` format.
-    pub fn from_h256_public(who: H256) -> Option<Keyring> {
-        Self::from_public(&Public::from_raw(who.into()))
-    }
-
-    /// Converts the public key of the `Keyring` into a type `H256`.
-    pub fn to_h256_public_vec(self) -> H256 {
-        Public::from(self).as_array_ref().into()
-    }
-
-    /// Converts the public key of the `Keyring` into a vector of bytes.
-    pub fn to_raw_public_vec(self) -> Vec<u8> {
-        Public::from(self).to_raw_vec()
-    }
-
-    /// Converts the public key of the `Keyring` into an `AccountId32`.
-    pub fn to_account_id(self) -> AccountId32 {
-        self.to_raw_public().into()
-    }
-
-    /// Gets a key pair (`Pair`) associated with the `Keyring`.
-    pub fn pair(self) -> Pair {
-        Pair::from_string(&format!("//{}", <&'static str>::from(self)), None)
-            .expect("static values are known good; qed")
-    }
-
-    /// Returns an iterator over all test accounts.
-    pub fn iter() -> impl Iterator<Item = Keyring> {
-        <Self as IntoEnumIterator>::iter()
-    }
-
-    /// Gets the public key (`Public`) associated with the `Keyring`.
-    pub fn public(self) -> Public {
-        self.pair().public()
-    }
-
-    /// Converts the public key of the `Keyring` into a seed in string format.
-    pub fn to_seed(self) -> String {
-        format!("//{}", self)
-    }
-
-    /// Create a crypto `Pair` from a numeric value.
-    pub fn numeric(idx: usize) -> Pair {
-        Pair::from_string(&format!("//{}", idx), None)
-            .expect("numeric values are known good; qed")
-    }
-
-    /// Get account id of a `numeric` account.
-    pub fn numeric_id(idx: usize) -> AccountId32 {
-        (*Self::numeric(idx).public().as_array_ref()).into()
-    }
-}
-
-impl From<Keyring> for sp_runtime::MultiSigner {
-    fn from(x: Keyring) -> Self {
-        sp_runtime::MultiSigner::Sr25519(x.into())
-    }
-}
-
-impl std::str::FromStr for Keyring {
-    type Err = ParseKeyringError;
-
-    fn from_str(s: &str) -> core::result::Result<Self, <Self as std::str::FromStr>::Err> {
-        match s {
-            "alice" => Ok(Keyring::Alice),
-            "bob" => Ok(Keyring::Bob),
-            "charlie" => Ok(Keyring::Charlie),
-            "dave" => Ok(Keyring::Dave),
-            "eve" => Ok(Keyring::Eve),
-            "ferdie" => Ok(Keyring::Ferdie),
-            "one" => Ok(Keyring::One),
-            "two" => Ok(Keyring::Two),
-            _ => Err(ParseKeyringError),
-        }
-    }
-}
-
-impl From<Keyring> for &'static str {
-    fn from(k: Keyring) -> Self {
-        match k {
-            Keyring::Alice => "Alice",
-            Keyring::Bob => "Bob",
-            Keyring::Charlie => "Charlie",
-            Keyring::Dave => "Dave",
-            Keyring::Eve => "Eve",
-            Keyring::Ferdie => "Ferdie",
-            Keyring::One => "One",
-            Keyring::Two => "Two",
-        }
-    }
-}
-
-impl From<Keyring> for AccountId32 {
-    fn from(k: Keyring) -> Self {
-        k.to_account_id()
-    }
-}
-
-impl From<Keyring> for Public {
-    fn from(k: Keyring) -> Self {
-        *(*PUBLIC_KEYS).get(&k).unwrap()
-    }
-}
-
-impl From<Keyring> for Pair {
-    fn from(k: Keyring) -> Self {
-        k.pair()
-    }
-}
-
-impl From<Keyring> for [u8; 32] {
-    fn from(k: Keyring) -> Self {
-        *(*PUBLIC_KEYS).get(&k).unwrap().as_array_ref()
-    }
-}
-
-impl From<Keyring> for H256 {
-    fn from(k: Keyring) -> Self {
-        (*PUBLIC_KEYS).get(&k).unwrap().as_array_ref().into()
-    }
-}
-
-impl From<Keyring> for &'static [u8; 32] {
-    fn from(k: Keyring) -> Self {
-        (*PUBLIC_KEYS).get(&k).unwrap().as_array_ref()
-    }
-}
-
-impl AsRef<[u8; 32]> for Keyring {
-    fn as_ref(&self) -> &[u8; 32] {
-        (*PUBLIC_KEYS).get(self).unwrap().as_array_ref()
-    }
-}
-
-impl AsRef<Public> for Keyring {
-    fn as_ref(&self) -> &Public {
-        (*PUBLIC_KEYS).get(self).unwrap()
-    }
-}
-
-impl Deref for Keyring {
-    type Target = [u8; 32];
-    fn deref(&self) -> &[u8; 32] {
-        (*PUBLIC_KEYS).get(self).unwrap().as_array_ref()
     }
 }
 

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -14,8 +14,14 @@
 
 //! Operations on the off-chain testing environment.
 
-use super::{EnvInstance, OnInstance};
-use crate::{Environment, Result};
+use super::{
+    EnvInstance,
+    OnInstance,
+};
+use crate::{
+    Environment,
+    Result,
+};
 use core::fmt::Debug;
 use ink_engine::test_api::RecordedDebugMessages;
 pub use sp_keyring::AccountKeyring;
@@ -46,13 +52,11 @@ pub struct EmittedEvent {
 /// - If the underlying `account` type does not match.
 /// - If the underlying `new_balance` type does not match.
 pub fn set_account_balance<T>(account_id: T::AccountId, new_balance: T::Balance)
-where
-    T: Environment<Balance = u128>, // Just temporary for the MVP!
+    where T: Environment<Balance = u128>
 {
+    // Just temporary for the MVP!
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance
-            .engine
-            .set_balance(scale::Encode::encode(&account_id), new_balance);
+        instance.engine.set_balance(scale::Encode::encode(&account_id), new_balance);
     })
 }
 
@@ -69,27 +73,18 @@ where
 /// - If `account` does not exist.
 /// - If the underlying `account` type does not match.
 pub fn get_account_balance<T>(account_id: T::AccountId) -> Result<T::Balance>
-where
-    T: Environment<Balance = u128>, // Just temporary for the MVP!
+    where
+        T: Environment<Balance = u128> // Just temporary for the MVP!
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance
-            .engine
-            .get_balance(scale::Encode::encode(&account_id))
-            .map_err(Into::into)
+        instance.engine.get_balance(scale::Encode::encode(&account_id)).map_err(Into::into)
     })
 }
 
 /// Registers a new chain extension.
-pub fn register_chain_extension<E>(extension: E)
-where
-    E: ink_engine::ChainExtension + 'static,
-{
+pub fn register_chain_extension<E>(extension: E) where E: ink_engine::ChainExtension + 'static {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance
-            .engine
-            .chain_extension_handler
-            .register(Box::new(extension));
+        instance.engine.chain_extension_handler.register(Box::new(extension));
     })
 }
 
@@ -108,16 +103,11 @@ pub fn recorded_debug_messages() -> RecordedDebugMessages {
 /// runs, because lazy storage structures automatically clear their associated cells when
 /// they are dropped.
 pub fn set_clear_storage_disabled(_disable: bool) {
-    unimplemented!(
-        "off-chain environment does not yet support `set_clear_storage_disabled`"
-    );
+    unimplemented!("off-chain environment does not yet support `set_clear_storage_disabled`");
 }
 
 /// Advances the chain by a single block.
-pub fn advance_block<T>()
-where
-    T: Environment,
-{
+pub fn advance_block<T>() where T: Environment {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.advance_block();
     })
@@ -125,9 +115,7 @@ where
 
 /// Sets a caller for the next call.
 pub fn set_caller<T>(caller: T::AccountId)
-where
-    T: Environment,
-    <T as Environment>::AccountId: From<[u8; 32]>,
+    where T: Environment, <T as Environment>::AccountId: From<[u8; 32]>
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.set_caller(scale::Encode::encode(&caller));
@@ -136,9 +124,7 @@ where
 
 /// Sets the callee for the next call.
 pub fn set_callee<T>(callee: T::AccountId)
-where
-    T: Environment,
-    <T as Environment>::AccountId: From<[u8; 32]>,
+    where T: Environment, <T as Environment>::AccountId: From<[u8; 32]>
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.set_callee(scale::Encode::encode(&callee));
@@ -147,53 +133,38 @@ where
 
 /// Sets an account as a contract
 pub fn set_contract<T>(contract: T::AccountId)
-where
-    T: Environment,
-    <T as Environment>::AccountId: From<[u8; 32]>,
+    where T: Environment, <T as Environment>::AccountId: From<[u8; 32]>
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance
-            .engine
-            .set_contract(scale::Encode::encode(&contract));
+        instance.engine.set_contract(scale::Encode::encode(&contract));
     })
 }
 
 /// Returns a boolean to indicate whether an account is a contract
 pub fn is_contract<T>(contract: T::AccountId) -> bool
-where
-    T: Environment,
-    <T as Environment>::AccountId: From<[u8; 32]>,
+    where T: Environment, <T as Environment>::AccountId: From<[u8; 32]>
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance
-            .engine
-            .is_contract(scale::Encode::encode(&contract))
+        instance.engine.is_contract(scale::Encode::encode(&contract))
     })
 }
 
 /// Gets the currently set callee.
 ///
 /// This is account id of the currently executing contract.
-pub fn callee<T>() -> T::AccountId
-where
-    T: Environment,
-{
+pub fn callee<T>() -> T::AccountId where T: Environment {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         let callee = instance.engine.get_callee();
-        scale::Decode::decode(&mut &callee[..])
+        scale::Decode
+            ::decode(&mut &callee[..])
             .unwrap_or_else(|err| panic!("encoding failed: {err}"))
     })
 }
 
 /// Returns the total number of reads and writes of the contract's storage.
-pub fn get_contract_storage_rw<T>(account_id: &T::AccountId) -> (usize, usize)
-where
-    T: Environment,
-{
+pub fn get_contract_storage_rw<T>(account_id: &T::AccountId) -> (usize, usize) where T: Environment {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance
-            .engine
-            .get_contract_storage_rw(scale::Encode::encode(&account_id))
+        instance.engine.get_contract_storage_rw(scale::Encode::encode(&account_id))
     })
 }
 
@@ -201,10 +172,8 @@ where
 ///
 /// Please note that the acting accounts should be set with [`set_caller()`] and
 /// [`set_callee()`] beforehand.
-pub fn set_value_transferred<T>(value: T::Balance)
-where
-    T: Environment<Balance = u128>, // Just temporary for the MVP!
-{
+pub fn set_value_transferred<T>(value: T::Balance) where T: Environment<Balance = u128> {
+    // Just temporary for the MVP!
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.set_value_transferred(value);
     })
@@ -214,37 +183,22 @@ where
 ///
 /// Please note that the acting accounts should be set with [`set_caller()`] and
 /// [`set_callee()`] beforehand.
-pub fn transfer_in<T>(value: T::Balance)
-where
-    T: Environment<Balance = u128>, // Just temporary for the MVP!
-{
+pub fn transfer_in<T>(value: T::Balance) where T: Environment<Balance = u128> {
+    // Just temporary for the MVP!
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        let caller = instance
-            .engine
-            .exec_context
-            .caller
+        let caller = instance.engine.exec_context.caller
             .as_ref()
             .expect("no caller has been set")
             .as_bytes()
             .to_vec();
 
-        let caller_old_balance = instance
-            .engine
-            .get_balance(caller.clone())
-            .unwrap_or_default();
+        let caller_old_balance = instance.engine.get_balance(caller.clone()).unwrap_or_default();
 
         let callee = instance.engine.get_callee();
-        let contract_old_balance = instance
-            .engine
-            .get_balance(callee.clone())
-            .unwrap_or_default();
+        let contract_old_balance = instance.engine.get_balance(callee.clone()).unwrap_or_default();
 
-        instance
-            .engine
-            .set_balance(caller, caller_old_balance - value);
-        instance
-            .engine
-            .set_balance(callee, contract_old_balance + value);
+        instance.engine.set_balance(caller, caller_old_balance - value);
+        instance.engine.set_balance(callee, contract_old_balance + value);
         instance.engine.set_value_transferred(value);
     });
 }
@@ -252,33 +206,23 @@ where
 /// Returns the amount of storage cells used by the account `account_id`.
 ///
 /// Returns `None` if the `account_id` is non-existent.
-pub fn count_used_storage_cells<T>(account_id: &T::AccountId) -> Result<usize>
-where
-    T: Environment,
-{
+pub fn count_used_storage_cells<T>(account_id: &T::AccountId) -> Result<usize> where T: Environment {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance
-            .engine
+        instance.engine
             .count_used_storage_cells(&scale::Encode::encode(&account_id))
             .map_err(Into::into)
     })
 }
 
 /// Sets the block timestamp for the next [`advance_block`] invocation.
-pub fn set_block_timestamp<T>(value: T::Timestamp)
-where
-    T: Environment<Timestamp = u64>,
-{
+pub fn set_block_timestamp<T>(value: T::Timestamp) where T: Environment<Timestamp = u64> {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.set_block_timestamp(value);
     })
 }
 
 /// Sets the block number for the next [`advance_block`] invocation.
-pub fn set_block_number<T>(value: T::BlockNumber)
-where
-    T: Environment<BlockNumber = u32>,
-{
+pub fn set_block_number<T>(value: T::BlockNumber) where T: Environment<BlockNumber = u32> {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         instance.engine.set_block_number(value);
     })
@@ -287,10 +231,10 @@ where
 /// Runs the given closure test function with the default configuration
 /// for the off-chain environment.
 pub fn run_test<T, F>(f: F) -> Result<()>
-where
-    T: Environment,
-    F: FnOnce(DefaultAccounts<T>) -> Result<()>,
-    <T as Environment>::AccountId: From<[u8; 32]>,
+    where
+        T: Environment,
+        F: FnOnce(DefaultAccounts<T>) -> Result<()>,
+        <T as Environment>::AccountId: From<[u8; 32]>
 {
     let default_accounts = default_accounts::<T>();
     <EnvInstance as OnInstance>::on_instance(|instance| {
@@ -304,21 +248,11 @@ where
         let substantial = 1_000_000;
         let some = 1_000;
         instance.engine.set_balance(encoded_alice, substantial);
-        instance
-            .engine
-            .set_balance(scale::Encode::encode(&default_accounts.bob), some);
-        instance
-            .engine
-            .set_balance(scale::Encode::encode(&default_accounts.charlie), some);
-        instance
-            .engine
-            .set_balance(scale::Encode::encode(&default_accounts.dave), 0);
-        instance
-            .engine
-            .set_balance(scale::Encode::encode(&default_accounts.eve), 0);
-        instance
-            .engine
-            .set_balance(scale::Encode::encode(&default_accounts.ferdie), 0);
+        instance.engine.set_balance(scale::Encode::encode(&default_accounts.bob), some);
+        instance.engine.set_balance(scale::Encode::encode(&default_accounts.charlie), some);
+        instance.engine.set_balance(scale::Encode::encode(&default_accounts.dave), 0);
+        instance.engine.set_balance(scale::Encode::encode(&default_accounts.eve), 0);
+        instance.engine.set_balance(scale::Encode::encode(&default_accounts.ferdie), 0);
     });
     f(default_accounts)
 }
@@ -326,16 +260,12 @@ where
 /// Returns the default accounts for testing purposes:
 /// Alice, Bob, Charlie, Dave, Eve, Ferdie, One and Two.
 pub fn default_accounts<T>() -> DefaultAccounts<T>
-where
-    T: Environment,
-    <T as Environment>::AccountId: From<[u8; 32]>,
+    where T: Environment, <T as Environment>::AccountId: From<[u8; 32]>
 {
     DefaultAccounts {
         alice: T::AccountId::from(sp_keyring::sr25519::Keyring::Alice.to_raw_public()),
         bob: T::AccountId::from(sp_keyring::sr25519::Keyring::Bob.to_raw_public()),
-        charlie: T::AccountId::from(
-            sp_keyring::sr25519::Keyring::Charlie.to_raw_public(),
-        ),
+        charlie: T::AccountId::from(sp_keyring::sr25519::Keyring::Charlie.to_raw_public()),
         dave: T::AccountId::from(sp_keyring::sr25519::Keyring::Dave.to_raw_public()),
         eve: T::AccountId::from(sp_keyring::sr25519::Keyring::Eve.to_raw_public()),
         ferdie: T::AccountId::from(sp_keyring::sr25519::Keyring::Ferdie.to_raw_public()),
@@ -344,21 +274,8 @@ where
     }
 }
 
-/// A custom error type representing a failure to parse a keyring.
-#[derive(Debug)]
-pub struct ParseKeyringError;
-
-impl std::fmt::Display for ParseKeyringError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ParseKeyringError")
-    }
-}
-
 /// The default accounts.
-pub struct DefaultAccounts<T>
-where
-    T: Environment,
-{
+pub struct DefaultAccounts<T> where T: Environment {
     /// The predefined `ALICE` account holding substantial amounts of value.
     pub alice: T::AccountId,
     /// The predefined `BOB` account holding some amounts of value.
@@ -380,8 +297,7 @@ where
 /// Returns the recorded emitted events in order.
 pub fn recorded_events() -> impl Iterator<Item = EmittedEvent> {
     <EnvInstance as OnInstance>::on_instance(|instance| {
-        instance
-            .engine
+        instance.engine
             .get_emitted_events()
             .map(|evt: ink_engine::test_api::EmittedEvent| evt.into())
     })
@@ -412,24 +328,24 @@ pub fn recorded_events() -> impl Iterator<Item = EmittedEvent> {
 pub fn assert_contract_termination<T, F>(
     should_terminate: F,
     expected_beneficiary: T::AccountId,
-    expected_value_transferred_to_beneficiary: T::Balance,
-) where
-    T: Environment,
-    F: FnMut() + UnwindSafe,
-    <T as Environment>::AccountId: Debug,
-    <T as Environment>::Balance: Debug,
+    expected_value_transferred_to_beneficiary: T::Balance
+)
+    where
+        T: Environment,
+        F: FnMut() + UnwindSafe,
+        <T as Environment>::AccountId: Debug,
+        <T as Environment>::Balance: Debug
 {
-    let value_any = ::std::panic::catch_unwind(should_terminate)
+    let value_any = ::std::panic
+        ::catch_unwind(should_terminate)
         .expect_err("contract did not terminate");
-    let encoded_input = value_any
-        .downcast_ref::<Vec<u8>>()
-        .expect("panic object can not be cast");
-    let (value_transferred, encoded_beneficiary): (T::Balance, Vec<u8>) =
-        scale::Decode::decode(&mut &encoded_input[..])
-            .unwrap_or_else(|err| panic!("input can not be decoded: {err}"));
-    let beneficiary =
-        <T::AccountId as scale::Decode>::decode(&mut &encoded_beneficiary[..])
-            .unwrap_or_else(|err| panic!("input can not be decoded: {err}"));
+    let encoded_input = value_any.downcast_ref::<Vec<u8>>().expect("panic object can not be cast");
+    let (value_transferred, encoded_beneficiary): (T::Balance, Vec<u8>) = scale::Decode
+        ::decode(&mut &encoded_input[..])
+        .unwrap_or_else(|err| panic!("input can not be decoded: {err}"));
+    let beneficiary = <T::AccountId as scale::Decode>
+        ::decode(&mut &encoded_beneficiary[..])
+        .unwrap_or_else(|err| panic!("input can not be decoded: {err}"));
     assert_eq!(value_transferred, expected_value_transferred_to_beneficiary);
     assert_eq!(beneficiary, expected_beneficiary);
 }
@@ -438,8 +354,10 @@ pub fn assert_contract_termination<T, F>(
 /// environment.
 #[macro_export]
 macro_rules! pay_with_call {
-    ($contract:ident . $message:ident ( $( $params:expr ),* ) , $amount:expr) => {{
+    ($contract:ident.$message:ident($($params:expr),*), $amount:expr) => {
+        {
         $crate::test::transfer_in::<Environment>($amount);
         $contract.$message($ ($params) ,*)
-    }}
+        }
+    };
 }

--- a/integration-tests/default-accounts/.gitignore
+++ b/integration-tests/default-accounts/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/integration-tests/default-accounts/Cargo.toml
+++ b/integration-tests/default-accounts/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "default-accounts"
+version = "4.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { path = "../../crates/ink", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
+
+[dev-dependencies]
+ink_e2e = { path = "../../crates/e2e" }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/integration-tests/default-accounts/lib.rs
+++ b/integration-tests/default-accounts/lib.rs
@@ -1,0 +1,124 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod custom_default_accounts {
+
+    #[ink(storage)]
+    pub struct CustomDefaultAccounts {}
+
+    impl CustomDefaultAccounts {
+        /// Creates a new Template contract.
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn message(&self) {}
+    }
+
+    impl Default for CustomDefaultAccounts {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use ink::env::test::DefaultAccounts;
+        use ink_e2e;
+
+        #[ink::test]
+        fn test_alice_account() {
+            let integration_test_accounts: DefaultAccounts<ink::env::DefaultEnvironment> =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let integration_alice_account_id = integration_test_accounts.alice;
+
+            let e2e_alice_account_id: AccountId =
+                ink_e2e::AccountKeyring::Alice.to_raw_public().into();
+
+            assert_eq!(integration_alice_account_id, e2e_alice_account_id);
+        }
+
+        #[ink::test]
+        fn test_bob_account() {
+            let integration_test_accounts: DefaultAccounts<ink::env::DefaultEnvironment> =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let integration_bob_account_id = integration_test_accounts.bob;
+
+            let e2e_bob_account_id: AccountId = ink_e2e::AccountKeyring::Bob.to_raw_public().into();
+
+            assert_eq!(integration_bob_account_id, e2e_bob_account_id);
+        }
+
+        #[ink::test]
+        fn test_charlie_account() {
+            let integration_test_accounts: DefaultAccounts<ink::env::DefaultEnvironment> =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let integration_charlie_account_id = integration_test_accounts.charlie;
+
+            let e2e_charlie_account_id: AccountId =
+                ink_e2e::AccountKeyring::Charlie.to_raw_public().into();
+
+            assert_eq!(integration_charlie_account_id, e2e_charlie_account_id);
+        }
+
+        #[ink::test]
+        fn test_dave_account() {
+            let integration_test_accounts: DefaultAccounts<ink::env::DefaultEnvironment> =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let integration_dave_account_id = integration_test_accounts.dave;
+
+            let e2e_dave_account_id: AccountId =
+                ink_e2e::AccountKeyring::Dave.to_raw_public().into();
+
+            assert_eq!(integration_dave_account_id, e2e_dave_account_id);
+        }
+
+        #[ink::test]
+        fn test_eve_account() {
+            let integration_test_accounts: DefaultAccounts<ink::env::DefaultEnvironment> =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let integration_eve_account_id = integration_test_accounts.eve;
+
+            let e2e_eve_account_id: AccountId = ink_e2e::AccountKeyring::Eve.to_raw_public().into();
+
+            assert_eq!(integration_eve_account_id, e2e_eve_account_id);
+        }
+
+        #[ink::test]
+        fn test_ferdie_account() {
+            let integration_test_accounts: DefaultAccounts<ink::env::DefaultEnvironment> =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let integration_ferdie_account_id = integration_test_accounts.ferdie;
+
+            let e2e_ferdie_account_id: AccountId =
+                ink_e2e::AccountKeyring::Ferdie.to_raw_public().into();
+
+            assert_eq!(integration_ferdie_account_id, e2e_ferdie_account_id);
+        }
+
+        #[ink::test]
+        fn test_one_account() {
+            let integration_test_accounts: DefaultAccounts<ink::env::DefaultEnvironment> =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let integration_one_account_id = integration_test_accounts.one;
+
+            let e2e_one_account_id: AccountId = ink_e2e::AccountKeyring::One.to_raw_public().into();
+
+            assert_eq!(integration_one_account_id, e2e_one_account_id);
+        }
+
+        #[ink::test]
+        fn test_two_account() {
+            let integration_test_accounts: DefaultAccounts<ink::env::DefaultEnvironment> =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let integration_two_account_id = integration_test_accounts.two;
+
+            let e2e_two_account_id: AccountId = ink_e2e::AccountKeyring::Two.to_raw_public().into();
+
+            assert_eq!(integration_two_account_id, e2e_two_account_id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1953 
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

## Description
<!--- Describe your changes in detail -->
### Function
`default_accounts()`

### Initial Status
Implementation Difference

### Issue Description
Default accounts addresses do not match across integration and e2e tests.

### Issue Documentation & Test Case
https://github.com/CoinFabrik/on-ink-integration-tests/tree/main/test-cases/default-accounts

### Current Status
Implementation Difference Corrected. Test Cases in Target Repo Passed. Pull Request Performed to Corresponding Repository.

### Implementation Notes
Now the integration tests mimic the account setup in e2e tests. We changed the name of the accounts "Django" to "Dave" and "Frank" to "Ferdie". On the other hand, there were two accounts in e2e that did not exist in integration tests, accounts “one” and “two”. We added these accounts to integration tests.<br><br>Moreover, since e2e tests were drawing these accounts from the library `sp_keyring::sr25519::Keyring`, we made integration tests depend on the same library in order to account for future changes in this lib.

### Updated Documentation

We updated the original documentation of this issue in [our repository](https://github.com/CoinFabrik/on-ink-integration-tests/tree/main), adding the section [Update on Correcting this Issue](https://github.com/CoinFabrik/on-ink-integration-tests/blob/main/test-cases/default-accounts/README.md#update-on-correcting-this-issue) and informing of the correction.<br><br>In the target repository, we updated the inline documentation. The associated documentation should be updated automatically in these pages: [ink_env test default_accounts](https://paritytech.github.io/ink/ink_env/test/fn.default_accounts.html), [ink_env test DefaultAccounts](https://paritytech.github.io/ink/ink_env/test/struct.DefaultAccounts.html), [ink_e2e AccountKeyring](https://paritytech.github.io/ink/ink_e2e/enum.AccountKeyring.html).

### Testing Guide
In the directory `integration-tests/default_accounts` of the [target directory](https://github.com/paritytech/ink), we include in our pull request a test case showing that the observed implementation difference has been corrected. Note that this test is different from the [original test case in our repo](https://github.com/CoinFabrik/on-ink-integration-tests/tree/main/test-cases/default-accounts), which showed the implementation difference.<br><br>In this directory `integration-tests/default_accounts`, run the following command to run both integration and e2e tests:<br> `cargo test -–features e2e-tests`<br><br>These tests are run in the same function in order to compare the results of both environments.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
