### PR TITLE
Linter: Support `StorageVec` in the `non_fallible_api` lint

### DIFF
--- a/linting/extra/src/non_fallible_api.rs
+++ b/linting/extra/src/non_fallible_api.rs
@@ -115,6 +115,7 @@ declare_lint_pass!(NonFallibleAPI => [NON_FALLIBLE_API]);
 enum TyToCheck {
     Mapping,
     Lazy,
+    StorageVec,
 }
 
 impl TyToCheck {
@@ -125,6 +126,9 @@ impl TyToCheck {
 
         if match_def_path(cx, did, &["ink_storage", "lazy", "mapping", "Mapping"]) {
             return Some(Self::Mapping)
+        }
+        if match_def_path(cx, did, &["ink_storage", "lazy", "vec", "StorageVec"]) {
+            return Some(Self::StorageVec)
         }
         None
     }
@@ -144,6 +148,16 @@ impl TyToCheck {
                 match method_name {
                     "get" => Some("try_get".to_string()),
                     "set" => Some("try_set".to_string()),
+                    _ => None,
+                }
+            }
+            StorageVec => {
+                match method_name {
+                    "peek" => Some("try_peek".to_string()),
+                    "get" => Some("try_get".to_string()),
+                    "set" => Some("try_set".to_string()),
+                    "pop" => Some("try_pop".to_string()),
+                    "push" => Some("try_push".to_string()),
                     _ => None,
                 }
             }

--- a/linting/extra/ui/fail/non_fallible_api.rs
+++ b/linting/extra/ui/fail/non_fallible_api.rs
@@ -14,6 +14,7 @@ pub mod non_fallible_api {
         storage::{
             Lazy,
             Mapping,
+            StorageVec,
         },
     };
 
@@ -23,6 +24,7 @@ pub mod non_fallible_api {
         map_2: Mapping<i32, TyAlias2>,
         lazy_1: Lazy<String>,
         lazy_2: Lazy<(String, String)>,
+        vec_1: StorageVec<String>,
     }
 
     impl NonFallibleAPI {
@@ -33,6 +35,7 @@ pub mod non_fallible_api {
                 map_2: Mapping::new(),
                 lazy_1: Lazy::new(),
                 lazy_2: Lazy::new(),
+                vec_1: StorageVec::new(),
             }
         }
 
@@ -51,7 +54,14 @@ pub mod non_fallible_api {
             // Lazy
             let _ = self.lazy_1.get();
             self.lazy_1.set(&a);
-            self.lazy_2.set(&(a.clone(), a));
+            self.lazy_2.set(&(a.clone(), a.clone()));
+
+            // StorageVec
+            let _ = self.vec_1.peek();
+            let _ = self.vec_1.get(0);
+            self.vec_1.set(0, &a.clone());
+            let _ = self.vec_1.pop();
+            self.vec_1.push(&a.clone());
         }
     }
 }

--- a/linting/extra/ui/fail/non_fallible_api.stderr
+++ b/linting/extra/ui/fail/non_fallible_api.stderr
@@ -1,5 +1,5 @@
 error: using a non-fallible `Mapping::insert` with an argument that may not fit into the static buffer
-  --> $DIR/non_fallible_api.rs:44:32
+  --> $DIR/non_fallible_api.rs:47:32
    |
 LL |             let _ = self.map_1.insert(a.clone(), &b);
    |                                ^^^^^^ help: consider using `try_insert`
@@ -7,40 +7,70 @@ LL |             let _ = self.map_1.insert(a.clone(), &b);
    = note: `-D non-fallible-api` implied by `-D warnings`
 
 error: using a non-fallible `Mapping::get` with an argument that may not fit into the static buffer
-  --> $DIR/non_fallible_api.rs:45:32
+  --> $DIR/non_fallible_api.rs:48:32
    |
 LL |             let _ = self.map_1.get(a.clone());
    |                                ^^^ help: consider using `try_get`
 
 error: using a non-fallible `Mapping::take` with an argument that may not fit into the static buffer
-  --> $DIR/non_fallible_api.rs:46:32
+  --> $DIR/non_fallible_api.rs:49:32
    |
 LL |             let _ = self.map_1.take(a.clone());
    |                                ^^^^ help: consider using `try_take`
 
 error: using a non-fallible `Mapping::insert` with an argument that may not fit into the static buffer
-  --> $DIR/non_fallible_api.rs:49:32
+  --> $DIR/non_fallible_api.rs:52:32
    |
 LL |             let _ = self.map_2.insert(42, &v);
    |                                ^^^^^^ help: consider using `try_insert`
 
 error: using a non-fallible `Lazy::get` with an argument that may not fit into the static buffer
