### PR TITLE
Move publish-docs job to GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
         with:
           name: ${{ github.job }}-data
           path: ./crate-docs
-          retention-days: 7
+          retention-days: 1
 
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,3 +1,6 @@
+# The workflow has write access, so it needs to be isolated for security reasons from pull request-based workflows,
+# which may be triggered from forked repositories.
+
 name: continuous-intergration/publish-docs
 
 on: 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -57,6 +57,5 @@ jobs:
           # We don't want to mark the entire job as failed if there's nothing to
           # publish though, hence the `|| true`.
           git commit -m "Updated docs for ${{ github.event.workflow_run.head_branch }}} and pushed to gh-pages" || true
-          # TODO: Publish disabled, It will be enabled in last migration step
-          # git push origin gh-pages --force
+          git push origin gh-pages --force
           rm -rf .git/ ./*

--- a/.github/workflows/submit-contract-sizes.yml
+++ b/.github/workflows/submit-contract-sizes.yml
@@ -1,5 +1,8 @@
 # The workflow has write access, so it needs to be isolated for security reasons from pull request-based workflows,
 # which may be triggered from forked repositories.
+
+name: continuous-intergration/submit-contract-sizes
+
 on:
   workflow_run:
     workflows:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -478,7 +478,7 @@ examples-docs:
 
 #### stage:                        publish
 
-publish-docs:
+.publish-docs:
   stage:                           publish
   <<:                              *kubernetes-env
   image:                           paritytech/tools:latest


### PR DESCRIPTION
## Summary
Related #1454
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
Move publish-docs job from gitlab CI to GHA

## Description
Publish-docs job is disabled in the Gitlab CI, and added to the Github CI

## Checklist before requesting a review
- [y] My code follows the style guidelines of this project
- [n] I have added an entry to `CHANGELOG.md`
- [y] I have commented my code, particularly in hard-to-understand areas
- [n] I have added tests that prove my fix is effective or that my feature works
- [y] Any dependent changes have been merged and published in downstream modules
