### PR TITLE
`5.0.0-rc` Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## Version 5.0.0-rc
+
 ### Added
 - Allow mutable parameters in messages - [#2004](https://github.com/paritytech/ink/pull/2004)
 - [E2E] Allow testing with live-chain state - [#1949](https://github.com/paritytech/ink/pull/1949)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `set_code_hash` generic - [#1906](https://github.com/paritytech/ink/pull/1906)
 
 ### Changed
-- Messages return `TypeSpec` directly - #[1999](https://github.com/paritytech/ink/pull/1999)
+- Messages return `TypeSpec` directly - [#1999](https://github.com/paritytech/ink/pull/1999)
 - Fail when decoding from storage and not all bytes consumed - [#1897](https://github.com/paritytech/ink/pull/1897)
 - [E2E] resolve DispatchError error details for dry-runs - [#1944](https://github.com/paritytech/ink/pull/1994)
 - [E2E] update to new `drink` API - [#2005](https://github.com/paritytech/ink/pull/2005)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,15 +2496,15 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "ink"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "derive_more",
- "ink_env 5.0.0-alpha",
+ "ink_env 5.0.0-rc",
  "ink_ir",
  "ink_macro",
- "ink_metadata 5.0.0-alpha",
- "ink_prelude 5.0.0-alpha",
- "ink_primitives 5.0.0-alpha",
+ "ink_metadata 5.0.0-rc",
+ "ink_prelude 5.0.0-rc",
+ "ink_primitives 5.0.0-rc",
  "ink_storage",
  "parity-scale-codec",
  "scale-info",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "ink_allocator"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "cfg-if",
  "quickcheck",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "ink_codegen"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "blake2",
  "derive_more",
@@ -2539,7 +2539,7 @@ dependencies = [
  "heck",
  "impl-serde",
  "ink_ir",
- "ink_primitives 5.0.0-alpha",
+ "ink_primitives 5.0.0-rc",
  "itertools 0.12.0",
  "parity-scale-codec",
  "proc-macro2",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "ink_e2e"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "cargo_metadata 0.18.1",
  "contract-build",
@@ -2560,8 +2560,8 @@ dependencies = [
  "impl-serde",
  "ink",
  "ink_e2e_macro",
- "ink_env 5.0.0-alpha",
- "ink_primitives 5.0.0-alpha",
+ "ink_env 5.0.0-rc",
+ "ink_primitives 5.0.0-rc",
  "jsonrpsee",
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "ink_e2e_macro"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "darling 0.20.3",
  "derive_more",
@@ -2614,11 +2614,11 @@ dependencies = [
 
 [[package]]
 name = "ink_engine"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "blake2",
  "derive_more",
- "ink_primitives 5.0.0-alpha",
+ "ink_primitives 5.0.0-rc",
  "parity-scale-codec",
  "secp256k1 0.28.0",
  "sha2 0.10.8",
@@ -2655,18 +2655,18 @@ dependencies = [
 
 [[package]]
 name = "ink_env"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "blake2",
  "cfg-if",
  "const_env",
  "derive_more",
  "ink",
- "ink_allocator 5.0.0-alpha",
- "ink_engine 5.0.0-alpha",
- "ink_prelude 5.0.0-alpha",
- "ink_primitives 5.0.0-alpha",
- "ink_storage_traits 5.0.0-alpha",
+ "ink_allocator 5.0.0-rc",
+ "ink_engine 5.0.0-rc",
+ "ink_prelude 5.0.0-rc",
+ "ink_primitives 5.0.0-rc",
+ "ink_storage_traits 5.0.0-rc",
  "num-traits",
  "parity-scale-codec",
  "paste",
@@ -2683,11 +2683,11 @@ dependencies = [
 
 [[package]]
 name = "ink_ir"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "blake2",
  "either",
- "ink_prelude 5.0.0-alpha",
+ "ink_prelude 5.0.0-rc",
  "itertools 0.12.0",
  "proc-macro2",
  "quote",
@@ -2696,15 +2696,15 @@ dependencies = [
 
 [[package]]
 name = "ink_macro"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "ink",
  "ink_codegen",
- "ink_env 5.0.0-alpha",
+ "ink_env 5.0.0-rc",
  "ink_ir",
- "ink_metadata 5.0.0-alpha",
- "ink_prelude 5.0.0-alpha",
- "ink_primitives 5.0.0-alpha",
+ "ink_metadata 5.0.0-rc",
+ "ink_prelude 5.0.0-rc",
+ "ink_primitives 5.0.0-rc",
  "ink_storage",
  "parity-scale-codec",
  "proc-macro2",
@@ -2730,12 +2730,12 @@ dependencies = [
 
 [[package]]
 name = "ink_metadata"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "derive_more",
  "impl-serde",
- "ink_prelude 5.0.0-alpha",
- "ink_primitives 5.0.0-alpha",
+ "ink_prelude 5.0.0-rc",
+ "ink_primitives 5.0.0-rc",
  "linkme",
  "pretty_assertions",
  "scale-info",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "ink_prelude"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "cfg-if",
 ]
@@ -2777,10 +2777,10 @@ dependencies = [
 
 [[package]]
 name = "ink_primitives"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "derive_more",
- "ink_prelude 5.0.0-alpha",
+ "ink_prelude 5.0.0-rc",
  "parity-scale-codec",
  "scale-decode",
  "scale-encode",
@@ -2790,17 +2790,17 @@ dependencies = [
 
 [[package]]
 name = "ink_storage"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
  "array-init",
  "cfg-if",
  "derive_more",
  "ink",
- "ink_env 5.0.0-alpha",
- "ink_metadata 5.0.0-alpha",
- "ink_prelude 5.0.0-alpha",
- "ink_primitives 5.0.0-alpha",
- "ink_storage_traits 5.0.0-alpha",
+ "ink_env 5.0.0-rc",
+ "ink_metadata 5.0.0-rc",
+ "ink_prelude 5.0.0-rc",
+ "ink_primitives 5.0.0-rc",
+ "ink_storage_traits 5.0.0-rc",
  "itertools 0.12.0",
  "parity-scale-codec",
  "quickcheck",
@@ -2823,11 +2823,11 @@ dependencies = [
 
 [[package]]
 name = "ink_storage_traits"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 dependencies = [
- "ink_metadata 5.0.0-alpha",
- "ink_prelude 5.0.0-alpha",
- "ink_primitives 5.0.0-alpha",
+ "ink_metadata 5.0.0-rc",
+ "ink_prelude 5.0.0-rc",
+ "ink_primitives 5.0.0-rc",
  "parity-scale-codec",
  "paste",
  "scale-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
+dependencies = [
+ "base64 0.21.5",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.43.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "bounded-collections"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,20 +758,6 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "cargo_metadata"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
@@ -802,6 +828,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-targets 0.48.5",
 ]
 
@@ -958,43 +985,49 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "contract-build"
-version = "3.2.0"
+version = "4.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1c9e0b024481d35d46e1043323ec8c1dc8b57f4a08c4ee5392c2aefb75859b"
+checksum = "d4998e19b98b55fb9c1b5f1c93bb1678ab64c96eb9216b4a10fdb9a521717fcf"
 dependencies = [
  "anyhow",
  "blake2",
- "cargo_metadata 0.15.4",
+ "bollard",
+ "cargo_metadata",
  "clap",
  "colored",
  "contract-metadata",
+ "crossterm",
  "duct",
  "heck",
  "hex",
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
+ "regex",
  "rustc_version",
  "semver",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.25.0",
  "tempfile",
  "term_size",
- "toml 0.7.8",
+ "tokio",
+ "tokio-stream",
+ "toml",
  "tracing",
  "url",
+ "users",
  "walkdir",
  "wasm-opt",
- "which 4.4.2",
+ "which",
  "zip",
 ]
 
 [[package]]
 name = "contract-metadata"
-version = "3.2.0"
+version = "4.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a88f62795e84270742796456086ddeebfa4cbd4e56f02777f792192d666725"
+checksum = "44f0ed28c6af5080a0cf0e4b943fc7eeb42731aee2e2154735b8c5ddd19cc412"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -1006,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "3.2.0"
+version = "4.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91279ca8e8a05dec90febb12a9529b310018c623adaebe691d9b2e8cc115a182"
+checksum = "af5ec69b9877e7565a9bb95040358149637714d0a422f67be9eff5a42c1ee86e"
 dependencies = [
  "anyhow",
  "base58",
@@ -1016,10 +1049,10 @@ dependencies = [
  "contract-metadata",
  "escape8259",
  "hex",
- "indexmap 1.9.3",
- "ink_env 4.3.0",
- "ink_metadata 4.3.0",
- "itertools 0.10.5",
+ "indexmap 2.1.0",
+ "ink_env 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_metadata 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.12.0",
  "nom",
  "nom-supreme",
  "parity-scale-codec",
@@ -1027,6 +1060,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
+ "strsim",
  "thiserror",
  "tracing",
 ]
@@ -1115,6 +1149,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1367,6 +1426,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,7 +1535,7 @@ dependencies = [
  "regex",
  "syn 2.0.39",
  "termcolor",
- "toml 0.8.8",
+ "toml",
  "walkdir",
 ]
 
@@ -1478,9 +1547,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bda335ff7a6c551a1f043b077c9b9ed50646321d2ccb04e6f0f0c214fcc525"
+checksum = "2c67a3581586495c81a0347a667f6ed5ca69af0125f3a3a138e48d4d0ee4201b"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1505,11 +1574,11 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a12a40a8a30ee8204d0dd0565ef59f9a50d7bfeea6918710424bda61904f5a"
+checksum = "9425dcc749a80945d760092eec0ec91ed1c6d751dfa0eb8dba899b005c6cfb88"
 dependencies = [
- "cargo_metadata 0.18.1",
+ "cargo_metadata",
  "contract-build",
  "contract-metadata",
  "convert_case 0.6.0",
@@ -2375,6 +2444,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2486,6 +2568,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -2513,20 +2596,20 @@ dependencies = [
 
 [[package]]
 name = "ink_allocator"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870914970470fd77a3f42d3c5d1918b562817af127fd063ee8b1d9fbf59aa1fe"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "ink_allocator"
 version = "5.0.0-rc"
 dependencies = [
  "cfg-if",
  "quickcheck",
  "quickcheck_macros",
+]
+
+[[package]]
+name = "ink_allocator"
+version = "5.0.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c1d2eddb445b3ef076dacaa9968a7ff5b80ad5b9b724966fab66a8f4e48bde4"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2553,7 +2636,7 @@ dependencies = [
 name = "ink_e2e"
 version = "5.0.0-rc"
 dependencies = [
- "cargo_metadata 0.18.1",
+ "cargo_metadata",
  "contract-build",
  "drink",
  "funty",
@@ -2580,7 +2663,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "wasm-instrument",
- "which 5.0.0",
+ "which",
 ]
 
 [[package]]
@@ -2599,21 +2682,6 @@ dependencies = [
 
 [[package]]
 name = "ink_engine"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722ec3a5eb557124b001c60ff8f961079f6d566af643edea579f152b15822fe5"
-dependencies = [
- "blake2",
- "derive_more",
- "ink_primitives 4.3.0",
- "parity-scale-codec",
- "secp256k1 0.27.0",
- "sha2 0.10.8",
- "sha3",
-]
-
-[[package]]
-name = "ink_engine"
 version = "5.0.0-rc"
 dependencies = [
  "blake2",
@@ -2626,31 +2694,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "ink_env"
-version = "4.3.0"
+name = "ink_engine"
+version = "5.0.0-rc"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584e73bc0982f6f1a067bb63ebc75262f6dc54ed2a17060efa73eaba84dc9308"
+checksum = "b99aae25c6820d9e9dae12f79df79a10cba3c961fe1204a68fefaf72f9ae7b14"
 dependencies = [
- "arrayref",
  "blake2",
- "cfg-if",
  "derive_more",
- "ink_allocator 4.3.0",
- "ink_engine 4.3.0",
- "ink_prelude 4.3.0",
- "ink_primitives 4.3.0",
- "ink_storage_traits 4.3.0",
- "num-traits",
+ "ink_primitives 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
- "paste",
- "rlibc",
- "scale-decode",
- "scale-encode",
- "scale-info",
- "secp256k1 0.27.0",
+ "secp256k1 0.28.0",
  "sha2 0.10.8",
  "sha3",
- "static_assertions",
 ]
 
 [[package]]
@@ -2667,6 +2722,35 @@ dependencies = [
  "ink_prelude 5.0.0-rc",
  "ink_primitives 5.0.0-rc",
  "ink_storage_traits 5.0.0-rc",
+ "num-traits",
+ "parity-scale-codec",
+ "paste",
+ "rlibc",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "schnorrkel 0.11.3",
+ "secp256k1 0.28.0",
+ "sha2 0.10.8",
+ "sha3",
+ "static_assertions",
+]
+
+[[package]]
+name = "ink_env"
+version = "5.0.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8f814ac18100f5ba3d265fbc29e1639325660571883184bedf31dcfecd2428"
+dependencies = [
+ "blake2",
+ "cfg-if",
+ "const_env",
+ "derive_more",
+ "ink_allocator 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_engine 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_prelude 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_primitives 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_storage_traits 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits",
  "parity-scale-codec",
  "paste",
@@ -2716,20 +2800,6 @@ dependencies = [
 
 [[package]]
 name = "ink_metadata"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fddff95ce3e01f42002fdaf96edda691dbccb08c9ae76d7101daa1fa634e601"
-dependencies = [
- "derive_more",
- "impl-serde",
- "ink_prelude 4.3.0",
- "ink_primitives 4.3.0",
- "scale-info",
- "serde",
-]
-
-[[package]]
-name = "ink_metadata"
 version = "5.0.0-rc"
 dependencies = [
  "derive_more",
@@ -2745,12 +2815,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "ink_prelude"
-version = "4.3.0"
+name = "ink_metadata"
+version = "5.0.0-rc"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8cfdf91d2b442f08efb34dd3780fd6fbd3d033f63b42f62684fe47534948ef6"
+checksum = "75859c7142101f3ad30a763fd0e5468df164e3d424086df8de40531fb54940f3"
 dependencies = [
- "cfg-if",
+ "derive_more",
+ "impl-serde",
+ "ink_prelude 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_primitives 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "linkme",
+ "scale-info",
+ "schemars",
+ "serde",
 ]
 
 [[package]]
@@ -2761,13 +2838,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "ink_primitives"
-version = "4.3.0"
+name = "ink_prelude"
+version = "5.0.0-rc"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6414bcad12ebf0c3abbbb192a09e4d06e22f662cf3e19545204e1b0684be12a1"
+checksum = "fc3fbd55e0cf78e456ad4a92558d55b577bf65944bb37bf7debb8f03ed66a47b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ink_primitives"
+version = "5.0.0-rc"
 dependencies = [
  "derive_more",
- "ink_prelude 4.3.0",
+ "ink_prelude 5.0.0-rc",
  "parity-scale-codec",
  "scale-decode",
  "scale-encode",
@@ -2778,9 +2862,11 @@ dependencies = [
 [[package]]
 name = "ink_primitives"
 version = "5.0.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c976554c1bd075c6722d0f30cc3a8337b7ebaf487b95a40c9e81097d995f921"
 dependencies = [
  "derive_more",
- "ink_prelude 5.0.0-rc",
+ "ink_prelude 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "scale-decode",
  "scale-encode",
@@ -2810,19 +2896,6 @@ dependencies = [
 
 [[package]]
 name = "ink_storage_traits"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8dcb50f70377ac35c28d63b06383a0a3cbb79542ea4cdc5b00e3e2b3de4a549"
-dependencies = [
- "ink_metadata 4.3.0",
- "ink_prelude 4.3.0",
- "ink_primitives 4.3.0",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "ink_storage_traits"
 version = "5.0.0-rc"
 dependencies = [
  "ink_metadata 5.0.0-rc",
@@ -2830,6 +2903,19 @@ dependencies = [
  "ink_primitives 5.0.0-rc",
  "parity-scale-codec",
  "paste",
+ "scale-info",
+]
+
+[[package]]
+name = "ink_storage_traits"
+version = "5.0.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a469c01b48282a459130ca72a75e57feedbb69ab151639f532156d10d574353"
+dependencies = [
+ "ink_metadata 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_prelude 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_primitives 5.0.0-rc (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec",
  "scale-info",
 ]
 
@@ -3374,6 +3460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -3891,6 +3978,12 @@ dependencies = [
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -4756,12 +4849,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+dependencies = [
+ "base64 0.21.5",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.1.0",
+ "serde",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -4840,6 +4972,27 @@ checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
 ]
 
 [[package]]
@@ -5281,7 +5434,7 @@ dependencies = [
  "lazy_static",
  "sp-core",
  "sp-runtime",
- "strum",
+ "strum 0.24.1",
 ]
 
 [[package]]
@@ -5604,7 +5757,16 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.3",
 ]
 
 [[package]]
@@ -5618,6 +5780,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -5891,6 +6066,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tiny-bip39"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5999,18 +6203,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
@@ -6037,8 +6229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.1.0",
- "serde",
- "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -6347,6 +6537,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6475,14 +6675,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt"
-version = "0.113.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a2799e08026234b07b44da6363703974e75be21430cef00756bbc438c8ff8a"
+checksum = "fc942673e7684671f0c5708fc18993569d184265fd5223bb51fc8e5b9b6cfd52"
 dependencies = [
  "anyhow",
  "libc",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "tempfile",
  "thiserror",
  "wasm-opt-cxx-sys",
@@ -6491,9 +6691,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.113.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d26f86d1132245e8bcea8fac7f02b10fb885b6696799969c94d7d3c14db5e1"
+checksum = "8c57b28207aa724318fcec6575fe74803c23f6f266fce10cbc9f3f116762f12e"
 dependencies = [
  "anyhow",
  "cxx",
@@ -6503,9 +6703,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.113.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497d069cd3420cdd52154a320b901114a20946878e2de62c670f9d906e472370"
+checksum = "8a1cce564dc768dacbdb718fc29df2dba80bd21cb47d8f77ae7e3d95ceb98cbe"
 dependencies = [
  "anyhow",
  "cc",
@@ -6740,18 +6940,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74a4c2488d058326466e086a43f5d4ea448241a8d0975e3eb0642c0828be1eb3"
 dependencies = [
  "wast",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.25",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ homepage = "https://www.parity.io/"
 keywords = ["wasm", "parity", "webassembly", "blockchain", "edsl"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/ink"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 
 [workspace.dependencies]
 arrayref = { version = "0.3" }
@@ -89,19 +89,19 @@ sp-runtime = { version = "26.0.0", default-features = false }
 sp-weights = { version = "22.0.0", default-features = false }
 
 # Local dependencies
-ink = { version = "=5.0.0-alpha", path = "crates/ink", default-features = false }
-ink_allocator = { version = "=5.0.0-alpha", path = "crates/allocator", default-features = false }
-ink_codegen = { version = "=5.0.0-alpha", path = "crates/ink/codegen", default-features = false }
-ink_e2e_macro = { version = "=5.0.0-alpha", path = "crates/e2e/macro", default-features = false }
-ink_engine = { version = "=5.0.0-alpha", path = "crates/engine", default-features = false }
-ink_env = { version = "=5.0.0-alpha", path = "crates/env", default-features = false }
-ink_ir = { version = "=5.0.0-alpha", path = "crates/ink/ir", default-features = false }
-ink_macro = { version = "=5.0.0-alpha", path = "crates/ink/macro", default-features = false }
-ink_metadata = { version = "=5.0.0-alpha", path = "crates/metadata", default-features = false }
-ink_prelude = { version = "=5.0.0-alpha", path = "crates/prelude", default-features = false }
-ink_primitives = { version = "=5.0.0-alpha", path = "crates/primitives", default-features = false }
-ink_storage = { version = "=5.0.0-alpha", path = "crates/storage", default-features = false }
-ink_storage_traits = { version = "=5.0.0-alpha", path = "crates/storage/traits", default-features = false }
+ink = { version = "=5.0.0-rc", path = "crates/ink", default-features = false }
+ink_allocator = { version = "=5.0.0-rc", path = "crates/allocator", default-features = false }
+ink_codegen = { version = "=5.0.0-rc", path = "crates/ink/codegen", default-features = false }
+ink_e2e_macro = { version = "=5.0.0-rc", path = "crates/e2e/macro", default-features = false }
+ink_engine = { version = "=5.0.0-rc", path = "crates/engine", default-features = false }
+ink_env = { version = "=5.0.0-rc", path = "crates/env", default-features = false }
+ink_ir = { version = "=5.0.0-rc", path = "crates/ink/ir", default-features = false }
+ink_macro = { version = "=5.0.0-rc", path = "crates/ink/macro", default-features = false }
+ink_metadata = { version = "=5.0.0-rc", path = "crates/metadata", default-features = false }
+ink_prelude = { version = "=5.0.0-rc", path = "crates/prelude", default-features = false }
+ink_primitives = { version = "=5.0.0-rc", path = "crates/primitives", default-features = false }
+ink_storage = { version = "=5.0.0-rc", path = "crates/storage", default-features = false }
+ink_storage_traits = { version = "=5.0.0-rc", path = "crates/storage/traits", default-features = false }
 
 [profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ array-init = { version = "2.0", default-features = false }
 blake2 = { version = "0.10" }
 cargo_metadata = { version = "0.18.0" }
 cfg-if = { version = "1.0" }
-contract-build = { version = "3.2.0" }
+contract-build = { version = "4.0.0-rc.1" }
 darling = { version = "0.20.3" }
 derive_more = { version = "0.99.17", default-features = false }
-drink = { version = "=0.8.2" }
+drink = { version = "=0.8.5" }
 either = { version = "1.5", default-features = false }
 funty = { version = "2.0.0" }
 heck = { version = "0.4.0" }
@@ -76,7 +76,7 @@ tokio = { version = "1.18.2" }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }
 trybuild = { version = "1.0.60" }
-wasm-instrument = { version = "0.4.0", features = ["sign_ext"] }
+wasm-instrument = { version = "0.4.0" }
 which = { version = "5.0.0" }
 xxhash-rust = { version = "0.8" }
 const_env = { version = "0.1"}

--- a/crates/e2e/src/contract_build.rs
+++ b/crates/e2e/src/contract_build.rs
@@ -17,6 +17,7 @@ use contract_build::{
     BuildMode,
     ExecuteArgs,
     Features,
+    ImageVariant,
     ManifestPath,
     Network,
     OptimizationPasses,
@@ -24,6 +25,7 @@ use contract_build::{
     Target,
     UnstableFlags,
     Verbosity,
+    DEFAULT_MAX_MEMORY_PAGES,
 };
 use std::{
     collections::{
@@ -175,10 +177,12 @@ fn build_contract(path_to_cargo_toml: &Path) -> PathBuf {
         unstable_flags: UnstableFlags::default(),
         optimization_passes: Some(OptimizationPasses::default()),
         keep_debug_symbols: false,
-        lint: false,
+        dylint: false,
         output_type: OutputType::HumanReadable,
         skip_wasm_validation: false,
         target: Target::Wasm,
+        max_memory_pages: DEFAULT_MAX_MEMORY_PAGES,
+        image: ImageVariant::Default,
     };
 
     match contract_build::execute(args) {

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -19,7 +19,7 @@ name = "ink_codegen"
 
 [dependencies]
 ink_primitives = { workspace = true }
-ir = { version = "=5.0.0-alpha", package = "ink_ir", path = "../ir", default-features = false }
+ir = { version = "=5.0.0-rc", package = "ink_ir", path = "../ir", default-features = false }
 quote = { workspace = true }
 syn = { workspace = true, features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = { workspace = true }

--- a/integration-tests/basic-contract-caller/Cargo.toml
+++ b/integration-tests/basic-contract-caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "basic-contract-caller"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/basic-contract-caller/other-contract/Cargo.toml
+++ b/integration-tests/basic-contract-caller/other-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "other-contract"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/call-builder-return-value/Cargo.toml
+++ b/integration-tests/call-builder-return-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder_return_value"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/combined-extension/Cargo.toml
+++ b/integration-tests/combined-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "combined_extension"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-terminate/Cargo.toml
+++ b/integration-tests/contract-terminate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_terminate"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-transfer/Cargo.toml
+++ b/integration-tests/contract-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_transfer"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/custom-allocator/Cargo.toml
+++ b/integration-tests/custom-allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom-allocator"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/custom-environment/Cargo.toml
+++ b/integration-tests/custom-environment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom-environment"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/dns/Cargo.toml
+++ b/integration-tests/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e2e_call_runtime"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/e2e-runtime-only-backend/Cargo.toml
+++ b/integration-tests/e2e-runtime-only-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e2e-runtime-only-backend"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc1155/Cargo.toml
+++ b/integration-tests/erc1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc1155"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc20/Cargo.toml
+++ b/integration-tests/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc20"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc721/Cargo.toml
+++ b/integration-tests/erc721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc721"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/events/Cargo.toml
+++ b/integration-tests/events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "events"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/flipper/Cargo.toml
+++ b/integration-tests/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/incrementer/Cargo.toml
+++ b/integration-tests/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder_delegate"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constructors_return_value"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_ref"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_flipper"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/mapping-integration-tests/Cargo.toml
+++ b/integration-tests/mapping-integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mapping-integration-tests"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/mother/Cargo.toml
+++ b/integration-tests/mother/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mother"
 description = "Mother of all contracts"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/multi-contract-caller/Cargo.toml
+++ b/integration-tests/multi-contract-caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-contract-caller"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/multi-contract-caller/accumulator/Cargo.toml
+++ b/integration-tests/multi-contract-caller/accumulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulator"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi-contract-caller/adder/Cargo.toml
+++ b/integration-tests/multi-contract-caller/adder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adder"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi-contract-caller/subber/Cargo.toml
+++ b/integration-tests/multi-contract-caller/subber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subber"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multisig/Cargo.toml
+++ b/integration-tests/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/payment-channel/Cargo.toml
+++ b/integration-tests/payment-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payment_channel"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/psp22-extension/Cargo.toml
+++ b/integration-tests/psp22-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_extension"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/rand-extension/Cargo.toml
+++ b/integration-tests/rand-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_extension"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/sr25519-verification/Cargo.toml
+++ b/integration-tests/sr25519-verification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sr25519_verification"
-version = "4.1.0"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>", "George Oastler <goastler4@gmail.com>"]
 edition = "2021"
 publish = false

--- a/integration-tests/static-buffer/Cargo.toml
+++ b/integration-tests/static-buffer/Cargo.toml
@@ -13,6 +13,7 @@ ink_e2e = { path = "../../crates/e2e" }
 
 [lib]
 path = "lib.rs"
+doctest = false
 
 [features]
 default = ["std"]

--- a/integration-tests/static-buffer/Cargo.toml
+++ b/integration-tests/static-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "static-buffer"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-dyn-cross-contract-calls/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer-caller"
-version = "4.0.0"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "4.0.0"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyn-traits"
-version = "4.0.0"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-erc20/Cargo.toml
+++ b/integration-tests/trait-erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_erc20"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-flipper/Cargo.toml
+++ b/integration-tests/trait-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_flipper"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-incrementer/Cargo.toml
+++ b/integration-tests/trait-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-incrementer/traits/Cargo.toml
+++ b/integration-tests/trait-incrementer/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traits"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/delegator/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/delegator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegator"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/delegator/delegatee/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/delegator/delegatee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegatee"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated-incrementer"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/wildcard-selector/Cargo.toml
+++ b/integration-tests/wildcard-selector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wildcard-selector"
-version = "4.1.0"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_linting"
-version = "5.0.0-alpha"
+version = "5.0.0-rc"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false


### PR DESCRIPTION
### Added
- Allow mutable parameters in messages - [#2004](https://github.com/paritytech/ink/pull/2004)
- [E2E] Allow testing with live-chain state - [#1949](https://github.com/paritytech/ink/pull/1949)
- [E2E] Call builders and extra gas margin option - [#1917](https://github.com/paritytech/ink/pull/1917)
- Linter: `storage_never_freed` lint - [#1932](https://github.com/paritytech/ink/pull/1932)
- Linter: `strict_balance_equality` lint - [#1914](https://github.com/paritytech/ink/pull/1914)
- Linter: `no_main` lint - [#2001](https://github.com/paritytech/ink/pull/2001)
- Clean E2E configuration parsing - [#1922](https://github.com/paritytech/ink/pull/1922)
- Make `set_code_hash` generic - [#1906](https://github.com/paritytech/ink/pull/1906)
- Provide a `StorageVec` datastructure built on top of `Lazy` - [#1995](https://github.com/paritytech/ink/pull/1955)

### Changed
- Messages return `TypeSpec` directly - [#1999](https://github.com/paritytech/ink/pull/1999)
- Fail when decoding from storage and not all bytes consumed - [#1897](https://github.com/paritytech/ink/pull/1897)
- [E2E] resolve DispatchError error details for dry-runs - [#1944](https://github.com/paritytech/ink/pull/1994)
- [E2E] update to new `drink` API - [#2005](https://github.com/paritytech/ink/pull/2005)
- Support multiple chain extensions - [#1958](https://github.com/paritytech/ink/pull/1958)
  - New example of how to use multiple chain extensions in one contract.
  - Affects the usage of the `#[ink::chain_extension]` macro and the definition of the chain extension.