### PR TITLE
`Lazy`: Account for key size in fallible storage ops

### DIFF
--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -156,13 +156,13 @@ where
     /// - `Some(Err(_))` if retrieving the `value` would exceed the static buffer size.
     /// - `None` if there was no value under this storage key.
     pub fn try_get(&self) -> Option<ink_env::Result<V>> {
-        let key_size = KeyType::KEY.encoded_size();
+        let key_size = <Key as Storable>::encoded_size(&KeyType::KEY);
 
         if key_size >= ink_env::BUFFER_SIZE {
             return Some(Err(ink_env::Error::BufferTooSmall))
         }
 
-        let value_size = ink_env::contains_contract_storage(&KeyType::KEY)?
+        let value_size: usize = ink_env::contains_contract_storage(&KeyType::KEY)?
             .try_into()
             .expect("targets of less than 32bit pointer size are not supported; qed");
 
@@ -187,8 +187,8 @@ where
     /// To successfully store the `value`, the encoded `key` and `value`
     /// must fit into the static buffer together.
     pub fn try_set(&mut self, value: &V) -> ink_env::Result<()> {
-        let key_size = KeyType::KEY.encoded_size();
-        let value_size = value.encoded_size();
+        let key_size = <Key as Storable>::encoded_size(&KeyType::KEY);
+        let value_size = <V as Storable>::encoded_size(value);
 
         if key_size.saturating_add(value_size) > ink_env::BUFFER_SIZE {
             return Err(ink_env::Error::BufferTooSmall)

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -148,7 +148,7 @@ where
 
     /// Try to read the `value` from the contract storage.
     ///
-    /// To succesfully retrieve the `value`, the encoded `key` and `value`
+    /// To successfully retrieve the `value`, the encoded `key` and `value`
     /// must both fit into the static buffer together.
     ///
     /// Returns:
@@ -184,7 +184,7 @@ where
 
     /// Try to set the given `value` to the contract storage.
     ///
-    /// To succesfully store the `value`, the encoded `key` and `value`
+    /// To successfully store the `value`, the encoded `key` and `value`
     /// must fit into the static buffer together.
     pub fn try_set(&mut self, value: &V) -> ink_env::Result<()> {
         let key_size = KeyType::KEY.encoded_size();


### PR DESCRIPTION
Followup to #1910. The on-chain engine encodes the key _and_ the value into the scoped buffer, so we need to account for both (same as `Mapping`).