### PR TITLE
Linter: Update toolchain

### DIFF
--- a/linting/extra/Cargo.toml
+++ b/linting/extra/Cargo.toml
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "2.1.12"
+dylint_linting = "2.6.0"
 if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
@@ -25,7 +25,7 @@ ink_linting_utils = { workspace = true }
 ink_env = { version = "=5.0.0-rc", path = "../../crates/env", default-features = false }
 
 [dev-dependencies]
-dylint_testing = "2.1.12"
+dylint_testing = "2.6.0"
 
 # The ink! dependencies used to build the `ui` tests and to compile the linting
 # library with `--default-features=std` (see the `features` section bellow).

--- a/linting/extra/src/non_fallible_api.rs
+++ b/linting/extra/src/non_fallible_api.rs
@@ -55,7 +55,7 @@ use rustc_session::{
     declare_lint,
     declare_lint_pass,
 };
-use rustc_type_ir::sty::TyKind;
+use rustc_type_ir::ty_kind::TyKind;
 
 declare_lint! {
     /// ## What it does

--- a/linting/extra/src/storage_never_freed.rs
+++ b/linting/extra/src/storage_never_freed.rs
@@ -168,7 +168,7 @@ fn find_collection_def_id(
     if_chain! {
         if let Res::Def(DefKind::TyAlias, def_id) = path.res;
         if let Some(local_id) = def_id.as_local();
-        if let Some(alias_ty) = cx.tcx.hir().get_by_def_id(local_id).alias_ty();
+        if let Some(alias_ty) = cx.tcx.hir_node_by_def_id(local_id).alias_ty();
         if let TyKind::Path(QPath::Resolved(_, path)) = alias_ty.kind;
         then { return find_collection_def_id(cx, path); }
     };
@@ -214,7 +214,7 @@ fn find_collection_fields(cx: &LateContext, storage_struct_id: ItemId) -> Fields
 /// Reports the given field definition
 fn report_field(cx: &LateContext, field_info: &FieldInfo) {
     if_chain! {
-        if let Node::Field(field) = cx.tcx.hir().get_by_def_id(field_info.did);
+        if let Node::Field(field) = cx.tcx.hir_node_by_def_id(field_info.did);
         if !is_lint_allowed(cx, STORAGE_NEVER_FREED, field.hir_id);
         then {
             span_lint_and_help(
@@ -257,7 +257,7 @@ impl<'hir> Visitor<'hir> for InsertRemoveCollector<'_> {
         match &e.kind {
             ExprKind::Assign(lhs, ..) => {
                 if_chain! {
-                    if let ExprKind::Index(field, _) = lhs.kind;
+                    if let ExprKind::Index(field, _, _) = lhs.kind;
                     if let Some(field_name) = self.find_field_name(field);
                     then {
                         self.fields

--- a/linting/extra/ui/fail/non_fallible_api.stderr
+++ b/linting/extra/ui/fail/non_fallible_api.stderr
@@ -5,6 +5,7 @@ LL |             let _ = self.map_1.insert(a.clone(), &b);
    |                                ^^^^^^ help: consider using `try_insert`
    |
    = note: `-D non-fallible-api` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(non_fallible_api)]`
 
 error: using a non-fallible `Mapping::get` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:48:32

--- a/linting/extra/ui/fail/primitive_topic.stderr
+++ b/linting/extra/ui/fail/primitive_topic.stderr
@@ -5,6 +5,7 @@ LL |         value_1: u8,
    |         ^^^^^^^^^^^ help: consider removing `#[ink(topic)]`: `value_1: u8`
    |
    = note: `-D primitive-topic` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(primitive_topic)]`
 
 error: using `#[ink(topic)]` for a field with a primitive number type
   --> $DIR/primitive_topic.rs:16:9

--- a/linting/extra/ui/fail/strict_balance_equality.stderr
+++ b/linting/extra/ui/fail/strict_balance_equality.stderr
@@ -5,6 +5,7 @@ LL |             if self.env().balance() == 10 { /* ... */ }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
    |
    = note: `-D strict-balance-equality` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(strict_balance_equality)]`
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:60:16

--- a/linting/extra/ui/pass/non_fallible_api.rs
+++ b/linting/extra/ui/pass/non_fallible_api.rs
@@ -57,9 +57,9 @@ pub mod non_fallible_api {
             // StorageVec
             let _ = self.vec_1.try_peek();
             let _ = self.vec_1.try_get(0);
-            self.vec_1.try_set(0, &a);
+            let _ = self.vec_1.try_set(0, &a);
             let _ = self.vec_1.try_pop();
-            self.vec_1.try_push(&a);
+            let _ = self.vec_1.try_push(&a);
         }
 
         // Don't raise warnings when using non-fallible API with argument which encoded

--- a/linting/mandatory/Cargo.toml
+++ b/linting/mandatory/Cargo.toml
@@ -17,14 +17,14 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 crate-type = ["cdylib"]
 
 [dependencies]
-dylint_linting = "2.1.12"
+dylint_linting = "2.6.0"
 if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
 ink_linting_utils = { workspace = true }
 
 [dev-dependencies]
-dylint_testing = "2.1.12"
+dylint_testing = "2.6.0"
 
 # The ink! dependencies used to build the `ui` tests and to compile the linting
 # library with `--default-features=std` (see the `features` section bellow).

--- a/linting/rust-toolchain.toml
+++ b/linting/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # https://github.com/trailofbits/dylint/blob/ef7210cb08aac920c18d2141604efe210029f2a2/internal/template/rust-toolchain
 
 [toolchain]
-channel = "nightly-2023-07-14"
+channel = "nightly-2023-12-28"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/linting/utils/Cargo.toml
+++ b/linting/utils/Cargo.toml
@@ -15,7 +15,7 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 
 [dependencies]
 if_chain = "1.0.2"
-parity_clippy_utils = "0.1.73"
+parity_clippy_utils = { package = "clippy_utils", git = "https://github.com/rust-lang/rust-clippy", rev = "3fceca23bb64e304df56b3bd86d26790b5301bdf" }
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/linting/utils/src/lib.rs
+++ b/linting/utils/src/lib.rs
@@ -75,7 +75,7 @@ pub fn find_storage_struct(cx: &LateContext, item_ids: &[ItemId]) -> Option<Item
 /// implementations of a contract.
 fn items_in_unnamed_const(cx: &LateContext<'_>, id: &ItemId) -> Vec<ItemId> {
     if_chain! {
-        if let ItemKind::Const(ty, body_id) = cx.tcx.hir().item(*id).kind;
+        if let ItemKind::Const(ty, _, body_id) = cx.tcx.hir().item(*id).kind;
         if let TyKind::Tup([]) = ty.kind;
         let body = cx.tcx.hir().body(body_id);
         if let ExprKind::Block(block, _) = body.value.kind;


### PR DESCRIPTION
## Summary
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

Update the toolchain version and the uses of internal rustc APIs.

## Description
It would be beneficial to compile both the linter and `cargo-contract` using the same toolchain version. This approach would prevent the need to build a second toolchain [in the CI](https://github.com/paritytech/cargo-contract/actions/runs/7577624398/job/20638789124?pr=1412#step:6:152) and on user's machine when compiling a contract.

The necessity of this update because `subxt`, a dependency of `cargo-contract`, requires rustc version 1.74.0 or higher, therefore `cargo-contract` cannot be built with the toolchain used in the linter before this PR.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
