### PR TITLE
Serialize storage keys in metadata as SCALE encoded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,6 +2767,7 @@ dependencies = [
  "ink_prelude 5.0.0-rc",
  "ink_primitives 5.0.0-rc",
  "linkme",
+ "parity-scale-codec",
  "pretty_assertions",
  "scale-info",
  "schemars",

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true, features = ["derive", "alloc"] }
 impl-serde = { workspace = true, default-features = true }
 derive_more = { workspace = true, features = ["from"] }
 linkme = { workspace = true }
+scale = { workspace = true }
 scale-info = { workspace = true, features = ["derive", "serde", "decode", "schema"] }
 schemars = { workspace = true }
 

--- a/crates/metadata/src/layout/tests.rs
+++ b/crates/metadata/src/layout/tests.rs
@@ -20,7 +20,7 @@ use scale_info::Path;
 fn layout_key_works() {
     let layout_key = LayoutKey::from(&1);
     let json = serde_json::to_string(&layout_key).unwrap();
-    assert_eq!(json, "\"0x00000001\"",);
+    assert_eq!(json, "\"0x01000000\"",);
 }
 
 fn named_fields_struct_layout(key: &Key) -> Layout {
@@ -47,7 +47,7 @@ fn named_fields_work() {
                     {
                         "layout": {
                             "leaf": {
-                                "key": "0x00000159",
+                                "key": "0x59010000",
                                 "ty": 0,
                             }
                         },
@@ -56,7 +56,7 @@ fn named_fields_work() {
                     {
                         "layout": {
                             "leaf": {
-                                "key": "0x00000159",
+                                "key": "0x59010000",
                                 "ty": 1,
                             }
                         },
@@ -94,7 +94,7 @@ fn tuple_struct_work() {
                     {
                         "layout": {
                             "leaf": {
-                                "key": "0x000000ea",
+                                "key": "0xea000000",
                                 "ty": 0,
                             }
                         },
@@ -103,7 +103,7 @@ fn tuple_struct_work() {
                     {
                         "layout": {
                             "leaf": {
-                                "key": "0x000000ea",
+                                "key": "0xea000000",
                                 "ty": 1,
                             }
                         },
@@ -139,7 +139,7 @@ fn clike_enum_work() {
     let expected = serde_json::json! {
         {
             "enum": {
-                "dispatchKey": "0x0000007b",
+                "dispatchKey": "0x7b000000",
                 "name": "Enum",
                 "variants": {
                     "0": {
@@ -219,7 +219,7 @@ fn mixed_enum_work() {
     let expected = serde_json::json! {
         {
             "enum": {
-                "dispatchKey": "0x000001c8",
+                "dispatchKey": "0xc8010000",
                 "name": "Enum",
                 "variants": {
                     "0": {
@@ -231,7 +231,7 @@ fn mixed_enum_work() {
                             {
                                 "layout": {
                                     "leaf": {
-                                        "key": "0x000001c8",
+                                        "key": "0xc8010000",
                                         "ty": 0,
                                     }
                                 },
@@ -240,7 +240,7 @@ fn mixed_enum_work() {
                             {
                                 "layout": {
                                     "leaf": {
-                                        "key": "0x000001c8",
+                                        "key": "0xc8010000",
                                         "ty": 1,
                                     }
                                 },
@@ -254,7 +254,7 @@ fn mixed_enum_work() {
                             {
                                 "layout": {
                                     "leaf": {
-                                        "key": "0x000001c8",
+                                        "key": "0xc8010000",
                                         "ty": 0,
                                     }
                                 },
@@ -263,7 +263,7 @@ fn mixed_enum_work() {
                             {
                                 "layout": {
                                     "leaf": {
-                                        "key": "0x000001c8",
+                                        "key": "0xc8010000",
                                         "ty": 1,
                                     }
                                 },
@@ -304,11 +304,11 @@ fn unbounded_layout_works() {
             "hash": {
                 "layout": {
                     "leaf": {
-                        "key": "0x00000237",
+                        "key": "0x37020000",
                         "ty": 0
                     }
                 },
-                "offset": "0x00000237",
+                "offset": "0x37020000",
                 "strategy": {
                         "hasher": "Blake2x256",
                         "prefix": "0x696e6b2073746f7261676520686173686d6170",


### PR DESCRIPTION
Storage keys are [SCALE encoded for storage access](https://github.com/paritytech/ink/blob/27407b5f59f24233cddc3cea59cc2213ba2c6674/crates/env/src/engine/on_chain/impls.rs#L224), so the layout keys in the metadata should also be serialized in the same way. At the moment they are BE encoded.

:warning: **BREAKING metadata change** :warning: 

Client tools which use the layout keys will need to adapt to this change by decoding from LE bytes instead of BE bytes.