### PR TITLE
Bugfix `ink_metadata`: `RootLayout` must work for PortableForm 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ You can see a more detailed log of changes below:
 - Use `decode_all`` for decoding cross contract call result - [#1810](https://github.com/paritytech/ink/pull/1810)
 - E2E: improve call API, remove `build_message` + callback - [#1782](https://github.com/paritytech/ink/pull/1782)
 
+### Fixed
+- `RootLayout::new()` is generic again to allow using `ink_metadata` in pure `PortableForm` contexts - [#1782](https://github.com/paritytech/ink/pull/1989)
+
 ## 4.3.0
 
 ### Fixed

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -76,7 +76,7 @@ impl Metadata<'_> {
         quote_spanned!(storage_span=>
             // Wrap the layout of the contract into the `RootLayout`, because
             // contract storage key is reserved for all packed fields
-            ::ink::metadata::layout::Layout::Root(::ink::metadata::layout::RootLayout::new::<_>(
+            ::ink::metadata::layout::Layout::Root(::ink::metadata::layout::RootLayout::new(
                 #layout_key,
                 <#storage_ident as ::ink::storage::traits::StorageLayout>::layout(
                     &#key,

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -81,7 +81,7 @@ impl Metadata<'_> {
                 <#storage_ident as ::ink::storage::traits::StorageLayout>::layout(
                     &#key,
                 ),
-                ::scale_info::meta_type::<#storage_ident>(),
+                ::ink::scale_info::meta_type::<#storage_ident>(),
             ))
         )
     }

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -76,11 +76,12 @@ impl Metadata<'_> {
         quote_spanned!(storage_span=>
             // Wrap the layout of the contract into the `RootLayout`, because
             // contract storage key is reserved for all packed fields
-            ::ink::metadata::layout::Layout::Root(::ink::metadata::layout::RootLayout::new::<#storage_ident, _>(
+            ::ink::metadata::layout::Layout::Root(::ink::metadata::layout::RootLayout::new::<_>(
                 #layout_key,
                 <#storage_ident as ::ink::storage::traits::StorageLayout>::layout(
                     &#key,
                 ),
+                ::scale_info::meta_type::<#storage_ident>(),
             ))
         )
     }

--- a/crates/metadata/src/layout/mod.rs
+++ b/crates/metadata/src/layout/mod.rs
@@ -154,25 +154,12 @@ impl IntoPortable for RootLayout {
 }
 
 impl RootLayout<MetaForm> {
-    /// Creates a new root layout.
-    pub fn new<Root, L>(root_key: LayoutKey, layout: L) -> Self
-    where
-        Root: TypeInfo + 'static,
-        L: Into<Layout<MetaForm>>,
-    {
-        Self {
-            root_key,
-            layout: Box::new(layout.into()),
-            ty: meta_type::<Root>(),
-        }
-    }
-
     /// Creates a new root layout with empty root type.
     pub fn new_empty<L>(root_key: LayoutKey, layout: L) -> Self
     where
         L: Into<Layout<MetaForm>>,
     {
-        Self::new::<(), L>(root_key, layout)
+        Self::new::<L>(root_key, layout, meta_type::<()>())
     }
 }
 
@@ -180,6 +167,18 @@ impl<F> RootLayout<F>
 where
     F: Form,
 {
+    /// Create a new root layout
+    pub fn new<L>(root_key: LayoutKey, layout: L, ty: <F as Form>::Type) -> Self
+    where
+        L: Into<Layout<F>>,
+    {
+        Self {
+            root_key,
+            layout: Box::new(layout.into()),
+            ty,
+        }
+    }
+
     /// Returns the root key of the sub-tree.
     pub fn root_key(&self) -> &LayoutKey {
         &self.root_key

--- a/crates/metadata/src/layout/tests.rs
+++ b/crates/metadata/src/layout/tests.rs
@@ -351,3 +351,13 @@ fn runtime_storage_layout_works() {
     );
     assert_eq!(json, expected);
 }
+
+#[test]
+fn ensure_portable_root_layout_are_supported() {
+    let root_key = LayoutKey::new(0u32);
+    let layout =
+        Layout::Struct(StructLayout::<PortableForm>::new(String::new(), Vec::new()));
+    let ty = 0.into();
+
+    let _: RootLayout<PortableForm> = RootLayout::new(root_key, layout, ty);
+}

--- a/crates/metadata/src/layout/tests.rs
+++ b/crates/metadata/src/layout/tests.rs
@@ -355,8 +355,7 @@ fn runtime_storage_layout_works() {
 #[test]
 fn ensure_portable_root_layout_are_supported() {
     let root_key = LayoutKey::new(0u32);
-    let layout =
-        Layout::Struct(StructLayout::<PortableForm>::new(String::new(), Vec::new()));
+    let layout = Layout::Struct(StructLayout::new(String::new(), Vec::new()));
     let ty = 0.into();
 
     let _: RootLayout<PortableForm> = RootLayout::new(root_key, layout, ty);

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -369,7 +369,7 @@ const _: () = {
         KeyType: StorageKey + scale_info::TypeInfo + 'static,
     {
         fn layout(_: &Key) -> Layout {
-            Layout::Root(RootLayout::new::<_>(
+            Layout::Root(RootLayout::new(
                 LayoutKey::from(&KeyType::KEY),
                 <V as StorageLayout>::layout(&KeyType::KEY),
                 scale_info::meta_type::<Self>(),

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -361,7 +361,6 @@ const _: () = {
         LayoutKey,
         RootLayout,
     };
-    use scale_info::meta_type;
 
     impl<K, V, KeyType> StorageLayout for Mapping<K, V, KeyType>
     where
@@ -373,7 +372,7 @@ const _: () = {
             Layout::Root(RootLayout::new::<_>(
                 LayoutKey::from(&KeyType::KEY),
                 <V as StorageLayout>::layout(&KeyType::KEY),
-                meta_type::<Self>(),
+                scale_info::meta_type::<Self>(),
             ))
         }
     }

--- a/crates/storage/src/lazy/mapping.rs
+++ b/crates/storage/src/lazy/mapping.rs
@@ -361,6 +361,7 @@ const _: () = {
         LayoutKey,
         RootLayout,
     };
+    use scale_info::meta_type;
 
     impl<K, V, KeyType> StorageLayout for Mapping<K, V, KeyType>
     where
@@ -369,9 +370,10 @@ const _: () = {
         KeyType: StorageKey + scale_info::TypeInfo + 'static,
     {
         fn layout(_: &Key) -> Layout {
-            Layout::Root(RootLayout::new::<Self, _>(
+            Layout::Root(RootLayout::new::<_>(
                 LayoutKey::from(&KeyType::KEY),
                 <V as StorageLayout>::layout(&KeyType::KEY),
+                meta_type::<Self>(),
             ))
         }
     }

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -191,7 +191,7 @@ where
         let value_size = <V as Storable>::encoded_size(value);
 
         if key_size.saturating_add(value_size) > ink_env::BUFFER_SIZE {
-            return Err(ink_env::Error::BufferTooSmall)
+            return Err(ink_env::Error::BufferTooSmall);
         };
 
         self.set(value);
@@ -259,6 +259,7 @@ const _: () = {
         LayoutKey,
         RootLayout,
     };
+    use scale_info::meta_type;
 
     impl<V, KeyType> StorageLayout for Lazy<V, KeyType>
     where
@@ -266,9 +267,10 @@ const _: () = {
         KeyType: StorageKey + scale_info::TypeInfo + 'static,
     {
         fn layout(_: &Key) -> Layout {
-            Layout::Root(RootLayout::new::<Self, _>(
+            Layout::Root(RootLayout::new::<_>(
                 LayoutKey::from(&KeyType::KEY),
                 <V as StorageLayout>::layout(&KeyType::KEY),
+                meta_type::<Self>(),
             ))
         }
     }

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -266,7 +266,7 @@ const _: () = {
         KeyType: StorageKey + scale_info::TypeInfo + 'static,
     {
         fn layout(_: &Key) -> Layout {
-            Layout::Root(RootLayout::new::<_>(
+            Layout::Root(RootLayout::new(
                 LayoutKey::from(&KeyType::KEY),
                 <V as StorageLayout>::layout(&KeyType::KEY),
                 scale_info::meta_type::<Self>(),

--- a/crates/storage/src/lazy/mod.rs
+++ b/crates/storage/src/lazy/mod.rs
@@ -191,7 +191,7 @@ where
         let value_size = <V as Storable>::encoded_size(value);
 
         if key_size.saturating_add(value_size) > ink_env::BUFFER_SIZE {
-            return Err(ink_env::Error::BufferTooSmall);
+            return Err(ink_env::Error::BufferTooSmall)
         };
 
         self.set(value);
@@ -259,7 +259,6 @@ const _: () = {
         LayoutKey,
         RootLayout,
     };
-    use scale_info::meta_type;
 
     impl<V, KeyType> StorageLayout for Lazy<V, KeyType>
     where
@@ -270,7 +269,7 @@ const _: () = {
             Layout::Root(RootLayout::new::<_>(
                 LayoutKey::from(&KeyType::KEY),
                 <V as StorageLayout>::layout(&KeyType::KEY),
-                meta_type::<Self>(),
+                scale_info::meta_type::<Self>(),
             ))
         }
     }


### PR DESCRIPTION
## Summary
#1784 changed `RootLayout::new()` to no longer be generic. Which breaks re-using the metadata for project relying on working with `PortableForm` exclusively (such as Solang).

This should go into the next release or it will stuck Solang to an older version of `ink_metadata`.

## Description
Changed the `RootLayout::new()` function to be generic again. I think the `Type` crafted inside the constructor is pure convenience that can be done by the caller anyways. However this cosmetic trade-off makes `RootLayout` usable in purely portable contexts again.

Also added a test that would break without the bugfix.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
