### PR TITLE
fix incorrect PR links and link text for some 5.0.0-rc and 5.0.0-alpha changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Linter: `no_main` lint - [#2001](https://github.com/paritytech/ink/pull/2001)
 - Clean E2E configuration parsing - [#1922](https://github.com/paritytech/ink/pull/1922)
 - Make `set_code_hash` generic - [#1906](https://github.com/paritytech/ink/pull/1906)
-- Provide a `StorageVec` datastructure built on top of `Lazy` - [#1995](https://github.com/paritytech/ink/pull/1955)
+- Provide a `StorageVec` datastructure built on top of `Lazy` - [#1995](https://github.com/paritytech/ink/pull/1995)
 
 ### Changed
 - Messages return `TypeSpec` directly - [#1999](https://github.com/paritytech/ink/pull/1999)
 - Fail when decoding from storage and not all bytes consumed - [#1897](https://github.com/paritytech/ink/pull/1897)
-- [E2E] resolve DispatchError error details for dry-runs - [#1944](https://github.com/paritytech/ink/pull/1994)
+- [E2E] resolve DispatchError error details for dry-runs - [#1994](https://github.com/paritytech/ink/pull/1994)
 - [E2E] update to new `drink` API - [#2005](https://github.com/paritytech/ink/pull/2005)
 - Support multiple chain extensions - [#1958](https://github.com/paritytech/ink/pull/1958)
   - New example of how to use multiple chain extensions in one contract.
@@ -40,7 +40,7 @@ You can read more about the change in the [PR](https://github.com/paritytech/ink
 
 There are also other notable changes:
 
-- Rework of event definitions - [#1827](https://github.com/paritytech/ink/pull/1708).
+- Rework of event definitions - [#1827](https://github.com/paritytech/ink/pull/1827).
 - Updated upgradeable contract example illustrating `delegate_call`
 - Removal of unchecked arithmetic. `cargo-contract` will fail compiling the contract with raw arithmetic operations.
 - Introduction of an alternative off-chain E2E testing backend, drink!
@@ -61,7 +61,7 @@ You can see a more detailed log of changes below:
 - [Drink backend]: Abstract error and result structs - [#1844](https://github.com/paritytech/ink/pull/1844)
 - Added `sr25519_verify` function to `ink_env` [#1840](https://github.com/paritytech/ink/pull/1840)
 - Warn when primitive number is annotated as event topic - [#1837](https://github.com/paritytech/ink/pull/1837)
-- Events `2.0` - [#1827](https://github.com/paritytech/ink/pull/1810)
+- Events `2.0` - [#1827](https://github.com/paritytech/ink/pull/1827)
 - Add `set_block_number` to off-chain test api `Engine` - [#1806](https://github.com/paritytech/ink/pull/1806)
 - Stabilize `call_runtime` ‒ [#1749](https://github.com/paritytech/ink/pull/1749)
 - Schema generation - [#1765](https://github.com/paritytech/ink/pull/1765)
@@ -77,7 +77,7 @@ You can see a more detailed log of changes below:
 - E2E: improve call API, remove `build_message` + callback - [#1782](https://github.com/paritytech/ink/pull/1782)
 
 ### Fixed
-- `RootLayout::new()` is generic again to allow using `ink_metadata` in pure `PortableForm` contexts - [#1782](https://github.com/paritytech/ink/pull/1989)
+- `RootLayout::new()` is generic again to allow using `ink_metadata` in pure `PortableForm` contexts - [#1989](https://github.com/paritytech/ink/pull/1989)
 
 ## 4.3.0
 


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->
Fixes incorrect PR links and link text for some 5.0.0-rc and 5.0.0-alpha changelog entries

## Checklist before requesting a review
- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have added an entry to `CHANGELOG.md`~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~

**NOTE:** Doesn't include any code changes
