### PR TITLE
Messages return `TypeSpec` directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [E2E] Allow testing with live-chain state - [#1949](https://github.com/paritytech/ink/pull/1949)
 - [E2E] Call builders and extra gas margin option - [#1917](https://github.com/paritytech/ink/pull/1917)
-- Make `set_code_hash` generic - [#1906](https://github.com/paritytech/ink/pull/1906)
+- Linter: `storage_never_freed` lint - [#1932](https://github.com/paritytech/ink/pull/1932)
+- Linter: `strict_balance_equality` lint - [#1914](https://github.com/paritytech/ink/pull/1914)
 - Clean E2E configuration parsing - [#1922](https://github.com/paritytech/ink/pull/1922)
+- Make `set_code_hash` generic - [#1906](https://github.com/paritytech/ink/pull/1906)
 
 ### Changed
+- Messages return `TypeSpec` directly - #[1999](https://github.com/paritytech/ink/pull/1999)
 - Fail when decoding from storage and not all bytes consumed - [#1897](https://github.com/paritytech/ink/pull/1897)
 - [E2E] resolve DispatchError error details for dry-runs - [#1944](https://github.com/paritytech/ink/pull/1994)
 
-### Added
-- Linter: `storage_never_freed` lint - [#1932](https://github.com/paritytech/ink/pull/1932)
-- Linter: `strict_balance_equality` lint - [#1914](https://github.com/paritytech/ink/pull/1914)
 
 ## Version 5.0.0-alpha
 

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -248,7 +248,8 @@ impl Metadata<'_> {
                 let ident = message.ident();
                 let args = message.inputs().map(Self::generate_dispatch_argument);
                 let cfg_attrs = message.get_cfg_attrs(span);
-                let ret_ty = Self::generate_return_type(Some(&message.wrapped_output()));
+                let ret_ty =
+                    Self::generate_message_return_type(&message.wrapped_output());
                 quote_spanned!(span =>
                     #( #cfg_attrs )*
                     ::ink::metadata::MessageSpec::from_label(::core::stringify!(#ident))
@@ -311,7 +312,7 @@ impl Metadata<'_> {
                         as #trait_path>::__ink_TraitInfo
                         as ::ink::reflect::TraitMessageInfo<#local_id>>::SELECTOR
                 }};
-                let ret_ty = Self::generate_return_type(Some(&message.wrapped_output()));
+                let ret_ty = Self::generate_message_return_type(&message.wrapped_output());
                 let label = [trait_ident.to_string(), message_ident.to_string()].join("::");
                 quote_spanned!(message_span=>
                     #( #cfg_attrs )*
@@ -333,19 +334,10 @@ impl Metadata<'_> {
     }
 
     /// Generates ink! metadata for the given return type.
-    fn generate_return_type(ret_ty: Option<&syn::Type>) -> TokenStream2 {
-        match ret_ty {
-            None => {
-                quote! {
-                    ::ink::metadata::ReturnTypeSpec::new(::core::option::Option::None)
-                }
-            }
-            Some(ty) => {
-                let type_spec = Self::generate_type_spec(ty);
-                quote! {
-                    ::ink::metadata::ReturnTypeSpec::new(#type_spec)
-                }
-            }
+    fn generate_message_return_type(ret_ty: &syn::Type) -> TokenStream2 {
+        let type_spec = Self::generate_type_spec(ret_ty);
+        quote! {
+            ::ink::metadata::ReturnTypeSpec::new(#type_spec)
         }
     }
 

--- a/crates/ink/codegen/src/generator/metadata.rs
+++ b/crates/ink/codegen/src/generator/metadata.rs
@@ -353,13 +353,13 @@ impl Metadata<'_> {
 
         quote_spanned!(span=>
             ::ink::metadata::ReturnTypeSpec::new(if #constructor_info::IS_RESULT {
-                ::core::option::Option::Some(::ink::metadata::TypeSpec::with_name_str::<
+                ::ink::metadata::TypeSpec::with_name_str::<
                     ::ink::ConstructorResult<::core::result::Result<(), #constructor_info::Error>>,
-                >("ink_primitives::ConstructorResult"))
+                >("ink_primitives::ConstructorResult")
             } else {
-                ::core::option::Option::Some(::ink::metadata::TypeSpec::with_name_str::<
+                ::ink::metadata::TypeSpec::with_name_str::<
                     ::ink::ConstructorResult<()>,
-                >("ink_primitives::ConstructorResult"))
+                >("ink_primitives::ConstructorResult")
             })
         )
     }

--- a/crates/ink/tests/return_type_metadata.rs
+++ b/crates/ink/tests/return_type_metadata.rs
@@ -106,7 +106,7 @@ mod tests {
         let message = metadata.spec().messages().iter().next().unwrap();
         assert_eq!("TraitDefinition::get_value", message.label());
 
-        let type_spec = message.return_type().opt_type().unwrap();
+        let type_spec = message.return_type().ret_type();
         let ty = resolve_type(&metadata, type_spec.ty().id);
         let (ok_ty, _) = extract_result(&metadata, ty);
 
@@ -119,7 +119,7 @@ mod tests {
         let constructor = metadata.spec().constructors().iter().next().unwrap();
 
         assert_eq!("try_new", constructor.label());
-        let type_spec = constructor.return_type().opt_type().unwrap();
+        let type_spec = constructor.return_type().ret_type();
         assert_eq!(
             "ink_primitives::ConstructorResult",
             format!("{}", type_spec.display_name())

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -1284,11 +1284,6 @@ where
     pub fn new(ty: <F as Form>::Type, display_name: DisplayName<F>) -> Self {
         Self { ty, display_name }
     }
-
-    // /// Creates a new type specification for a given type and display name.
-    // pub fn of_type_with_display_name<T: TypeInfo + 'static>(display_name:
-    // DisplayName<F>) -> Self {     Self { ty: meta_type::<T>(), display_name }
-    // }
 }
 
 /// Describes a pair of parameter label and type.
@@ -1448,7 +1443,7 @@ where
     ///
     /// ```no_run
     /// # use ink_metadata::{TypeSpec, ReturnTypeSpec};
-    /// <ReturnTypeSpec<scale_info::form::MetaForm>>::new(None); // no return type;
+    /// <ReturnTypeSpec<scale_info::form::MetaForm>>::new(TypeSpec::default()); // no return type;
     /// ```
     pub fn new<T>(ty: T) -> Self
     where

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -468,6 +468,7 @@ pub struct ConstructorSpecBuilder<F: Form, Selector, IsPayable, Returns> {
 impl<F> ConstructorSpec<F>
 where
     F: Form,
+    TypeSpec<F>: Default,
 {
     /// Creates a new constructor spec builder.
     pub fn from_label(
@@ -484,7 +485,7 @@ where
                 selector: Selector::default(),
                 payable: Default::default(),
                 args: Vec::new(),
-                return_type: ReturnTypeSpec::new(None),
+                return_type: ReturnTypeSpec::new(TypeSpec::default()),
                 docs: Vec::new(),
                 default: false,
             },
@@ -668,6 +669,7 @@ mod state {
 impl<F> MessageSpec<F>
 where
     F: Form,
+    TypeSpec<F>: Default,
 {
     /// Creates a new message spec builder.
     pub fn from_label(
@@ -686,7 +688,7 @@ where
                 mutates: false,
                 payable: false,
                 args: Vec::new(),
-                return_type: ReturnTypeSpec::new(None),
+                return_type: ReturnTypeSpec::new(TypeSpec::default()),
                 docs: Vec::new(),
                 default: false,
             },
@@ -1282,6 +1284,11 @@ where
     pub fn new(ty: <F as Form>::Type, display_name: DisplayName<F>) -> Self {
         Self { ty, display_name }
     }
+
+    // /// Creates a new type specification for a given type and display name.
+    // pub fn of_type_with_display_name<T: TypeInfo + 'static>(display_name:
+    // DisplayName<F>) -> Self {     Self { ty: meta_type::<T>(), display_name }
+    // }
 }
 
 /// Describes a pair of parameter label and type.
@@ -1417,7 +1424,7 @@ where
 #[must_use]
 pub struct ReturnTypeSpec<F: Form = MetaForm> {
     #[serde(rename = "type")]
-    opt_type: Option<TypeSpec<F>>,
+    ret_type: TypeSpec<F>,
 }
 
 impl IntoPortable for ReturnTypeSpec {
@@ -1425,9 +1432,7 @@ impl IntoPortable for ReturnTypeSpec {
 
     fn into_portable(self, registry: &mut Registry) -> Self::Output {
         ReturnTypeSpec {
-            opt_type: self
-                .opt_type
-                .map(|opt_type| opt_type.into_portable(registry)),
+            ret_type: self.ret_type.into_portable(registry),
         }
     }
 }
@@ -1435,6 +1440,7 @@ impl IntoPortable for ReturnTypeSpec {
 impl<F> ReturnTypeSpec<F>
 where
     F: Form,
+    TypeSpec<F>: Default,
 {
     /// Creates a new return type specification from the given type or `None`.
     ///
@@ -1446,16 +1452,16 @@ where
     /// ```
     pub fn new<T>(ty: T) -> Self
     where
-        T: Into<Option<TypeSpec<F>>>,
+        T: Into<TypeSpec<F>>,
     {
         Self {
-            opt_type: ty.into(),
+            ret_type: ty.into(),
         }
     }
 
-    /// Returns the optional return type
-    pub fn opt_type(&self) -> Option<&TypeSpec<F>> {
-        self.opt_type.as_ref()
+    /// Returns the return type
+    pub fn ret_type(&self) -> &TypeSpec<F> {
+        &self.ret_type
     }
 }
 

--- a/crates/metadata/src/tests.rs
+++ b/crates/metadata/src/tests.rs
@@ -24,11 +24,16 @@ use serde_json::json;
 #[test]
 fn spec_constructor_selector_must_serialize_to_hex() {
     // given
+    let selector_id = 123_456_789u32;
     let label = "foo";
     let cs = ConstructorSpec::from_label(label)
-        .selector(123_456_789u32.to_be_bytes())
+        .selector(selector_id.to_be_bytes())
         .payable(true)
-        .returns(ReturnTypeSpec::new(None))
+        .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+            ink_primitives::ConstructorResult<()>,
+        >(
+            "ink_primitives::ConstructorResult"
+        )))
         .done();
     let mut registry = Registry::new();
     let portable_spec = cs.into_portable(&mut registry);
@@ -45,7 +50,13 @@ fn spec_constructor_selector_must_serialize_to_hex() {
             "label": "foo",
             "payable": true,
             "selector": "0x075bcd15",
-            "returnType": null,
+            "returnType": {
+                "displayName": [
+                    "ink_primitives",
+                    "ConstructorResult"
+                ],
+                "type": 0
+            },
             "args": [],
             "docs": [],
             "default": false,
@@ -66,7 +77,11 @@ fn spec_contract_only_one_default_message_allowed() {
                     vec!["i32"].into_iter().map(AsRef::as_ref),
                 ))
                 .done()])
-            .returns(ReturnTypeSpec::new(None))
+            .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                ink_primitives::ConstructorResult<()>,
+            >(
+                "ink_primitives::ConstructorResult"
+            )))
             .docs(Vec::new())
             .done()])
         .messages(vec![
@@ -79,7 +94,11 @@ fn spec_contract_only_one_default_message_allowed() {
                         vec!["i32"].into_iter().map(AsRef::as_ref),
                     ))
                     .done()])
-                .returns(ReturnTypeSpec::new(None))
+                .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                    ink_primitives::MessageResult<()>,
+                >(
+                    "ink_primitives::MessageResult"
+                )))
                 .default(true)
                 .done(),
             MessageSpec::from_label("get")
@@ -116,7 +135,11 @@ fn spec_contract_only_one_default_constructor_allowed() {
                         vec!["i32"].into_iter().map(AsRef::as_ref),
                     ))
                     .done()])
-                .returns(ReturnTypeSpec::new(None))
+                .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                    ink_primitives::ConstructorResult<()>,
+                >(
+                    "ink_primitives::ConstructorResult"
+                )))
                 .docs(Vec::new())
                 .default(true)
                 .done(),
@@ -124,7 +147,11 @@ fn spec_contract_only_one_default_constructor_allowed() {
                 .selector([2u8, 34u8, 255u8, 24u8])
                 .payable(Default::default())
                 .args(Vec::new())
-                .returns(ReturnTypeSpec::new(None))
+                .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                    ink_primitives::ConstructorResult<()>,
+                >(
+                    "ink_primitives::ConstructorResult"
+                )))
                 .docs(Vec::new())
                 .default(true)
                 .done(),
@@ -138,7 +165,11 @@ fn spec_contract_only_one_default_constructor_allowed() {
                     vec!["i32"].into_iter().map(AsRef::as_ref),
                 ))
                 .done()])
-            .returns(ReturnTypeSpec::new(None))
+            .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                ink_primitives::MessageResult<()>,
+            >(
+                "ink_primitives::MessageResult"
+            )))
             .default(true)
             .done()])
         .events(Vec::new())
