### PR TITLE
Balance integration fix

### DIFF
--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -14,14 +14,8 @@
 
 //! Operations on the off-chain testing environment.
 
-use super::{
-    EnvInstance,
-    OnInstance,
-};
-use crate::{
-    Environment,
-    Result,
-};
+use super::{EnvInstance, OnInstance};
+use crate::{Environment, Result};
 use core::fmt::Debug;
 use ink_engine::test_api::RecordedDebugMessages;
 use std::panic::UnwindSafe;
@@ -306,7 +300,8 @@ where
         instance.engine.set_callee(encoded_alice.clone());
 
         // set up the funds for the default accounts
-        let substantial = 1_000_000;
+        // the 1_000_000_000 is the same value as in the e2e tests
+        let substantial = 1_000_000_000;
         let some = 1_000;
         instance.engine.set_balance(encoded_alice, substantial);
         instance

--- a/crates/env/src/engine/off_chain/test_api.rs
+++ b/crates/env/src/engine/off_chain/test_api.rs
@@ -14,8 +14,14 @@
 
 //! Operations on the off-chain testing environment.
 
-use super::{EnvInstance, OnInstance};
-use crate::{Environment, Result};
+use super::{
+    EnvInstance,
+    OnInstance,
+};
+use crate::{
+    Environment,
+    Result,
+};
 use core::fmt::Debug;
 use ink_engine::test_api::RecordedDebugMessages;
 use std::panic::UnwindSafe;


### PR DESCRIPTION
## Summary
- [N] y/n | Does it introduce breaking changes?
- [N] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

Updated the default balance in integration tests.

## Description
We updated the default balance in integration tests to be the same as in e2e-tests. This is not definitive, as we want opinions if this should be like this.


## Checklist before requesting a review
- [X] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
