### PR TITLE
`[ink_e2e]` resolve `DispatchError` error details for dry-runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Fail when decoding from storage and not all bytes consumed - [#1897](https://github.com/paritytech/ink/pull/1897)
+- [E2E] resolve DispatchError error details for dry-runs - [#1944](https://github.com/paritytech/ink/pull/1994)
 
 ### Added
 - Linter: `storage_never_freed` lint - [#1932](https://github.com/paritytech/ink/pull/1932)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ subxt-metadata = { version = "0.32.1" }
 subxt-signer = { version = "0.32.1" }
 syn = { version = "2" }
 synstructure = { version = "0.13.0" }
+thiserror = { version = "1.0.50" }
 tokio = { version = "1.18.2" }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -35,7 +35,7 @@ scale = { package = "parity-scale-codec", workspace = true }
 subxt = { workspace = true }
 subxt-metadata = { workspace = true, optional = true }
 subxt-signer = { workspace = true, features = ["subxt", "sr25519"] }
-thiserror = "1.0.50"
+thiserror = { workspace = true }
 wasm-instrument = { workspace = true }
 which = { workspace = true }
 

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -35,6 +35,7 @@ scale = { package = "parity-scale-codec", workspace = true }
 subxt = { workspace = true }
 subxt-metadata = { workspace = true, optional = true }
 subxt-signer = { workspace = true, features = ["subxt", "sr25519"] }
+thiserror = "1.0.50"
 wasm-instrument = { workspace = true }
 which = { workspace = true }
 

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -219,7 +219,7 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
         message: &CallBuilderFinal<E, Args, RetType>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> CallDryRunResult<E, RetType>
+    ) -> Result<CallDryRunResult<E, RetType>, Self::Error>
     where
         CallBuilderFinal<E, Args, RetType>: Clone;
 
@@ -272,5 +272,5 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
         constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> ContractInstantiateResult<E::AccountId, E::Balance, ()>;
+    ) -> Result<ContractInstantiateResult<E::AccountId, E::Balance, ()>, Self::Error>;
 }

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -19,7 +19,10 @@ use crate::{
         UploadBuilder,
     },
     builders::CreateBuilderPartial,
-    contract_results::BareInstantiationResult,
+    contract_results::{
+        BareInstantiationResult,
+        InstantiateDryRunResult,
+    },
     CallBuilder,
     CallBuilderFinal,
     CallDryRunResult,
@@ -30,7 +33,6 @@ use ink_env::{
     Environment,
 };
 use jsonrpsee::core::async_trait;
-use pallet_contracts_primitives::ContractInstantiateResult;
 use scale::{
     Decode,
     Encode,
@@ -272,5 +274,5 @@ pub trait BuilderClient<E: Environment>: ContractsBackend<E> {
         constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> Result<ContractInstantiateResult<E::AccountId, E::Balance, ()>, Self::Error>;
+    ) -> Result<InstantiateDryRunResult<E>, Self::Error>;
 }

