### PR TITLE
Use PAT in docs deployment

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,13 +17,12 @@ jobs:
         github.event.workflow_run.head_branch == 'master' &&
         github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 100
+          token: ${{ secrets.GH_PAGES }}
 
       - name: Download Contract Sizes
         uses: ./.github/download-artifact
@@ -34,9 +33,6 @@ jobs:
 
       - name: Push docs
         run: |
-          # Set git config
-          git config user.email "paritytech-ci@parity.io"
-          git config user.name "paritytech-ci"
           git fetch origin gh-pages
           # saving README and docs
           cp -r ./crate-docs/ /tmp/doc/

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Push docs
         run: |
+          # Set git config
+          git config user.email "paritytech-ci@parity.io"
+          git config user.name "paritytech-ci"
           git fetch origin gh-pages
           # saving README and docs
           cp -r ./crate-docs/ /tmp/doc/


### PR DESCRIPTION
## Summary

- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

Use PAT in docs deployment

## Description
A Personal Access Token (PAT) is generated for the 'paritytech-ci' user. It needs to be used to enable branch protection rules for 'gh-pages'.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
