### PR TITLE
Add fuzz tests on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,14 +583,15 @@ jobs:
 # fuzz
 
   fuzz:
-    # Temporarily disabled until https://github.com/paritytech/ink/issues/1374
-    # is fixed.
-    if: >
-      false &&
-        github.event_name == 'push' &&
-        github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    needs: [set-image, measurements]
+      #    needs: [set-image, measurements]
+    needs: [set-image]
+    if: >
+      github.event_name == 'push' &&
+        github.ref == 'refs/heads/master'
+
+    permissions:
+      issues: write
     defaults:
       run:
         shell: bash
@@ -611,6 +612,7 @@ jobs:
         uses: ./.github/rust-info
 
       - name: Fuzz
+        id: fuzz_test
         env:
           QUICKCHECK_TESTS:              5000
         run: |
@@ -625,3 +627,47 @@ jobs:
             fi
           done
           exit ${all_tests_passed}
+
+      - name: Create Issue
+        if: ${{ failure() && steps.fuzz_test.conclusion == 'failure' }}
+
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const runId = context.runId;
+
+            // Get the list of jobs for the current run using GitHub API
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId
+            });
+
+            // Find the job ID by name
+            const job = jobs.data.jobs.find(job => job.name === context.job);
+
+            if (!job) {
+              console.error(`Job with name '${jobName}' not found.`);
+              return;
+            }
+
+            const jobId = job.id;
+            const title = "[ci] Failing fuzz tests on master ('" + new Date().toLocaleDateString() + "')";
+            const runUrl = context.serverUrl + "/" + context.repo.owner + "/" + context.repo.repo + "/actions/runs/" + runId + "/job/" + jobId;
+            const commitUrl = context.serverUrl + "/" + context.repo.owner + "/" + context.repo.repo + "/commit/" + context.sha;
+            const message = context.payload.head_commit.message;
+            const body = `
+            The CI job [${runId}](${runUrl}) just failed.
+
+            The offending commit is [${message}](${commitUrl}).
+            `;
+
+            const issue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: title,
+              body: body,
+              assignees: [],
+              labels: ['P-high']
+            });
+            console.log(`Issue created: ${issue.data.html_url}`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,8 +584,7 @@ jobs:
 
   fuzz:
     runs-on: ubuntu-latest
-      #    needs: [set-image, measurements]
-    needs: [set-image]
+    needs: [set-image, measurements]
     if: >
       github.event_name == 'push' &&
         github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,7 +584,7 @@ jobs:
 
   fuzz:
     runs-on: ubuntu-latest
-    needs: [set-image, measurements]
+    needs: [set-image, examples-docs, examples-contract-build, examples-test]
     if: >
       github.event_name == 'push' &&
         github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Summary
Closes #1454
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
Add fuzz tests triggered on merge to master

## Description
Add fuzz tests, and in case of failure, report a Github issue.
Fuzz tests are only executed on the master branch after merging a pull request.

## Checklist before requesting a review
- [y] My code follows the style guidelines of this project
- [n] I have added an entry to `CHANGELOG.md`
- [y] I have commented my code, particularly in hard-to-understand areas
- [n] I have added tests that prove my fix is effective or that my feature works
- [y] Any dependent changes have been merged and published in downstream modules
