### PR TITLE
CI auto merge `--squash` instead of `--merge`

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,7 +23,7 @@ jobs:
             GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         - name: Enable auto-merge for Dependabot PRs
           if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
-          run: gh pr merge --auto --merge "$PR_URL"
+          run: gh pr merge --auto --squash "$PR_URL"
           env:
             PR_URL: ${{github.event.pull_request.html_url}}
             GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Merge commits are disabled, needs to be a squash commit.

![image](https://github.com/paritytech/ink/assets/75586/3e4230b8-9c91-4bd7-8d63-ea20eacfd1d1)
