### PR TITLE
Add submit-contract-sizes GHA workflow

### DIFF
--- a/.github/download-artifact/action.yml
+++ b/.github/download-artifact/action.yml
@@ -1,0 +1,47 @@
+name: Download Artifact
+description: Download artifact
+inputs:
+  GITHUB_TOKEN:
+    description: Token for using the GitHub REST API
+    required: true
+  ARTIFACT_NAME:
+    description: Name of the artifact to be downloaded
+    required: true
+  DOWNLOAD_DIR:
+    description: Destination directory
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+      - name: Download Artifact
+        uses: actions/github-script@v6
+        with:
+          retries: 3
+          github-token: ${{ inputs.GITHUB_TOKEN }}
+          script: |
+            const artifactName = '${{ inputs.ARTIFACT_NAME }}';
+
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            const matchArtifact = artifacts.data.artifacts.find((artifact) => artifact.name === artifactName);
+
+            if (matchArtifact) {
+              var download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+              });
+              var fs = require('fs');
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/data.zip`, Buffer.from(download.data));
+            } else {
+              core.setFailed(`Artifact ${artifactName} not found.`);
+            }
+
+      - run: unzip data.zip -d ./${{ inputs.DOWNLOAD_DIR }}
+        shell: bash

--- a/.github/workflows/submit-contract-sizes.yml
+++ b/.github/workflows/submit-contract-sizes.yml
@@ -28,7 +28,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_NAME: contract-sizes-data
 
-
       - name: Submit Comment
         env:
           GITHUB_PR_TOKEN:         ${{ secrets.github_token }}

--- a/.github/workflows/submit-contract-sizes.yml
+++ b/.github/workflows/submit-contract-sizes.yml
@@ -1,0 +1,46 @@
+# The workflow has write access, so it needs to be isolated for security reasons from pull request-based workflows,
+# which may be triggered from forked repositories.
+on:
+  workflow_run:
+    workflows:
+      - continuous-integration
+    types:
+      - completed
+
+jobs:
+  submit-contract-sizes:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+
+      - name: Download Contract Sizes
+        uses: ./.github/download-artifact
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_NAME: contract-sizes-data
+
+
+      - name: Submit Comment
+        env:
+          GITHUB_PR_TOKEN:         ${{ secrets.github_token }}
+          GITHUB_PR_WORKFLOW_ID:   ${{ github.event.workflow_run.id }}
+        run: |
+          # context.out is considered as an untrusted file
+          PR_NUMBER=$(grep -oE 'PR_NUMBER="[^"]+"' context.out | awk -F '"' '{print $2}')
+          CARGO_CONTRACT_VERSION=$(grep -oE 'CARGO_CONTRACT_VERSION="[^"]+"' context.out | awk -F '"' '{print $2}')
+          PR_COMMENTS_URL="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments"
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_PR_WORKFLOW_ID}"
+
+          # Submit the comparison table as a comment to the PR
+          echo "Submitting contract sizes diff to ${PR_COMMENTS_URL}"
+          GITHUB_PR_TOKEN=${GITHUB_PR_TOKEN} scripts/contract_sizes_submit.sh ${PR_COMMENTS_URL} ${WORKFLOW_URL} ${CARGO_CONTRACT_VERSION} < ./contract_sizes_diff.md
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -429,6 +429,7 @@ contract-sizes:
     UPSTREAM_DIR: ${MEASUREMENTS_DIR}/ink-${UPSTREAM_BRANCH}
     CONTRACT_SIZES_DIFF: ${MEASUREMENTS_DIR}/${CI_COMMIT_BRANCH}_contract_sizes_diff.md
     PR_COMMENTS_URL: "https://api.github.com/repos/paritytech/ink/issues/${CI_COMMIT_REF_NAME}/comments"
+    WORKFLOW_URL: "https://gitlab.parity.io/parity/mirrors/ink/-/pipelines/${CI_PIPELINE_ID}"
   before_script:
     - mkdir ${MEASUREMENTS_DIR}
   script:
@@ -452,7 +453,8 @@ contract-sizes:
     - cat ${CONTRACT_SIZES_DIFF}
     # Submit the comparison table as a comment to the PR
     - echo "Submitting contract sizes diff to ${PR_COMMENTS_URL}"
-    - ${SCRIPTS_DIR}/contract_sizes_submit.sh ${PR_COMMENTS_URL} < ${CONTRACT_SIZES_DIFF}
+    - CARGO_CONTRACT_VERSION=$(cargo-contract --version | egrep --only-matching "cargo-contract.* .*-x86" | sed -s 's/-x86//')
+    - ${SCRIPTS_DIR}/contract_sizes_submit.sh ${PR_COMMENTS_URL} ${WORKFLOW_URL} ${CARGO_CONTRACT_VERSION} < ${CONTRACT_SIZES_DIFF}
   after_script:
     - rm -rf ${MEASUREMENTS_DIR}
 


### PR DESCRIPTION
## Summary
Related #1454
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
Add submit-contract-sizes workflow

## Description
Adds submit-contract-sizes workflow.
After merging, this workflow will fail because 'ARTIFACT_NAME: contract-sizes-data' does not exist. This won't impact the review process, as it is not marked as a required workflow, but it will allow for testing the measurement functionality in #1971

## Checklist before requesting a review
- [y] My code follows the style guidelines of this project
- [n] I have added an entry to `CHANGELOG.md`
- [y] I have commented my code, particularly in hard-to-understand areas
- [n] I have added tests that prove my fix is effective or that my feature works
- [y] Any dependent changes have been merged and published in downstream modules
