### PR TITLE
`[ink_e2e]` update to new `drink` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Fail when decoding from storage and not all bytes consumed - [#1897](https://github.com/paritytech/ink/pull/1897)
 - [E2E] resolve DispatchError error details for dry-runs - [#1944](https://github.com/paritytech/ink/pull/1994)
+- [E2E] update to new `drink` API
 
 ### Added
 - Linter: `storage_never_freed` lint - [#1932](https://github.com/paritytech/ink/pull/1932)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Fail when decoding from storage and not all bytes consumed - [#1897](https://github.com/paritytech/ink/pull/1897)
 - [E2E] resolve DispatchError error details for dry-runs - [#1944](https://github.com/paritytech/ink/pull/1994)
-- [E2E] update to new `drink` API
+- [E2E] update to new `drink` API - [#2005](https://github.com/paritytech/ink/pull/2005)
 
 ### Added
 - Linter: `storage_never_freed` lint - [#1932](https://github.com/paritytech/ink/pull/1932)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ cfg-if = { version = "1.0" }
 contract-build = { version = "3.2.0" }
 darling = { version = "0.20.3" }
 derive_more = { version = "0.99.17", default-features = false }
-drink = { version = "=0.6.0" }
+drink = { version = "=0.8.2" }
 either = { version = "1.5", default-features = false }
 funty = { version = "2.0.0" }
 heck = { version = "0.4.0" }

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -67,8 +67,8 @@ pub trait ChainBackend {
         amount: Self::Balance,
     ) -> Keypair;
 
-    /// Returns the balance of `actor`.
-    async fn balance(
+    /// Returns the free balance of `account`.
+    async fn free_balance(
         &mut self,
         account: Self::AccountId,
     ) -> Result<Self::Balance, Self::Error>;

--- a/crates/e2e/src/drink_client.rs
+++ b/crates/e2e/src/drink_client.rs
@@ -240,7 +240,7 @@ where
             salt(),
             keypair_to_account(caller),
             gas_limit,
-            storage_deposit_limit.map(ContractsBalanceOf::<Runtime>::from),
+            storage_deposit_limit,
         );
 
         let account_id_raw = match &result.result {

--- a/crates/e2e/src/drink_client.rs
+++ b/crates/e2e/src/drink_client.rs
@@ -129,7 +129,7 @@ impl<AccountId: AsRef<[u8; 32]> + Send, Hash, Runtime> ChainBackend
 where
     Runtime: RuntimeT + drink::pallet_balances::Config,
     AccountIdFor<Runtime>: From<[u8; 32]>,
-    BalanceOf<Runtime>: From<u128>,
+    BalanceOf<Runtime>: From<u128> + Into<u128>,
 {
     type AccountId = AccountId;
     type Balance = u128;
@@ -150,12 +150,12 @@ where
         Keypair::from_seed(seed).expect("Failed to create keypair")
     }
 
-    async fn balance(
+    async fn free_balance(
         &mut self,
         account: Self::AccountId,
     ) -> Result<Self::Balance, Self::Error> {
         let account = AccountIdFor::<Runtime>::from(*account.as_ref());
-        Ok(self.sandbox.balance(&account))
+        Ok(self.sandbox.free_balance(&account).into())
     }
 
     async fn runtime_call<'a>(
@@ -412,7 +412,7 @@ impl<
     > E2EBackend<E> for Client<AccountId, Hash, Runtime>
 where
     AccountIdFor<Runtime>: From<[u8; 32]> + AsRef<[u8; 32]>,
-    BalanceOf<Runtime>: From<u128>,
+    BalanceOf<Runtime>: From<u128> + Into<u128>,
 {
 }
 

--- a/crates/e2e/src/drink_client.rs
+++ b/crates/e2e/src/drink_client.rs
@@ -124,7 +124,7 @@ where
         for account in accounts.into_iter() {
             sandbox
                 .mint_into(account, TOKENS.into())
-                .expect(&format!("Failed to mint {} tokens", TOKENS));
+                .unwrap_or_else(|_| panic!("Failed to mint {} tokens", TOKENS));
         }
     }
 }
@@ -149,7 +149,7 @@ where
         let (pair, seed) = Pair::generate();
 
         self.sandbox
-            .mint_into(pair.public().0.into(), amount.into())
+            .mint_into(pair.public().0.into(), amount)
             .expect("Failed to mint tokens");
 
         Keypair::from_seed(seed).expect("Failed to create keypair")
@@ -160,7 +160,7 @@ where
         account: Self::AccountId,
     ) -> Result<Self::Balance, Self::Error> {
         let account = AccountIdFor::<Runtime>::from(*account.as_ref());
-        Ok(self.sandbox.free_balance(&account).into())
+        Ok(self.sandbox.free_balance(&account))
     }
 
     async fn runtime_call<'a>(

--- a/crates/e2e/src/drink_client.rs
+++ b/crates/e2e/src/drink_client.rs
@@ -214,8 +214,7 @@ impl<
                 AccountId = AccountId,
                 Balance = ContractsBalanceOf<Runtime>,
                 Hash = Hash,
-            > + Send
-            + 'static,
+            > + 'static,
     > BuilderClient<E> for Client<AccountId, Hash, Runtime>
 where
     AccountIdFor<Runtime>: From<[u8; 32]> + AsRef<[u8; 32]>,
@@ -426,8 +425,7 @@ impl<
                 AccountId = AccountId,
                 Balance = ContractsBalanceOf<Runtime>,
                 Hash = Hash,
-            > + Send
-            + 'static,
+            > + 'static,
     > E2EBackend<E> for Client<AccountId, Hash, Runtime>
 where
     AccountIdFor<Runtime>: From<[u8; 32]> + AsRef<[u8; 32]>,

--- a/crates/e2e/src/subxt_client.rs
+++ b/crates/e2e/src/subxt_client.rs
@@ -371,7 +371,7 @@ where
         keypair
     }
 
-    async fn balance(
+    async fn free_balance(
         &mut self,
         account: Self::AccountId,
     ) -> Result<Self::Balance, Self::Error> {

--- a/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
@@ -81,8 +81,8 @@ impl ContractRef<'_> {
             .storage()
             .attrs()
             .iter()
-            .filter(syn::Attribute::is_doc_attribute)
-            .cloned();
+            .cloned()
+            .filter(syn::Attribute::is_doc_attribute);
         let storage_ident = self.contract.module().storage().ident();
         let ref_ident = self.generate_contract_ref_ident();
         quote_spanned!(span=>

--- a/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
@@ -81,8 +81,8 @@ impl ContractRef<'_> {
             .storage()
             .attrs()
             .iter()
-            .cloned()
-            .filter(syn::Attribute::is_doc_attribute);
+            .filter(syn::Attribute::is_doc_attribute)
+            .cloned();
         let storage_ident = self.contract.module().storage().ident();
         let ref_ident = self.generate_contract_ref_ident();
         quote_spanned!(span=>

--- a/integration-tests/call-runtime/lib.rs
+++ b/integration-tests/call-runtime/lib.rs
@@ -167,11 +167,11 @@ mod runtime_call {
             let receiver: AccountId = default_accounts::<DefaultEnvironment>().bob;
 
             let contract_balance_before = client
-                .balance(contract.account_id)
+                .free_balance(contract.account_id)
                 .await
                 .expect("Failed to get account balance");
             let receiver_balance_before = client
-                .balance(receiver)
+                .free_balance(receiver)
                 .await
                 .expect("Failed to get account balance");
 
@@ -189,11 +189,11 @@ mod runtime_call {
 
             // then
             let contract_balance_after = client
-                .balance(contract.account_id)
+                .free_balance(contract.account_id)
                 .await
                 .expect("Failed to get account balance");
             let receiver_balance_after = client
-                .balance(receiver)
+                .free_balance(receiver)
                 .await
                 .expect("Failed to get account balance");
 

--- a/integration-tests/contract-transfer/lib.rs
+++ b/integration-tests/contract-transfer/lib.rs
@@ -236,7 +236,7 @@ pub mod give_me {
             let mut call = contract.call::<GiveMe>();
 
             let balance_before: Balance = client
-                .balance(contract.account_id.clone())
+                .free_balance(contract.account_id.clone())
                 .await
                 .expect("getting balance failed");
 
@@ -253,7 +253,7 @@ pub mod give_me {
             assert!(call_res.debug_message().contains("requested value: 120\n"));
 
             let balance_after: Balance = client
-                .balance(contract.account_id.clone())
+                .free_balance(contract.account_id.clone())
                 .await
                 .expect("getting balance failed");
             assert_eq!(balance_before - balance_after, 120);


### PR DESCRIPTION
Updates the `drink` backend to be compatible with the latest API, specifically with changes done as part of https://github.com/inkdevhub/drink/pull/84 by @pgherveou 

:warning: **breaking** change for e2e tests :warning: 
