### PR TITLE
chore: fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ older nodes, please do the following:
 1. Mark the old `ink_env::function()` (which depends on the imported `[seal0]` function)
    with the `#[deprecated]` attribute. Please, specify the `since` field with the ink!
    version which will introduce the new API. We will leave this function in for backwards
-   compatibility purposes. Specifing some additional helpful info in the `note` field
+   compatibility purposes. Specifying some additional helpful info in the `note` field
    could also be a good idea.
 2. Name the new function (which depends on the `[seal1] function()`) in a descriptive
    way, like `ink_env::function_whats_special()`.

--- a/crates/ink/macro/src/lib.rs
+++ b/crates/ink/macro/src/lib.rs
@@ -1064,7 +1064,7 @@ pub fn test(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     #[ink(extension = 4, handle_status = false)]
 ///     fn access(key: &[u8]) -> Option<Access>;
 ///
-///     /// Unlocks previously aquired permission to access key.
+///     /// Unlocks previously acquired permission to access key.
 ///     ///
 ///     /// # Errors
 ///     ///

--- a/crates/ink/tests/ui/chain_extension/E-01-simple.rs
+++ b/crates/ink/tests/ui/chain_extension/E-01-simple.rs
@@ -29,7 +29,7 @@ pub trait RuntimeReadWrite {
     #[ink(extension = 4, handle_status = false)]
     fn access(key: &[u8]) -> Option<Access>;
 
-    /// Unlocks previously aquired permission to access key.
+    /// Unlocks previously acquired permission to access key.
     ///
     /// # Errors
     ///

--- a/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
@@ -30,7 +30,7 @@ pub mod integration_flipper {
             Self::new(Default::default())
         }
 
-        /// Attemps to create a new integration_flipper smart contract initialized with
+        /// Attempts to create a new integration_flipper smart contract initialized with
         /// the given value.
         #[ink(constructor)]
         pub fn try_new(succeed: bool) -> Result<Self, FlipperError> {

--- a/linting/src/storage_never_freed.rs
+++ b/linting/src/storage_never_freed.rs
@@ -212,7 +212,7 @@ fn find_collection_fields(cx: &LateContext, storage_struct_id: ItemId) -> Fields
     result
 }
 
-/// Reports the given field defintion
+/// Reports the given field definition
 fn report_field(cx: &LateContext, field_info: &FieldInfo) {
     if_chain! {
         if let Node::Field(field) = cx.tcx.hir().get_by_def_id(field_info.did);

--- a/linting/src/strict_balance_equality.rs
+++ b/linting/src/strict_balance_equality.rs
@@ -432,7 +432,7 @@ impl<'tcx> TransferFunction<'_, 'tcx> {
                 return
             };
 
-        // Handle `PartialEq` functions that implement comparsion for non-primitive types,
+        // Handle `PartialEq` functions that implement comparison for non-primitive types,
         // including references like `&i32`.
         if_chain! {
             if init_taints.len() == 2;


### PR DESCRIPTION
fix typos in comments