@@ -168,7 +199,11 @@ fn spec_contract_event_definition_exceeds_environment_topics_limit() {
                     vec!["i32"].into_iter().map(AsRef::as_ref),
                 ))
                 .done()])
-            .returns(ReturnTypeSpec::new(None))
+            .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                ink_primitives::ConstructorResult<()>,
+            >(
+                "ink_primitives::ConstructorResult"
+            )))
             .docs(Vec::new())
             .default(true)
             .done()])
@@ -181,7 +216,11 @@ fn spec_contract_event_definition_exceeds_environment_topics_limit() {
                     vec!["i32"].into_iter().map(AsRef::as_ref),
                 ))
                 .done()])
-            .returns(ReturnTypeSpec::new(None))
+            .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                ink_primitives::MessageResult<()>,
+            >(
+                "ink_primitives::MessageResult"
+            )))
             .default(true)
             .done()])
         .events(vec![
@@ -262,7 +301,11 @@ fn spec_contract_event_definition_signature_topic_collision() {
                     vec!["i32"].into_iter().map(AsRef::as_ref),
                 ))
                 .done()])
-            .returns(ReturnTypeSpec::new(None))
+            .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                ink_primitives::ConstructorResult<()>,
+            >(
+                "ink_primitives::ConstructorResult"
+            )))
             .docs(Vec::new())
             .default(true)
             .done()])
