### PR TITLE
Missing Limitation for Storage Size on Integration Testing for set_contract_storage()

### DIFF
--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -194,6 +194,10 @@ impl EnvBackend for EnvInstance {
     {
         let mut v = vec![];
         Storable::encode(value, &mut v);
+        const VALUE_SIZE_LIMIT: usize = BUFFER_SIZE - 4;
+        if v.len() > VALUE_SIZE_LIMIT {
+            panic!("Value too large to be stored in contract storage, maximum size is {} bytes", VALUE_SIZE_LIMIT);
+        }
         self.engine.set_storage(&key.encode(), &v[..])
     }
 

--- a/integration-tests/set-contract-storage/.gitignore
+++ b/integration-tests/set-contract-storage/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/integration-tests/set-contract-storage/Cargo.toml
+++ b/integration-tests/set-contract-storage/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "set-contract-storage"
+version = "4.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { path = "../../crates/ink", default-features = false }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
+
+[dev-dependencies]
+ink_e2e = { path = "../../crates/e2e" }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std"
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/integration-tests/set-contract-storage/lib.rs
+++ b/integration-tests/set-contract-storage/lib.rs
@@ -1,0 +1,126 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod set_contract_storage {
+    use ink::env::set_contract_storage;
+
+    const SIZE_LIMIT: usize = (1 << 14) - 4;
+
+    #[ink(storage)]
+    pub struct SetContractStorage {}
+
+    impl SetContractStorage {
+        /// Creates a new SetContractStorage contract.
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self {}
+        }
+
+        /// Stores an array that is JUST big enough to be validly allocated.
+        #[ink(message)]
+        pub fn set_storage_big(&self) {
+            set_contract_storage(&42, &[42u8; SIZE_LIMIT]);
+        }
+
+        /// Tries to store the smallest array that is too big to be validly
+        /// allocated. This function should always fail.
+        #[ink(message)]
+        pub fn set_storage_very_big(&self) {
+            set_contract_storage(&42, &[42u8; SIZE_LIMIT + 1]);
+        }
+    }
+
+    impl Default for SetContractStorage {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[ink::test]
+        fn contract_storage_big() {
+            let contract = SetContractStorage::new();
+
+            contract.set_storage_big();
+
+            assert_eq!(0, 0);
+        }
+
+        #[ink::test]
+        #[should_panic(
+            expected = "Value too large to be stored in contract storage, maximum size is 16380 bytes"
+        )]
+        fn contract_storage_too_big() {
+            let contract = SetContractStorage::new();
+
+            contract.set_storage_very_big();
+        }
+    }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use ink_e2e::build_message;
+
+        use super::*;
+
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn contract_storage_big(
+            mut client: ink_e2e::Client<C, E>,
+        ) -> E2EResult<()> {
+            let constructor = SetContractStorageRef::new();
+
+            let contract_acc_id = client
+                .instantiate(
+                    "set-contract-storage",
+                    &ink_e2e::alice(),
+                    constructor,
+                    0,
+                    None,
+                )
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            let message = build_message::<SetContractStorageRef>(contract_acc_id.clone())
+                .call(|contract| contract.set_storage_big());
+
+            client
+                .call(&ink_e2e::alice(), message, 0, None)
+                .await
+                .expect("set_storage_big failed");
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        #[should_panic]
+        async fn contract_storage_too_big(mut client: ink_e2e::Client<C, E>) {
+            let constructor = SetContractStorageRef::new();
+
+            let contract_acc_id = client
+                .instantiate(
+                    "set-contract-storage",
+                    &ink_e2e::bob(),
+                    constructor,
+                    0,
+                    None,
+                )
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            let message = build_message::<SetContractStorageRef>(contract_acc_id.clone())
+                .call(|contract| contract.set_storage_very_big());
+
+            client
+                .call(&ink_e2e::bob(), message, 0, None)
+                .await
+                .expect("set_storage_very_big failed");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #1960 
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->
### **Issue Description**
The storage in the integration environment does not have the same limitation as in the e2e environment. In the e2e environment, the storage size is limited by 16380 bytes.

### **Issue Documentation & Test Case**
https://github.com/CoinFabrik/on-ink-integration-tests/tree/main/test-cases/set-contract-storage

### **Current Status**
Missing Limitation Implemented. Test Cases Passed. Pull Request Performed to Corresponding Repository.

### **Implementation Notes**
The function `set_contract_storage()` sets the storage in a contract. There was a missing validation in integration tests that was present in e2e. This validation checked that the size of the storage set did not exceed 16380 bytes.<br><br>We added a validation to the function `set_contract_storage()` in integration tests that checks the size of the input value against the same limit set in e2e test: 16380 bytes. In case this limit is exceeded, a panic is raised with the message: "Value too large to be stored in contract storage, maximum size is {} bytes".

### **Updated Documentation** 
We updated the original documentation of this issue in [our repository](https://github.com/CoinFabrik/on-ink-integration-tests/tree/main), adding the section [Update on Correcting this Issue](https://github.com/CoinFabrik/on-ink-integration-tests/blob/main/test-cases/set-contract-storage/README.md#update-on-correcting-this-issue) and informing of the correction.<br><br>There is no necessary update to the associated documentation: [ink_env set_contract_storage](https://paritytech.github.io/ink/ink_env/fn.set_contract_storage.html).

### **Testing Guide**
In the directory `integration-tests/set_contract_storage` of the [target directory](https://github.com/paritytech/ink), we include in our pull request a test case showing that the observed implementation difference has been corrected. Note that this test is different from the [original test case in our repository](https://github.com/CoinFabrik/on-ink-integration-tests/tree/main/test-cases/set-contract-storage), which showed the difference.<br><br>In order to run the integration tests run:<br>`cargo test`<br><br>In order to run the e2e tests run:<br>`cargo test -–features e2e-tests`<br><br>These tests are run separately because we do not need to compare their results.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
