### PR TITLE
Fix the `StorageVec` type by excluding the `len_cached` field from its type info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Fix `TypeInfo` for the `len_cached` field of the `StorageVec` type - [#2052](https://github.com/paritytech/ink/pull/2052)
+- Fix the `StorageVec` type by excluding the `len_cached` field from its type info - [#2052](https://github.com/paritytech/ink/pull/2052)
 
 ## Version 5.0.0-rc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix `TypeInfo` for the `len_cached` field of the `StorageVec` type - [#2052](https://github.com/paritytech/ink/pull/2052)
 
 ## Version 5.0.0-rc
 

--- a/crates/storage/src/lazy/vec.rs
+++ b/crates/storage/src/lazy/vec.rs
@@ -132,10 +132,10 @@ struct CachedLen(Cell<Option<u32>>);
 
 #[cfg(feature = "std")]
 impl scale_info::TypeInfo for CachedLen {
-    type Identity = Option<u32>;
+    type Identity = Self;
 
     fn type_info() -> scale_info::Type {
-        <Self::Identity as scale_info::TypeInfo>::type_info()
+        <() as scale_info::TypeInfo>::type_info()
     }
 }
 

--- a/crates/storage/src/lazy/vec.rs
+++ b/crates/storage/src/lazy/vec.rs
@@ -117,6 +117,7 @@ pub struct StorageVec<V: Packed, KeyType: StorageKey = AutoKey> {
     ///
     /// Because of caching, never operate on this field directly!
     /// Always use `fn get_len()` an `fn set_len()` instead.
+    #[cfg_attr(feature = "std", codec(skip))]
     len_cached: CachedLen,
     /// We use a [Mapping] to store all elements of the vector.
     /// Each element is living in storage under `&(KeyType::KEY, index)`.
@@ -129,15 +130,6 @@ pub struct StorageVec<V: Packed, KeyType: StorageKey = AutoKey> {
 
 #[derive(Debug)]
 struct CachedLen(Cell<Option<u32>>);
-
-#[cfg(feature = "std")]
-impl scale_info::TypeInfo for CachedLen {
-    type Identity = Self;
-
-    fn type_info() -> scale_info::Type {
-        <() as scale_info::TypeInfo>::type_info()
-    }
-}
 
 impl<V, KeyType> Default for StorageVec<V, KeyType>
 where


### PR DESCRIPTION
## Summary
- [n] y/n | Does it introduce breaking changes?
- [n y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

Fix the `StorageVec` type by excluding the `len_cached` field from its type info

## Description
There is an issue with the `len_cached` field of the `StorageVec` type. It is not stored in the storage but is defined in the `StorageVec` as `TypeInfo`  `Option<u32>`. This is causing a decoding error when the `StorageVec` type is decoded from storage.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
