### PR TITLE
Fix documentation generation order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,10 @@ jobs:
         env:
           RUSTDOCFLAGS:                  -Dwarnings
         run: |
-          cargo doc --no-deps --all-features
+          for package in $(cargo metadata --format-version 1 | jq -r '.workspace_members[]' | awk '{print $1}'); do
+            # Run cargo doc for each workspace member
+            cargo doc --no-deps --all-features -p ${package}
+          done
           mv ${CARGO_TARGET_DIR}/doc ./crate-docs
           # FIXME: remove me after CI image gets nonroot
           chown -R nonroot:nonroot ./crate-docs


### PR DESCRIPTION
## Summary
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
Fix documentation generation order

## Description
Documentation is generated in a different order with each run. 
Even PR that did not change the documentation pushed new version due to this issue. 
The solution here is to enforce the order.

## Checklist before requesting a review
- [ ] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