--- a/crates/e2e/src/backend_calls.rs
+++ b/crates/e2e/src/backend_calls.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use ink_env::Environment;
-use pallet_contracts_primitives::ContractInstantiateResult;
 use scale::{
     Decode,
     Encode,
@@ -27,6 +26,7 @@ use crate::{
     CallDryRunResult,
     CallResult,
     ContractsBackend,
+    InstantiateDryRunResult,
     InstantiationResult,
     UploadResult,
 };
@@ -312,7 +312,7 @@ where
         let gas_limit = if let Some(limit) = self.gas_limit {
             limit
         } else {
-            let gas_required = dry_run.gas_required;
+            let gas_required = dry_run.contract_result.gas_required;
             if let Some(m) = self.extra_gas_portion {
                 gas_required + (gas_required / 100 * m)
             } else {
@@ -339,9 +339,7 @@ where
     }
 
     /// Dry run the instantiate call.
-    pub async fn dry_run(
-        &mut self,
-    ) -> Result<ContractInstantiateResult<E::AccountId, E::Balance, ()>, B::Error> {
+    pub async fn dry_run(&mut self) -> Result<InstantiateDryRunResult<E>, B::Error> {
         B::bare_instantiate_dry_run(
             self.client,
             self.contract_name,

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -204,18 +204,6 @@ impl<E: Environment, V: scale::Decode> CallDryRunResult<E, V> {
         self.exec_result.result.is_err()
     }
 
-    /// Converts the dry-run result into a `Result` type.
-    pub fn to_result<Error>(self) -> Result<Self, Error>
-    where
-        Error: From<ContractExecResult<E::Balance, ()>>,
-    {
-        if self.is_err() {
-            Err(Error::from(self.exec_result))
-        } else {
-            Ok(self)
-        }
-    }
-
     /// Returns the [`ExecReturnValue`] resulting from the dry-run message call.
     ///
     /// Panics if the dry-run message call failed to execute.

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -303,13 +303,6 @@ impl<E: Environment> InstantiateDryRunResult<E> {
         })
     }
 
-    /// Returns the return value as raw bytes of the message from the dry-run.
-    ///
-    /// Panics if the dry-run message call failed to execute.
-    pub fn return_data(&self) -> &[u8] {
-        &self.instantiate_return_value().result.data
-    }
-
     /// Returns any debug message output by the contract decoded as UTF-8.
     pub fn debug_message(&self) -> String {
         String::from_utf8_lossy(&self.contract_result.debug_message).into()

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -17,7 +17,10 @@ use ink_env::{
     call::FromAccountId,
     Environment,
 };
-use ink_primitives::MessageResult;
+use ink_primitives::{
+    ConstructorResult,
+    MessageResult,
+};
 use pallet_contracts_primitives::{
     CodeUploadResult,
     ContractExecResult,
@@ -293,7 +296,7 @@ impl<E: Environment> InstantiateDryRunResult<E> {
     /// # Panics
     /// - if the dry-run message instantiate failed to execute.
     /// - if message result cannot be decoded into the expected return value type.
-    pub fn constructor_result(&self) -> Result<(), ink::LangError> {
+    pub fn constructor_result<V: scale::Decode>(&self) -> ConstructorResult<V> {
         let data = &self.instantiate_return_value().result.data;
         scale::Decode::decode(&mut data.as_ref()).unwrap_or_else(|env_err| {
             panic!("Decoding dry run result to constructor return type failed: {env_err}")

--- a/crates/e2e/src/drink_client.rs
+++ b/crates/e2e/src/drink_client.rs
@@ -341,7 +341,7 @@ where
         let account_id = (*account_id.as_ref()).into();
 
         self.bare_call_dry_run(caller, message, value, storage_deposit_limit)
-            .await;
+            .await?;
 
         if self
             .sandbox
@@ -386,7 +386,7 @@ where
                 storage_deposit_limit,
             )
         });
-        CallDryRunResult {
+        Ok(CallDryRunResult {
             exec_result: ContractResult {
                 gas_consumed: result.gas_consumed,
                 gas_required: result.gas_required,
@@ -396,7 +396,7 @@ where
                 events: None,
             },
             _marker: Default::default(),
-        }
+        })
     }
 }
 

--- a/crates/e2e/src/drink_client.rs
+++ b/crates/e2e/src/drink_client.rs
@@ -30,6 +30,7 @@ use crate::{
     ChainBackend,
     ContractsBackend,
     E2EBackend,
+    InstantiateDryRunResult,
     UploadResult,
 };
 use drink::{
@@ -248,10 +249,7 @@ where
         constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> Result<
-        ContractInstantiateResult<E::AccountId, E::Balance, Self::EventLog>,
-        Self::Error,
-    > {
+    ) -> Result<InstantiateDryRunResult<E>, Self::Error> {
         let code = self.contracts.load_code(contract_name);
         let data = constructor_exec_input(constructor.clone());
         let result = self.sandbox.dry_run(|r| {
@@ -274,7 +272,7 @@ where
         };
         let account_id = AccountId::from(account_id_raw);
 
-        Ok(ContractInstantiateResult {
+        let result = ContractInstantiateResult {
             gas_consumed: result.gas_consumed,
             gas_required: result.gas_required,
             storage_deposit: result.storage_deposit,
@@ -286,7 +284,8 @@ where
                 }
             }),
             events: None,
-        })
+        };
+        Ok(result.into())
     }
 
     async fn bare_upload(

--- a/crates/e2e/src/drink_client.rs
+++ b/crates/e2e/src/drink_client.rs
@@ -248,7 +248,10 @@ where
         constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> ContractInstantiateResult<E::AccountId, E::Balance, Self::EventLog> {
+    ) -> Result<
+        ContractInstantiateResult<E::AccountId, E::Balance, Self::EventLog>,
+        Self::Error,
+    > {
         let code = self.contracts.load_code(contract_name);
         let data = constructor_exec_input(constructor.clone());
         let result = self.sandbox.dry_run(|r| {
@@ -271,7 +274,7 @@ where
         };
         let account_id = AccountId::from(account_id_raw);
 
-        ContractInstantiateResult {
+        Ok(ContractInstantiateResult {
             gas_consumed: result.gas_consumed,
             gas_required: result.gas_required,
             storage_deposit: result.storage_deposit,
@@ -283,7 +286,7 @@ where
                 }
             }),
             events: None,
-        }
+        })
     }
 
     async fn bare_upload(
@@ -365,7 +368,7 @@ where
         message: &CallBuilderFinal<E, Args, RetType>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> CallDryRunResult<E, RetType>
+    ) -> Result<CallDryRunResult<E, RetType>, Self::Error>
     where
         CallBuilderFinal<E, Args, RetType>: Clone,
     {

--- a/crates/e2e/src/error.rs
+++ b/crates/e2e/src/error.rs
@@ -15,7 +15,6 @@
 use pallet_contracts_primitives::{
     CodeUploadResult,
     ContractExecResult,
-    ContractInstantiateResult,
 };
 
 /// An error occurred while interacting with the E2E backend.
@@ -24,11 +23,14 @@ use pallet_contracts_primitives::{
 /// anything concerning the execution environment (like inability to communicate with node
 /// or runtime, fetch the nonce, account info, etc.) we panic.
 #[derive(Debug)]
-pub enum Error<AccountId, Balance, CodeHash, DispatchError> {
+pub enum Error<Balance, CodeHash, DispatchError> {
     /// No contract with the given name found in scope.
     ContractNotFound(String),
     /// The `instantiate_with_code` dry run failed.
-    InstantiateDryRun(ContractInstantiateResult<AccountId, Balance, ()>),
+    InstantiateDryRun {
+        debug_message: String,
+        error: DispatchError,
+    },
     /// The `instantiate_with_code` extrinsic failed.
     InstantiateExtrinsic(DispatchError),
     /// The `upload` dry run failed.
@@ -45,17 +47,8 @@ pub enum Error<AccountId, Balance, CodeHash, DispatchError> {
     Decoding(String),
 }
 
-impl<AccountId, Balance, CodeHash, DispatchError>
-    From<ContractInstantiateResult<AccountId, Balance, ()>>
-    for Error<AccountId, Balance, CodeHash, DispatchError>
-{
-    fn from(value: ContractInstantiateResult<AccountId, Balance, ()>) -> Self {
-        Self::InstantiateDryRun(value)
-    }
-}
-
-impl<AccountId, Balance, CodeHash, DispatchError> From<ContractExecResult<Balance, ()>>
-    for Error<AccountId, Balance, CodeHash, DispatchError>
+impl<Balance, CodeHash, DispatchError> From<ContractExecResult<Balance, ()>>
+    for Error<Balance, CodeHash, DispatchError>
 {
     fn from(value: ContractExecResult<Balance, ()>) -> Self {
         Self::CallDryRun(value)
@@ -67,14 +60,6 @@ impl<AccountId, Balance, CodeHash, DispatchError> From<ContractExecResult<Balanc
 /// todo: https://github.com/Cardinal-Cryptography/drink/issues/32
 #[derive(Debug)]
 pub struct DrinkErr;
-
-impl<AccountId, Balance> From<ContractInstantiateResult<AccountId, Balance, ()>>
-    for DrinkErr
-{
-    fn from(_value: ContractInstantiateResult<AccountId, Balance, ()>) -> Self {
-        Self {}
-    }
-}
 
 impl<Balance> From<ContractExecResult<Balance, ()>> for DrinkErr {
     fn from(_value: ContractExecResult<Balance, ()>) -> Self {

--- a/crates/e2e/src/error.rs
+++ b/crates/e2e/src/error.rs
@@ -12,54 +12,73 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use pallet_contracts_primitives::{
-    CodeUploadResult,
-    ContractExecResult,
-};
+use pallet_contracts_primitives::ContractExecResult;
+
+use std::fmt;
 
 /// An error occurred while interacting with the E2E backend.
 ///
 /// We only convey errors here that are caused by the contract's testing logic. For
 /// anything concerning the execution environment (like inability to communicate with node
 /// or runtime, fetch the nonce, account info, etc.) we panic.
-#[derive(Debug)]
-pub enum Error<Balance, CodeHash, DispatchError> {
+#[derive(Debug, thiserror::Error)]
+pub enum Error<DispatchError: fmt::Debug + fmt::Display> {
     /// No contract with the given name found in scope.
+    #[error("Contract not found: {0}")]
     ContractNotFound(String),
     /// The `instantiate_with_code` dry run failed.
-    InstantiateDryRun {
-        debug_message: String,
-        error: DispatchError,
-    },
+    #[error("Instantiate dry-run error: {0}")]
+    InstantiateDryRun(DryRunError<DispatchError>),
     /// The `instantiate_with_code` extrinsic failed.
+    #[error("Instantiate extrinsic error: {0}")]
     InstantiateExtrinsic(DispatchError),
     /// The `upload` dry run failed.
-    UploadDryRun(CodeUploadResult<CodeHash, Balance>),
+    #[error("Upload dry-run error: {0}")]
+    UploadDryRun(DispatchError),
     /// The `upload` extrinsic failed.
+    #[error("Upload extrinsic error: {0}")]
     UploadExtrinsic(DispatchError),
     /// The `call` dry run failed.
-    CallDryRun(ContractExecResult<Balance, ()>),
+    #[error("Call dry-run error: {0}")]
+    CallDryRun(DryRunError<DispatchError>),
     /// The `call` extrinsic failed.
+    #[error("Call extrinsic error: {0}")]
     CallExtrinsic(DispatchError),
     /// Error fetching account balance.
+    #[error("Fetching account Balance error: {0}")]
     Balance(String),
     /// Decoding failed.
+    #[error("Decoding failed: {0}")]
     Decoding(String),
 }
 
-impl<Balance, CodeHash, DispatchError> From<ContractExecResult<Balance, ()>>
-    for Error<Balance, CodeHash, DispatchError>
+/// Error during a dry run RPC invocation.
+#[derive(Debug)]
+pub struct DryRunError<DispatchError: fmt::Display + fmt::Debug> {
+    pub debug_message: String,
+    pub error: DispatchError,
+}
+
+impl<DispatchError> fmt::Display for DryRunError<DispatchError>
+where
+    DispatchError: fmt::Display + fmt::Debug,
 {
-    fn from(value: ContractExecResult<Balance, ()>) -> Self {
-        Self::CallDryRun(value)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
     }
 }
 
 /// Dummy error type for drink!
 ///
 /// todo: https://github.com/Cardinal-Cryptography/drink/issues/32
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub struct DrinkErr;
+
+impl fmt::Display for DrinkErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DrinkErr")
+    }
+}
 
 impl<Balance> From<ContractExecResult<Balance, ()>> for DrinkErr {
     fn from(_value: ContractExecResult<Balance, ()>) -> Self {

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -49,6 +49,7 @@ pub use backend_calls::{
 pub use contract_results::{
     CallDryRunResult,
     CallResult,
+    InstantiateDryRunResult,
     InstantiationResult,
     UploadResult,
 };

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -25,8 +25,8 @@ use super::{
     log_error,
     log_info,
     sr25519,
-    ContractInstantiateResult,
     ContractsApi,
+    InstantiateDryRunResult,
     Keypair,
 };
 use crate::{
@@ -498,8 +498,7 @@ where
         constructor: &mut CreateBuilderPartial<E, Contract, Args, R>,
         value: E::Balance,
         storage_deposit_limit: Option<E::Balance>,
-    ) -> Result<ContractInstantiateResult<E::AccountId, E::Balance, ()>, Self::Error>
-    {
+    ) -> Result<InstantiateDryRunResult<E>, Self::Error> {
         let code = self.contracts.load_code(contract_name);
         let data = constructor_exec_input(constructor.clone());
 
@@ -514,8 +513,12 @@ where
                 caller,
             )
             .await;
-        self.contract_result_to_result(result)
-            .map_err(Error::InstantiateDryRun)
+
+        let result = self
+            .contract_result_to_result(result)
+            .map_err(Error::InstantiateDryRun)?;
+
+        Ok(result.into())
     }
 
     async fn bare_upload(

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -277,8 +277,10 @@ where
             E::Balance,
             (),
         >,
-    ) -> Result<ContractResult<Result<V, sp_runtime::DispatchError>, E::Balance, ()>, DryRunError<DispatchError>>
-    {
+    ) -> Result<
+        ContractResult<Result<V, sp_runtime::DispatchError>, E::Balance, ()>,
+        DryRunError<DispatchError>,
+    > {
         if let Err(error) = contract_result.result {
             let debug_message = String::from_utf8(contract_result.debug_message.clone())
                 .expect("invalid utf8 debug message");
@@ -604,7 +606,8 @@ where
             String::from_utf8_lossy(&exec_result.debug_message)
         ));
 
-        let exec_result = self.contract_result_to_result(exec_result)
+        let exec_result = self
+            .contract_result_to_result(exec_result)
             .map_err(Error::CallDryRun)?;
 
         Ok(CallDryRunResult {

--- a/integration-tests/call-builder-return-value/lib.rs
+++ b/integration-tests/call-builder-return-value/lib.rs
@@ -192,7 +192,7 @@ mod call_builder {
             let call =
                 call_builder_call.delegate_call_short_return_type(code_hash, selector);
             let call_result: Result<i8, String> =
-                client.call(&origin, &call).dry_run().await.return_value();
+                client.call(&origin, &call).dry_run().await?.return_value();
 
             assert!(
                 call_result.is_err(),
@@ -280,7 +280,7 @@ mod call_builder {
             let call = call_builder_call
                 .forward_call_short_return_type(incrementer.account_id, selector);
             let call_result: Result<i8, String> =
-                client.call(&origin, &call).dry_run().await.return_value();
+                client.call(&origin, &call).dry_run().await?.return_value();
 
             assert!(
                 call_result.is_err(),

--- a/integration-tests/call-runtime/lib.rs
+++ b/integration-tests/call-runtime/lib.rs
@@ -237,7 +237,7 @@ mod runtime_call {
             let call_res = client
                 .call(&ink_e2e::alice(), &transfer_message)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             // then

--- a/integration-tests/contract-transfer/lib.rs
+++ b/integration-tests/contract-transfer/lib.rs
@@ -213,12 +213,8 @@ pub mod give_me {
                 .await;
 
             // then
-            if let Err(ink_e2e::Error::<ink::env::DefaultEnvironment>::CallDryRun(
-                dry_run,
-            )) = call_res
-            {
-                let debug_message = String::from_utf8_lossy(&dry_run.debug_message);
-                assert!(debug_message.contains("paid an unpayable message"))
+            if let Err(ink_e2e::Error::CallDryRun(dry_run)) = call_res {
+                assert!(dry_run.debug_message.contains("paid an unpayable message"))
             } else {
                 panic!("Paying an unpayable message should fail")
             }

--- a/integration-tests/custom-allocator/lib.rs
+++ b/integration-tests/custom-allocator/lib.rs
@@ -128,7 +128,7 @@ mod custom_allocator {
 
             // Then
             let get = call.get();
-            let get_result = client.call(&ink_e2e::alice(), &get).dry_run().await;
+            let get_result = client.call(&ink_e2e::alice(), &get).dry_run().await?;
             assert!(matches!(get_result.return_value(), false));
 
             Ok(())
@@ -148,7 +148,7 @@ mod custom_allocator {
             let mut call = contract.call::<CustomAllocator>();
 
             let get = call.get();
-            let get_result = client.call(&ink_e2e::bob(), &get).dry_run().await;
+            let get_result = client.call(&ink_e2e::bob(), &get).dry_run().await?;
             assert!(matches!(get_result.return_value(), false));
 
             // When
@@ -161,7 +161,7 @@ mod custom_allocator {
 
             // Then
             let get = call.get();
-            let get_result = client.call(&ink_e2e::bob(), &get).dry_run().await;
+            let get_result = client.call(&ink_e2e::bob(), &get).dry_run().await?;
             assert!(matches!(get_result.return_value(), true));
 
             Ok(())

--- a/integration-tests/custom-environment/lib.rs
+++ b/integration-tests/custom-environment/lib.rs
@@ -97,7 +97,7 @@ mod runtime_call {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let call = contract.call::<Topics>();
+            let mut call = contract.call::<Topics>();
 
             // when
             let message = call.trigger();

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -58,7 +58,7 @@ pub mod e2e_call_runtime {
             let pre_balance = client
                 .call(&ink_e2e::alice(), &get_balance)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             // Send funds from Alice to the contract using Balances::transfer
@@ -75,7 +75,7 @@ pub mod e2e_call_runtime {
             // then
             let get_balance = call.get_contract_balance();
             let get_balance_res =
-                client.call(&ink_e2e::alice(), &get_balance).dry_run().await;
+                client.call(&ink_e2e::alice(), &get_balance).dry_run().await?;
 
             assert_eq!(
                 get_balance_res.return_value(),

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -74,8 +74,10 @@ pub mod e2e_call_runtime {
 
             // then
             let get_balance = call.get_contract_balance();
-            let get_balance_res =
-                client.call(&ink_e2e::alice(), &get_balance).dry_run().await?;
+            let get_balance_res = client
+                .call(&ink_e2e::alice(), &get_balance)
+                .dry_run()
+                .await?;
 
             assert_eq!(
                 get_balance_res.return_value(),

--- a/integration-tests/e2e-runtime-only-backend/lib.rs
+++ b/integration-tests/e2e-runtime-only-backend/lib.rs
@@ -76,7 +76,7 @@ pub mod flipper {
             let _flip_res = client.call(&ink_e2e::bob(), &call.flip()).submit().await;
 
             // then
-            let get_res = client.call(&ink_e2e::bob(), &call.get()).dry_run().await;
+            let get_res = client.call(&ink_e2e::bob(), &call.get()).dry_run().await?;
             assert_eq!(get_res.return_value(), !INITIAL_VALUE);
 
             Ok(())

--- a/integration-tests/erc20/lib.rs
+++ b/integration-tests/erc20/lib.rs
@@ -535,7 +535,7 @@ mod erc20 {
             let total_supply_res = client
                 .call(&ink_e2e::bob(), &total_supply_msg)
                 .dry_run()
-                .await;
+                .await?;
 
             let bob_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Bob);
             let transfer_to_bob = 500_000_000u128;
@@ -548,7 +548,7 @@ mod erc20 {
 
             let balance_of = call.balance_of(bob_account);
             let balance_of_res =
-                client.call(&ink_e2e::alice(), &balance_of).dry_run().await;
+                client.call(&ink_e2e::alice(), &balance_of).dry_run().await?;
 
             // then
             assert_eq!(
@@ -614,7 +614,7 @@ mod erc20 {
 
             let balance_of = call.balance_of(bob_account);
             let balance_of_res =
-                client.call(&ink_e2e::alice(), &balance_of).dry_run().await;
+                client.call(&ink_e2e::alice(), &balance_of).dry_run().await?;
 
             // `transfer_from` again, this time exceeding the approved amount
             let transfer_from = call.transfer_from(bob_account, charlie_account, 1);

--- a/integration-tests/erc20/lib.rs
+++ b/integration-tests/erc20/lib.rs
@@ -547,8 +547,10 @@ mod erc20 {
                 .expect("transfer failed");
 
             let balance_of = call.balance_of(bob_account);
-            let balance_of_res =
-                client.call(&ink_e2e::alice(), &balance_of).dry_run().await?;
+            let balance_of_res = client
+                .call(&ink_e2e::alice(), &balance_of)
+                .dry_run()
+                .await?;
 
             // then
             assert_eq!(
@@ -613,8 +615,10 @@ mod erc20 {
             );
 
             let balance_of = call.balance_of(bob_account);
-            let balance_of_res =
-                client.call(&ink_e2e::alice(), &balance_of).dry_run().await?;
+            let balance_of_res = client
+                .call(&ink_e2e::alice(), &balance_of)
+                .dry_run()
+                .await?;
 
             // `transfer_from` again, this time exceeding the approved amount
             let transfer_from = call.transfer_from(bob_account, charlie_account, 1);

--- a/integration-tests/flipper/lib.rs
+++ b/integration-tests/flipper/lib.rs
@@ -71,7 +71,7 @@ pub mod flipper {
             let mut call = contract.call::<Flipper>();
 
             let get = call.get();
-            let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await;
+            let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await?;
             assert!(matches!(get_res.return_value(), false));
 
             // when
@@ -84,7 +84,7 @@ pub mod flipper {
 
             // then
             let get = call.get();
-            let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await;
+            let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await?;
             assert!(matches!(get_res.return_value(), true));
 
             Ok(())
@@ -105,7 +105,7 @@ pub mod flipper {
 
             // then
             let get = call.get();
-            let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await;
+            let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await?;
             assert!(matches!(get_res.return_value(), false));
 
             Ok(())

--- a/integration-tests/lang-err-integration-tests/call-builder-delegate/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder-delegate/lib.rs
@@ -171,10 +171,13 @@ mod call_builder {
             let call = call_builder_call.invoke(code_hash, selector);
             let call_result = client.call(&origin, &call).dry_run().await;
 
-            assert!(call_result.is_err());
-            assert!(call_result
-                .debug_message()
-                .contains("Cross-contract call failed with CouldNotReadInput"));
+            if let Err(ink_e2e::Error::CallDryRun(dry_run)) = call_result {
+                assert!(dry_run
+                    .debug_message
+                    .contains("Cross-contract call failed with CouldNotReadInput"));
+            } else {
+                panic!("Expected call to fail");
+            }
 
             Ok(())
         }

--- a/integration-tests/lang-err-integration-tests/call-builder/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder/lib.rs
@@ -258,10 +258,12 @@ mod call_builder {
             let call_result = client.call(&origin, &call).dry_run().await;
 
             if let Err(ink_e2e::Error::CallDryRun(dry_run)) = call_result {
-                assert!(dry_run
-                            .debug_message
-                            .contains("Cross-contract call failed with CouldNotReadInput"),
-                        "Call execution failed for an unexpected reason.");
+                assert!(
+                    dry_run
+                        .debug_message
+                        .contains("Cross-contract call failed with CouldNotReadInput"),
+                    "Call execution failed for an unexpected reason."
+                );
             } else {
                 panic!("Call execution should've failed, but didn't.");
             }

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
@@ -124,11 +124,9 @@ pub mod constructors_return_value {
                     &mut constructor,
                 )
                 .dry_run()
-                .await
-                .result
-                .expect("Instantiate dry run should succeed");
+                .await?;
 
-            let data = infallible_constructor_result.result.data;
+            let data = infallible_constructor_result.result.unwrap().data;
             let decoded_result = Result::<(), ink::LangError>::decode(&mut &data[..])
                 .expect("Failed to decode constructor Result");
             assert!(
@@ -200,7 +198,7 @@ pub mod constructors_return_value {
             let value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             assert_eq!(
@@ -224,14 +222,12 @@ pub mod constructors_return_value {
                     &mut constructor,
                 )
                 .dry_run()
-                .await
-                .result
-                .expect("Instantiate dry run should succeed");
+                .await?;
 
             let decoded_result = Result::<
                 Result<(), super::ConstructorError>,
                 ink::LangError,
-            >::decode(&mut &result.result.data[..])
+            >::decode(&mut &result.result.unwrap().data[..])
             .expect("Failed to decode fallible constructor Result");
 
             assert!(

--- a/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
+++ b/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
@@ -93,7 +93,7 @@ mod contract_ref {
 
             let get_check = call.get_check();
             let get_call_result =
-                client.call(&ink_e2e::alice(), &get_check).dry_run().await;
+                client.call(&ink_e2e::alice(), &get_check).dry_run().await?;
 
             let initial_value = get_call_result.return_value();
 
@@ -109,7 +109,7 @@ mod contract_ref {
             );
 
             let get_call_result =
-                client.call(&ink_e2e::alice(), &get_check).dry_run().await;
+                client.call(&ink_e2e::alice(), &get_check).dry_run().await?;
             let flipped_value = get_call_result.return_value();
             assert!(flipped_value != initial_value);
 
@@ -138,7 +138,7 @@ mod contract_ref {
 
             let get_check = call.get_check();
             let get_call_result =
-                client.call(&ink_e2e::bob(), &get_check).dry_run().await;
+                client.call(&ink_e2e::bob(), &get_check).dry_run().await?;
             let initial_value = get_call_result.return_value();
 
             assert!(initial_value);
@@ -170,8 +170,8 @@ mod contract_ref {
             );
 
             let contains_err_msg = match instantiate_result.unwrap_err() {
-                ink_e2e::Error::<ink::env::DefaultEnvironment>::InstantiateDryRun(dry_run) => {
-                    String::from_utf8_lossy(&dry_run.debug_message).contains(
+                ink_e2e::Error::InstantiateDryRun(dry_run) => {
+                    dry_run.debug_message.contains(
                         "Received an error from the Flipper constructor while instantiating Flipper FlipperError"
                     )
                 }

--- a/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
@@ -87,7 +87,7 @@ pub mod integration_flipper {
             let initial_value = client
                 .call(&ink_e2e::alice(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             let flip = call.flip();
@@ -104,7 +104,7 @@ pub mod integration_flipper {
             let flipped_value = client
                 .call(&ink_e2e::alice(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
             assert!(flipped_value != initial_value);
 
@@ -127,7 +127,7 @@ pub mod integration_flipper {
             let initial_value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             let err_flip = call.err_flip();
@@ -136,13 +136,13 @@ pub mod integration_flipper {
 
             assert!(matches!(
                 err_flip_call_result,
-                Err(ink_e2e::Error::<ink::env::DefaultEnvironment>::CallExtrinsic(_))
+                Err(ink_e2e::Error::CallExtrinsic(_))
             ));
 
             let flipped_value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
             assert!(flipped_value == initial_value);
 

--- a/integration-tests/mapping-integration-tests/lib.rs
+++ b/integration-tests/mapping-integration-tests/lib.rs
@@ -178,7 +178,7 @@ mod mapping_integration_tests {
             let balance = client
                 .call(&ink_e2e::alice(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             assert!(size.is_none());
@@ -218,7 +218,7 @@ mod mapping_integration_tests {
             let is_there = client
                 .call(&ink_e2e::bob(), &contains)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             assert!(is_there);
@@ -265,7 +265,7 @@ mod mapping_integration_tests {
             let balance = client
                 .call(&ink_e2e::charlie(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             assert_eq!(balance, Some(10_000));
@@ -311,7 +311,7 @@ mod mapping_integration_tests {
             let balance = client
                 .call(&ink_e2e::dave(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             assert_eq!(balance, None);
@@ -360,7 +360,7 @@ mod mapping_integration_tests {
             let is_there = client
                 .call(&ink_e2e::eve(), &contains)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             assert!(!is_there);
@@ -397,7 +397,7 @@ mod mapping_integration_tests {
             let expected_insert_result = client
                 .call(&ink_e2e::ferdie(), &insert)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
             let received_insert_result =
                 Err(crate::mapping_integration_tests::ContractError::ValueTooLarge);
@@ -407,7 +407,7 @@ mod mapping_integration_tests {
             let received_mapping_value = client
                 .call(&ink_e2e::ferdie(), &call.try_get_names())
                 .dry_run()
-                .await
+                .await?
                 .return_value();
             let expected_mapping_value = Some(Ok(names));
             assert_eq!(received_mapping_value, expected_mapping_value);

--- a/integration-tests/multi-contract-caller/lib.rs
+++ b/integration-tests/multi-contract-caller/lib.rs
@@ -164,7 +164,7 @@ mod multi_contract_caller {
             let value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
             assert_eq!(value, 1234);
             let change = call.change(6);
@@ -179,7 +179,7 @@ mod multi_contract_caller {
             let value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
             assert_eq!(value, 1234 + 6);
 
@@ -202,7 +202,7 @@ mod multi_contract_caller {
             let value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
             assert_eq!(value, 1234 + 6 - 3);
 

--- a/integration-tests/trait-dyn-cross-contract-calls/lib.rs
+++ b/integration-tests/trait-dyn-cross-contract-calls/lib.rs
@@ -107,7 +107,7 @@ mod e2e_tests {
         let value = client
             .call(&ink_e2e::alice(), &get)
             .dry_run()
-            .await
+            .await?
             .return_value();
         assert_eq!(value, 0);
 
@@ -126,7 +126,7 @@ mod e2e_tests {
         let value = client
             .call(&ink_e2e::alice(), &get)
             .dry_run()
-            .await
+            .await?
             .return_value();
         assert_eq!(value, 1);
 

--- a/integration-tests/upgradeable-contracts/delegator/lib.rs
+++ b/integration-tests/upgradeable-contracts/delegator/lib.rs
@@ -139,7 +139,7 @@ pub mod delegator {
             let call_get_result = client
                 .call(&origin, &call_get)
                 .dry_run()
-                .await
+                .await?
                 .return_value();
 
             // This fails

--- a/integration-tests/upgradeable-contracts/set-code-hash/lib.rs
+++ b/integration-tests/upgradeable-contracts/set-code-hash/lib.rs
@@ -84,7 +84,7 @@ pub mod incrementer {
             let mut call = contract.call::<Incrementer>();
 
             let get = call.get();
-            let get_res = client.call(&ink_e2e::alice(), &get).dry_run().await;
+            let get_res = client.call(&ink_e2e::alice(), &get).dry_run().await?;
             assert!(matches!(get_res.return_value(), 0));
 
             let inc = call.inc();
@@ -95,7 +95,7 @@ pub mod incrementer {
                 .expect("`inc` failed");
 
             let get = call.get();
-            let get_res = client.call(&ink_e2e::alice(), &get).dry_run().await;
+            let get_res = client.call(&ink_e2e::alice(), &get).dry_run().await?;
             assert!(matches!(get_res.return_value(), 1));
 
             // When
@@ -127,7 +127,7 @@ pub mod incrementer {
                 .expect("`inc` failed");
 
             let get = call.get();
-            let get_res = client.call(&ink_e2e::alice(), &get).dry_run().await;
+            let get_res = client.call(&ink_e2e::alice(), &get).dry_run().await?;
 
             // Remember, we updated our incrementer contract to increment by `4`.
             assert!(matches!(get_res.return_value(), 5));


### PR DESCRIPTION
Currently for dry runs we only get raw dispatch errors e.g. `ModuleError { index: 21, error: [22, 0, 0, 0],`. This PR will resolve the error message to a more useful e.g.`InstantiateDryRun(DryRunError { debug_message: "", error: Module(ModuleError(<Contracts::StorageDepositNotEnoughFunds>)) })`

The API for executing dry runs will be aligned with the transaction execution methods by returning a top level `Result`. The signatures for the `dry_run` methods are now:

```rust
pub async fn dry_run(&mut self) -> Result<CallDryRunResult<E, RetType>, B::Error>;
pub async fn dry_run(&mut self) -> Result<InstantiateDryRunResult<E>, B::Error>
```
`InstantiateDryRunResult` has been added in this PR to encapsulate the returned result, similar to the existing `CallDryRunResult`.

- [x] y/n | Does it introduce breaking changes?