### PR TITLE
Fixing gitspiegel trigger workflow

### DIFF
--- a/.github/workflows/gitspiegel-trigger.yml
+++ b/.github/workflows/gitspiegel-trigger.yml
@@ -1,5 +1,10 @@
 name: gitspiegel sync
 
+# This workflow doesn't do anything, it's only use is to trigger "workflow_run"
+# webhook, that'll be consumed by gitspiegel
+# This way, gitspiegel won't do mirroring, unless this workflow runs,
+# and running the workflow is protected by GitHub
+
 on:
   pull_request:
     types:
@@ -13,8 +18,5 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger sync via API
-        run: |
-          curl --fail-with-body -XPOST "https://gitspiegel.parity-prod.parity.io/api/v1/mirror/${{ github.repository }}/pull/${{ github.event.number }}" \
-           -H "Content-Type: application/json" \
-           -H "x-auth: ${{ secrets.GITSPIEGEL_TOKEN }}"
+      - name: Do nothing
+        run: echo "let's go"


### PR DESCRIPTION
The first attept to use a workflow to protect GitLab CI from untrusted contributors failed, because GitHub doesn't pass secrets to workflows for PRs that originate from forks. 
 
This uses a different approach: instead of triggerring gitspiegel API directly from the workflow, we're just spawning an empty workflow with a specific path, and gitspiegel listens for `workflow_run` event to start mirroring.  

The idea is the same: for the first-time contributors, running workflows would require manual aciton and that would block mirroring. But this time, we don't need any secrets to make it work.
