### PR TITLE
:t-rex: fix ui test

### DIFF
--- a/crates/ink/tests/ui/event/fail/generics.rs
+++ b/crates/ink/tests/ui/event/fail/generics.rs
@@ -1,4 +1,4 @@
-#[derive(ink::Event, scale::Encode)]
+#[derive(ink::Event)]
 pub struct Event<T> {
     #[ink(topic)]
     pub topic: T,


### PR DESCRIPTION
Removes redundant `scale::Derive` which could not be resolved, now `parity_scale_codec` is reexported. Uncovered by #2007 