@@ -275,7 +318,11 @@ fn spec_contract_event_definition_signature_topic_collision() {
                     vec!["i32"].into_iter().map(AsRef::as_ref),
                 ))
                 .done()])
-            .returns(ReturnTypeSpec::new(None))
+            .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                ink_primitives::MessageResult<()>,
+            >(
+                "ink_primitives::MessageResult"
+            )))
             .default(true)
             .done()])
         .events(vec![
@@ -337,14 +384,22 @@ fn spec_contract_json() {
                         vec!["i32"].into_iter().map(AsRef::as_ref),
                     ))
                     .done()])
-                .returns(ReturnTypeSpec::new(None))
+                .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                    ink_primitives::ConstructorResult<()>,
+                >(
+                    "ink_primitives::ConstructorResult"
+                )))
                 .docs(Vec::new())
                 .done(),
             ConstructorSpec::from_label("default")
                 .selector([2u8, 34u8, 255u8, 24u8])
                 .payable(Default::default())
                 .args(Vec::new())
-                .returns(ReturnTypeSpec::new(None))
+                .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                    ink_primitives::ConstructorResult<()>,
+                >(
+                    "ink_primitives::ConstructorResult"
+                )))
                 .docs(Vec::new())
                 .default(true)
                 .done(),
@@ -352,11 +407,11 @@ fn spec_contract_json() {
                 .selector([6u8, 3u8, 55u8, 123u8])
                 .payable(Default::default())
                 .args(Vec::new())
-                .returns(ReturnTypeSpec::new(Some(TypeSpec::with_name_str::<
-                    Result<(), ()>,
+                .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                    ink_primitives::ConstructorResult<Result<(), ()>>,
                 >(
-                    "core::result::Result"
-                ))))
+                    "ink_primitives::ConstructorResult"
+                )))
                 .docs(Vec::new())
                 .done(),
         ])
