### PR TITLE
Add branch coverage reports to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,6 @@ jobs:
           # The `cargo-taurpalin` coverage reporting tool seems to have better code instrumentation and thus
           # produces better results for Rust codebases in general. However, unlike `grcov` it requires
           # running docker with `--security-opt seccomp=unconfined` which is why we use `grcov` instead.
-          CODECOV_P_TOKEN:               ${{ secrets.CODECOV_P_TOKEN }}
           CODECOV_L_TOKEN:               ${{ secrets.CODECOV_L_TOKEN }}
         run: |
           # RUSTFLAGS are the cause target cache can't be used here
@@ -443,7 +442,7 @@ jobs:
           grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm --branch \
             --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-w-branch.info
           rust-covfix lcov-w-branch.info --output lcov-w-branch-fixed.info
-          codecov --token "$CODECOV_P_TOKEN" --file lcov-w-branch-fixed.info --nonZero
+          codecov --token "$CODECOV_L_TOKEN" --file lcov-w-branch-fixed.info --nonZero
           # lines coverage
           grcov . --binary-path ./target/debug/ --source-dir . --output-type lcov --llvm \
             --ignore-not-existing --ignore "/*" --ignore "tests/*" --output-path lcov-lines.info


### PR DESCRIPTION
## Summary
Related #1454
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

Add branch coverage reports to CI

## Description
We had two tokens to report code coverage: one for branch coverage and another for line coverage. The tokens correspond to the following URLs:
```
https://app.codecov.io/gh/paritytech-ci/ink/pulls
https://app.codecov.io/gh/paritytech/ink/pulls
```
However, the bot responsible for reporting only uses one URL, so branch coverage was not used.

Add branches reports:
```
@@            Coverage Diff             @@
##           master    #2010      +/-   ##
==========================================
- Coverage   53.37%   53.35%   -0.02%     
==========================================
  Files         220      220              
  Lines        6884     6884              
  Branches        0     3054    +3054     
==========================================
- Hits         3674     3673       -1     
- Misses       3210     3211       +1     
```
## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