-  --> $DIR/non_fallible_api.rs:52:33
+  --> $DIR/non_fallible_api.rs:55:33
    |
 LL |             let _ = self.lazy_1.get();
    |                                 ^^^ help: consider using `try_get`
 
 error: using a non-fallible `Lazy::set` with an argument that may not fit into the static buffer
-  --> $DIR/non_fallible_api.rs:53:25
+  --> $DIR/non_fallible_api.rs:56:25
    |
 LL |             self.lazy_1.set(&a);
    |                         ^^^ help: consider using `try_set`
 
 error: using a non-fallible `Lazy::set` with an argument that may not fit into the static buffer
-  --> $DIR/non_fallible_api.rs:54:25
+  --> $DIR/non_fallible_api.rs:57:25
    |
-LL |             self.lazy_2.set(&(a.clone(), a));
+LL |             self.lazy_2.set(&(a.clone(), a.clone()));
    |                         ^^^ help: consider using `try_set`
 
-error: aborting due to 7 previous errors
+error: using a non-fallible `StorageVec::peek` with an argument that may not fit into the static buffer
+  --> $DIR/non_fallible_api.rs:60:32
+   |
+LL |             let _ = self.vec_1.peek();
+   |                                ^^^^ help: consider using `try_peek`
+
+error: using a non-fallible `StorageVec::get` with an argument that may not fit into the static buffer
+  --> $DIR/non_fallible_api.rs:61:32
+   |
+LL |             let _ = self.vec_1.get(0);
+   |                                ^^^ help: consider using `try_get`
+
+error: using a non-fallible `StorageVec::set` with an argument that may not fit into the static buffer
+  --> $DIR/non_fallible_api.rs:62:24
+   |
+LL |             self.vec_1.set(0, &a.clone());
+   |                        ^^^ help: consider using `try_set`
+
+error: using a non-fallible `StorageVec::pop` with an argument that may not fit into the static buffer
+  --> $DIR/non_fallible_api.rs:63:32
+   |
+LL |             let _ = self.vec_1.pop();
+   |                                ^^^ help: consider using `try_pop`
+
+error: using a non-fallible `StorageVec::push` with an argument that may not fit into the static buffer
+  --> $DIR/non_fallible_api.rs:64:24
+   |
+LL |             self.vec_1.push(&a.clone());
+   |                        ^^^^ help: consider using `try_push`
+
+error: aborting due to 12 previous errors
 

--- a/linting/extra/ui/pass/non_fallible_api.rs
+++ b/linting/extra/ui/pass/non_fallible_api.rs
@@ -13,6 +13,7 @@ pub mod non_fallible_api {
         storage::{
             Lazy,
             Mapping,
+            StorageVec,
         },
     };
 
@@ -24,6 +25,7 @@ pub mod non_fallible_api {
         lazy_1: Lazy<AccountId>,
         lazy_2: Lazy<TyAlias2>,
         lazy_3: Lazy<String>,
+        vec_1: StorageVec<AccountId>,
     }
 
     impl NonFallibleAPI {
@@ -36,6 +38,7 @@ pub mod non_fallible_api {
                 lazy_1: Lazy::new(),
                 lazy_2: Lazy::new(),
                 lazy_3: Lazy::new(),
+                vec_1: StorageVec::new(),
             }
         }
 
@@ -50,6 +53,13 @@ pub mod non_fallible_api {
             // Lazy
             let _ = self.lazy_1.try_get();
             let _ = self.lazy_1.try_set(&a);
+
+            // StorageVec
+            let _ = self.vec_1.try_peek();
+            let _ = self.vec_1.try_get(0);
+            self.vec_1.try_set(0, &a);
+            let _ = self.vec_1.try_pop();
+            self.vec_1.try_push(&a);
         }
 
         // Don't raise warnings when using non-fallible API with argument which encoded
@@ -68,6 +78,13 @@ pub mod non_fallible_api {
             self.lazy_1.set(&a);
             let _ = self.lazy_2.get();
             self.lazy_2.set(&a);
+
+            // StorageVec
+            let _ = self.vec_1.peek();
+            let _ = self.vec_1.get(0);
+            self.vec_1.set(0, &a);
+            let _ = self.vec_1.pop();
+            self.vec_1.push(&a);
         }
 
         // Check if local suppressions work


### PR DESCRIPTION
## Summary
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

## Description
Support `StorageVec` struct, since it also has non-fallible API that potentially can lead to static buffer overflow. 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- (n/a) I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
