### PR TITLE
Use existing node to run e2e tests in dev

### DIFF
--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -76,7 +76,7 @@ impl E2EConfig {
         self.backend.clone()
     }
 
-    /// The URL to the running node, default value can be overriden with
+    /// The URL to the running node, default value can be overridden with
     /// `CONTRACTS_NODE_URL`. If no URL is provided, then a default node instance will
     /// be spawned per test.
     pub fn node_url(&self) -> Option<String> {

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -76,7 +76,7 @@ impl E2EConfig {
         self.backend.clone()
     }
 
-    /// The URL to the running node, default to `CONTRACTS_NODE_URL` env is not set.
+    /// The URL to the running node, default to `CONTRACTS_NODE_URL` if not set.
     /// If no URL is provided, then a default node instance will be spawned per test.
     pub fn node_url(&self) -> Option<String> {
         self.node_url

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -46,8 +46,7 @@ pub struct E2EConfig {
     /// The type of the architecture that should be used to run test.
     #[darling(default)]
     backend: Backend,
-    /// The URL to the running node. If not set then a default node instance will be
-    /// spawned per test.
+    /// The URL to the running node. See [`Self::node_url()`] for more details.
     node_url: Option<String>,
 }
 
@@ -77,10 +76,12 @@ impl E2EConfig {
         self.backend.clone()
     }
 
-    /// The URL to the running node. If not set then a default node instance will be
-    /// spawned per test.
+    /// The URL to the running node, default to `CONTRACTS_NODE_URL` env is not set.
+    /// If no URL is provided, then a default node instance will be spawned per test.
     pub fn node_url(&self) -> Option<String> {
-        self.node_url.clone()
+        self.node_url
+            .clone()
+            .or_else(|| std::env::var("CONTRACTS_NODE_URL").ok())
     }
 }
 

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -76,12 +76,13 @@ impl E2EConfig {
         self.backend.clone()
     }
 
-    /// The URL to the running node, default to `CONTRACTS_NODE_URL` if not set.
-    /// If no URL is provided, then a default node instance will be spawned per test.
+    /// The URL to the running node, default value can be overriden with
+    /// `CONTRACTS_NODE_URL`. If no URL is provided, then a default node instance will
+    /// be spawned per test.
     pub fn node_url(&self) -> Option<String> {
-        self.node_url
-            .clone()
-            .or_else(|| std::env::var("CONTRACTS_NODE_URL").ok())
+        std::env::var("CONTRACTS_NODE_URL")
+            .ok()
+            .or_else(|| self.node_url.clone())
     }
 }
 
@@ -115,7 +116,10 @@ mod tests {
         );
 
         assert_eq!(config.backend(), Backend::RuntimeOnly { runtime: None });
-        assert_eq!(config.node_url(), Some(String::from("ws://127.0.0.1:8000")))
+        assert_eq!(config.node_url(), Some(String::from("ws://127.0.0.1:8000")));
+
+        std::env::set_var("CONTRACTS_NODE_URL", "ws://127.0.0.1:9000");
+        assert_eq!(config.node_url(), Some(String::from("ws://127.0.0.1:9000")))
     }
 
     #[test]


### PR DESCRIPTION
Add an option to run e2e tests with an existing node in dev.
This is useful when you want to easily scan the debug logs of pallet-contracts to debug an e2e test