@@ -370,7 +425,11 @@ fn spec_contract_json() {
                         vec!["i32"].into_iter().map(AsRef::as_ref),
                     ))
                     .done()])
-                .returns(ReturnTypeSpec::new(None))
+                .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+                    ink_primitives::MessageResult<()>,
+                >(
+                    "ink_primitives::MessageResult"
+                )))
                 .default(true)
                 .done(),
             MessageSpec::from_label("get")
@@ -460,7 +519,13 @@ fn spec_contract_json() {
                     "default": false,
                     "label": "new",
                     "payable": true,
-                    "returnType": null,
+                    "returnType": {
+                        "displayName": [
+                            "ink_primitives",
+                            "ConstructorResult"
+                        ],
+                        "type": 1
+                    },
                     "selector": "0x5ebd88d6"
                 },
                 {
@@ -469,7 +534,13 @@ fn spec_contract_json() {
                     "default": true,
                     "label": "default",
                     "payable": false,
-                    "returnType": null,
+                    "returnType": {
+                        "displayName": [
+                            "ink_primitives",
+                            "ConstructorResult"
+                        ],
+                        "type": 1
+                    },
                     "selector": "0x0222ff18"
                 },
                 {
@@ -480,11 +551,10 @@ fn spec_contract_json() {
                     "payable": false,
                     "returnType": {
                         "displayName": [
-                            "core",
-                            "result",
-                            "Result"
+                            "ink_primitives",
+                            "ConstructorResult"
                         ],
-                        "type": 1
+                        "type": 4
                     },
                     "selector": "0x0603377b"
                 }
@@ -495,39 +565,39 @@ fn spec_contract_json() {
                     "displayName":  [
                         "AccountId",
                     ],
-                    "type": 4,
+                    "type": 6,
                 },
                 "balance":  {
                     "displayName":  [
                         "Balance",
                     ],
-                    "type": 7,
+                    "type": 9,
                 },
                 "blockNumber":  {
                     "displayName":  [
                         "BlockNumber",
                     ],
-                    "type": 9,
+                    "type": 11,
                 },
                 "staticBufferSize": 16384,
                 "chainExtension":  {
                     "displayName":  [
                         "ChainExtension",
                     ],
-                    "type": 10,
+                    "type": 12,
                 },
                 "hash":  {
                     "displayName":  [
                         "Hash",
                     ],
-                    "type": 8,
+                    "type": 10,
                 },
                 "maxEventTopics": 4,
                 "timestamp":  {
                     "displayName":  [
                         "Timestamp",
                     ],
-                    "type": 7,
+                    "type": 9,
                 },
             },
             "events": [],
@@ -556,7 +626,13 @@ fn spec_contract_json() {
                     "mutates": true,
                     "payable": true,
                     "label": "inc",
-                    "returnType": null,
+                    "returnType": {
+                        "displayName": [
+                            "ink_primitives",
+                            "MessageResult"
+                        ],
+                        "type": 1
+                    },
                     "selector": "0xe7d0590f"
                 },
                 {
@@ -588,7 +664,11 @@ fn trim_docs() {
         .selector(123_456_789u32.to_be_bytes())
         .docs(vec![" foobar      "])
         .payable(Default::default())
-        .returns(ReturnTypeSpec::new(None))
+        .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+            ink_primitives::ConstructorResult<()>,
+        >(
+            "ink_primitives::ConstructorResult"
+        )))
         .done();
     let mut registry = Registry::new();
     let compact_spec = cs.into_portable(&mut registry);
@@ -604,7 +684,13 @@ fn trim_docs() {
         json!({
             "label": "foo",
             "payable": false,
-            "returnType": null,
+            "returnType": {
+                "displayName": [
+                    "ink_primitives",
+                    "ConstructorResult"
+                ],
+                "type": 0
+            },
             "selector": "0x075bcd15",
             "args": [],
             "docs": ["foobar"],
@@ -630,7 +716,11 @@ fn trim_docs_with_code() {
             " ```",
         ])
         .payable(Default::default())
-        .returns(ReturnTypeSpec::new(None))
+        .returns(ReturnTypeSpec::new(TypeSpec::with_name_str::<
+            ink_primitives::ConstructorResult<()>,
+        >(
+            "ink_primitives::ConstructorResult"
+        )))
         .done();
     let mut registry = Registry::new();
     let compact_spec = cs.into_portable(&mut registry);
@@ -646,7 +736,13 @@ fn trim_docs_with_code() {
         json!({
             "label": "foo",
             "payable": false,
-            "returnType": null,
+            "returnType": {
+                "displayName": [
+                    "ink_primitives",
+                    "ConstructorResult"
+                ],
+                "type": 0
+            },
             "selector": "0x075bcd15",
             "args": [],
             "docs": [
@@ -728,8 +824,12 @@ fn environment_spec() -> EnvironmentSpec<PortableForm> {
 /// Helper for creating a constructor spec at runtime
 fn runtime_constructor_spec() -> ConstructorSpec<PortableForm> {
     let path: Path<PortableForm> = Path::from_segments_unchecked(["FooType".to_string()]);
+    let lang_path: Path<PortableForm> = Path::from_segments_unchecked([
+        "ink_primitives".to_string(),
+        "ConstructorResult".to_string(),
+    ]);
     let spec = TypeSpec::new(123.into(), path);
-    let ret_spec = ReturnTypeSpec::new(None);
+    let ret_spec = ReturnTypeSpec::new(TypeSpec::new(456.into(), lang_path));
     let args = [MessageParamSpec::new("foo_arg".to_string())
         .of_type(spec)
         .done()];
@@ -794,7 +894,13 @@ fn construct_runtime_contract_spec() {
             "label": "foo",
             "selector": "0x00000000",
             "payable": true,
-            "returnType": null,
+            "returnType": {
+                "displayName": [
+                    "ink_primitives",
+                    "ConstructorResult"
+                ],
+                "type": 456
+            },
             "args": [
                 {
                     "label": "foo_arg",

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -62,3 +62,7 @@ pub type MessageResult<T> = ::core::result::Result<T, LangError>;
 
 /// The `Result` type for ink! constructors.
 pub type ConstructorResult<T> = ::core::result::Result<T, LangError>;
+
+// impl Into  {
+
+// }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -62,7 +62,3 @@ pub type MessageResult<T> = ::core::result::Result<T, LangError>;
 
 /// The `Result` type for ink! constructors.
 pub type ConstructorResult<T> = ::core::result::Result<T, LangError>;
-
-// impl Into  {
-
-// }


### PR DESCRIPTION
## Summary
Closes #1515 
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

Just a minor code refactoring.
Similarly to constructors, messages return `TypeSpec` directly due to the introduction of `LangError`

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
