### PR TITLE
[E2E] Rename `.call` to `.call_builder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- [E2E] Rename `.call` to `.call_builder` ‒ [#2076](https://github.com/paritytech/ink/pull/2076)
+
 ### Added
 - Custom signature topic in Events - [#2031](https://github.com/paritytech/ink/pull/2031)
 - Linter: `non_fallible_api` lint - [#2004](https://github.com/paritytech/ink/pull/2004)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- [E2E] Rename `.call` to `.call_builder` ‒ [#2076](https://github.com/paritytech/ink/pull/2076)
+- [E2E] Rename `.call` to `.call_builder` ‒ [#2078](https://github.com/paritytech/ink/pull/2078)
 
 ### Added
 - Custom signature topic in Events - [#2031](https://github.com/paritytech/ink/pull/2031)

--- a/crates/e2e/src/backend.rs
+++ b/crates/e2e/src/backend.rs
@@ -165,7 +165,7 @@ pub trait ContractsBackend<E: Environment> {
     ///
     /// ```ignore
     /// // Message method
-    /// let get = call.get();
+    /// let get = call_builder.get();
     /// let get_res = client
     ///    .call(&ink_e2e::bob(), &get)
     ///     // Optional arguments

--- a/crates/e2e/src/contract_results.rs
+++ b/crates/e2e/src/contract_results.rs
@@ -84,7 +84,7 @@ pub struct InstantiationResult<E: Environment, EventLog> {
 
 impl<E: Environment, EventLog> InstantiationResult<E, EventLog> {
     /// Returns the account id at which the contract was instantiated.
-    pub fn call<Contract>(&self) -> <Contract as ContractCallBuilder>::Type
+    pub fn call_builder<Contract>(&self) -> <Contract as ContractCallBuilder>::Type
     where
         Contract: ContractCallBuilder,
         Contract::Type: FromAccountId<E>,

--- a/integration-tests/call-builder-return-value/lib.rs
+++ b/integration-tests/call-builder-return-value/lib.rs
@@ -137,7 +137,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder = call_builder.call_builder::<CallBuilderReturnValue>();
+            let mut call_builder = contract.call_builder::<CallBuilderReturnValue>();
 
             let code_hash = client
                 .upload("incrementer", &origin)

--- a/integration-tests/call-builder-return-value/lib.rs
+++ b/integration-tests/call-builder-return-value/lib.rs
@@ -137,7 +137,8 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderReturnValue>();
+            let mut call_builder_call =
+                call_builder.call_builder::<CallBuilderReturnValue>();
 
             let code_hash = client
                 .upload("incrementer", &origin)
@@ -179,7 +180,8 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderReturnValue>();
+            let mut call_builder_call =
+                call_builder.call_builder::<CallBuilderReturnValue>();
 
             let code_hash = client
                 .upload("incrementer", &origin)
@@ -223,7 +225,8 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderReturnValue>();
+            let mut call_builder_call =
+                call_builder.call_builder::<CallBuilderReturnValue>();
 
             let expected_value = 42;
             let mut incrementer_constructor = IncrementerRef::new(expected_value);
@@ -266,7 +269,8 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderReturnValue>();
+            let mut call_builder_call =
+                call_builder.call_builder::<CallBuilderReturnValue>();
 
             let expected_value = 42;
             let mut incrementer_constructor = IncrementerRef::new(expected_value);

--- a/integration-tests/call-builder-return-value/lib.rs
+++ b/integration-tests/call-builder-return-value/lib.rs
@@ -147,7 +147,7 @@ mod call_builder {
                 .code_hash;
 
             let selector = ink::selector_bytes!("get");
-            let call = contract.delegate_call(code_hash, selector);
+            let call = call_builder.delegate_call(code_hash, selector);
             let call_result = client
                 .call(&origin, &call)
                 .submit()

--- a/integration-tests/call-builder-return-value/lib.rs
+++ b/integration-tests/call-builder-return-value/lib.rs
@@ -132,12 +132,12 @@ mod call_builder {
 
             let expected_value = 42;
             let mut constructor = CallBuilderReturnValueRef::new(expected_value);
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder_return_value", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut contract = call_builder.call_builder::<CallBuilderReturnValue>();
+            let mut call_builder = call_builder.call_builder::<CallBuilderReturnValue>();
 
             let code_hash = client
                 .upload("incrementer", &origin)

--- a/integration-tests/call-builder-return-value/lib.rs
+++ b/integration-tests/call-builder-return-value/lib.rs
@@ -137,8 +137,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call =
-                call_builder.call_builder::<CallBuilderReturnValue>();
+            let mut contract = call_builder.call_builder::<CallBuilderReturnValue>();
 
             let code_hash = client
                 .upload("incrementer", &origin)
@@ -148,7 +147,7 @@ mod call_builder {
                 .code_hash;
 
             let selector = ink::selector_bytes!("get");
-            let call = call_builder_call.delegate_call(code_hash, selector);
+            let call = contract.delegate_call(code_hash, selector);
             let call_result = client
                 .call(&origin, &call)
                 .submit()
@@ -175,13 +174,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderReturnValueRef::new(42);
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder_return_value", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call =
-                call_builder.call_builder::<CallBuilderReturnValue>();
+            let mut call_builder = contract.call_builder::<CallBuilderReturnValue>();
 
             let code_hash = client
                 .upload("incrementer", &origin)
@@ -191,8 +189,7 @@ mod call_builder {
                 .code_hash;
 
             let selector = ink::selector_bytes!("get");
-            let call =
-                call_builder_call.delegate_call_short_return_type(code_hash, selector);
+            let call = call_builder.delegate_call_short_return_type(code_hash, selector);
             let call_result: Result<i8, String> =
                 client.call(&origin, &call).dry_run().await?.return_value();
 
@@ -220,13 +217,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderReturnValueRef::new(0);
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder_return_value", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call =
-                call_builder.call_builder::<CallBuilderReturnValue>();
+            let mut call_builder = contract.call_builder::<CallBuilderReturnValue>();
 
             let expected_value = 42;
             let mut incrementer_constructor = IncrementerRef::new(expected_value);
@@ -237,7 +233,7 @@ mod call_builder {
                 .expect("instantiate failed");
 
             let selector = ink::selector_bytes!("get");
-            let call = call_builder_call.forward_call(incrementer.account_id, selector);
+            let call = call_builder.forward_call(incrementer.account_id, selector);
             let call_result = client
                 .call(&origin, &call)
                 .submit()
@@ -264,13 +260,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderReturnValueRef::new(0);
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder_return_value", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call =
-                call_builder.call_builder::<CallBuilderReturnValue>();
+            let mut call_builder = contract.call_builder::<CallBuilderReturnValue>();
 
             let expected_value = 42;
             let mut incrementer_constructor = IncrementerRef::new(expected_value);
@@ -281,7 +276,7 @@ mod call_builder {
                 .expect("instantiate failed");
 
             let selector = ink::selector_bytes!("get");
-            let call = call_builder_call
+            let call = call_builder
                 .forward_call_short_return_type(incrementer.account_id, selector);
             let call_result: Result<i8, String> =
                 client.call(&origin, &call).dry_run().await?.return_value();

--- a/integration-tests/call-builder-return-value/lib.rs
+++ b/integration-tests/call-builder-return-value/lib.rs
@@ -137,7 +137,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderReturnValue>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderReturnValue>();
 
             let code_hash = client
                 .upload("incrementer", &origin)
@@ -179,7 +179,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderReturnValue>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderReturnValue>();
 
             let code_hash = client
                 .upload("incrementer", &origin)
@@ -223,7 +223,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderReturnValue>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderReturnValue>();
 
             let expected_value = 42;
             let mut incrementer_constructor = IncrementerRef::new(expected_value);
@@ -266,7 +266,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderReturnValue>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderReturnValue>();
 
             let expected_value = 42;
             let mut incrementer_constructor = IncrementerRef::new(expected_value);

--- a/integration-tests/call-runtime/lib.rs
+++ b/integration-tests/call-runtime/lib.rs
@@ -234,8 +234,8 @@ mod runtime_call {
             let receiver: AccountId = default_accounts::<DefaultEnvironment>().bob;
 
             // when
-            let transfer_message =
-                call_builder.transfer_through_runtime(receiver, INSUFFICIENT_TRANSFER_VALUE);
+            let transfer_message = call_builder
+                .transfer_through_runtime(receiver, INSUFFICIENT_TRANSFER_VALUE);
 
             let call_res = client
                 .call(&ink_e2e::alice(), &transfer_message)

--- a/integration-tests/call-runtime/lib.rs
+++ b/integration-tests/call-runtime/lib.rs
@@ -165,7 +165,7 @@ mod runtime_call {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<RuntimeCaller>();
+            let mut call_builder = contract.call_builder::<RuntimeCaller>();
 
             let receiver: AccountId = default_accounts::<DefaultEnvironment>().bob;
 
@@ -180,7 +180,7 @@ mod runtime_call {
 
             // when
             let transfer_message =
-                call.transfer_through_runtime(receiver, TRANSFER_VALUE);
+                call_builder.transfer_through_runtime(receiver, TRANSFER_VALUE);
 
             let call_res = client
                 .call(&ink_e2e::alice(), &transfer_message)
@@ -229,13 +229,13 @@ mod runtime_call {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<RuntimeCaller>();
+            let mut call_builder = contract.call_builder::<RuntimeCaller>();
 
             let receiver: AccountId = default_accounts::<DefaultEnvironment>().bob;
 
             // when
             let transfer_message =
-                call.transfer_through_runtime(receiver, INSUFFICIENT_TRANSFER_VALUE);
+                call_builder.transfer_through_runtime(receiver, INSUFFICIENT_TRANSFER_VALUE);
 
             let call_res = client
                 .call(&ink_e2e::alice(), &transfer_message)
@@ -265,10 +265,10 @@ mod runtime_call {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<RuntimeCaller>();
+            let mut call_builder = contract.call_builder::<RuntimeCaller>();
 
             // when
-            let transfer_message = call.call_nonexistent_extrinsic();
+            let transfer_message = call_builder.call_nonexistent_extrinsic();
 
             let call_res = client
                 .call(&ink_e2e::alice(), &transfer_message)

--- a/integration-tests/contract-storage/e2e_tests.rs
+++ b/integration-tests/contract-storage/e2e_tests.rs
@@ -14,13 +14,13 @@ async fn get_contract_storage_consumes_entire_buffer<Client: E2EBackend>(
         .submit()
         .await
         .expect("instantiate failed");
-    let call = contract.call::<ContractStorage>();
+    let call_builder = contract.call_builder::<ContractStorage>();
 
     // when
     let result = client
         .call(
             &ink_e2e::alice(),
-            &call.set_and_get_storage_all_data_consumed(),
+            &call_builder.set_and_get_storage_all_data_consumed(),
         )
         .submit()
         .await
@@ -43,13 +43,13 @@ async fn get_contract_storage_fails_when_extra_data<Client: E2EBackend>(
         .submit()
         .await
         .expect("instantiate failed");
-    let call = contract.call::<ContractStorage>();
+    let call_builder = contract.call_builder::<ContractStorage>();
 
     // when
     let result = client
         .call(
             &ink_e2e::alice(),
-            &call.set_and_get_storage_partial_data_consumed(),
+            &call_builder.set_and_get_storage_partial_data_consumed(),
         )
         .submit()
         .await;
@@ -73,13 +73,13 @@ async fn take_contract_storage_consumes_entire_buffer<Client: E2EBackend>(
         .submit()
         .await
         .expect("instantiate failed");
-    let call = contract.call::<ContractStorage>();
+    let call_builder = contract.call_builder::<ContractStorage>();
 
     // when
     let result = client
         .call(
             &ink_e2e::alice(),
-            &call.set_and_take_storage_all_data_consumed(),
+            &call_builder.set_and_take_storage_all_data_consumed(),
         )
         .submit()
         .await
@@ -102,13 +102,13 @@ async fn take_contract_storage_fails_when_extra_data<Client: E2EBackend>(
         .submit()
         .await
         .expect("instantiate failed");
-    let call = contract.call::<ContractStorage>();
+    let call_builder = contract.call_builder::<ContractStorage>();
 
     // when
     let result = client
         .call(
             &ink_e2e::alice(),
-            &call.set_and_take_storage_partial_data_consumed(),
+            &call_builder.set_and_take_storage_partial_data_consumed(),
         )
         .submit()
         .await;

--- a/integration-tests/contract-terminate/lib.rs
+++ b/integration-tests/contract-terminate/lib.rs
@@ -71,10 +71,10 @@ pub mod just_terminates {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<JustTerminate>();
+            let mut call_builder = contract.call_builder::<JustTerminate>();
 
             // when
-            let terminate_me = call.terminate_me();
+            let terminate_me = call_builder.terminate_me();
             let call_res = client
                 .call(&ink_e2e::alice(), &terminate_me)
                 .submit()

--- a/integration-tests/contract-transfer/lib.rs
+++ b/integration-tests/contract-transfer/lib.rs
@@ -201,10 +201,10 @@ pub mod give_me {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<GiveMe>();
+            let mut call_builder = contract.call_builder::<GiveMe>();
 
             // when
-            let transfer = call.give_me(120);
+            let transfer = call_builder.give_me(120);
 
             let call_res = client
                 .call(&ink_e2e::bob(), &transfer)
@@ -233,7 +233,7 @@ pub mod give_me {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<GiveMe>();
+            let mut call_builder = contract.call_builder::<GiveMe>();
 
             let balance_before: Balance = client
                 .free_balance(contract.account_id.clone())
@@ -241,7 +241,7 @@ pub mod give_me {
                 .expect("getting balance failed");
 
             // when
-            let transfer = call.give_me(120);
+            let transfer = call_builder.give_me(120);
 
             let call_res = client
                 .call(&ink_e2e::eve(), &transfer)

--- a/integration-tests/custom-allocator/lib.rs
+++ b/integration-tests/custom-allocator/lib.rs
@@ -124,10 +124,10 @@ mod custom_allocator {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let call = contract.call::<CustomAllocator>();
+            let call_builder = contract.call_builder::<CustomAllocator>();
 
             // Then
-            let get = call.get();
+            let get = call_builder.get();
             let get_result = client.call(&ink_e2e::alice(), &get).dry_run().await?;
             assert!(matches!(get_result.return_value(), false));
 
@@ -145,14 +145,14 @@ mod custom_allocator {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<CustomAllocator>();
+            let mut call_builder = contract.call_builder::<CustomAllocator>();
 
-            let get = call.get();
+            let get = call_builder.get();
             let get_result = client.call(&ink_e2e::bob(), &get).dry_run().await?;
             assert!(matches!(get_result.return_value(), false));
 
             // When
-            let flip = call.flip();
+            let flip = call_builder.flip();
             let _flip_result = client
                 .call(&ink_e2e::bob(), &flip)
                 .submit()
@@ -160,7 +160,7 @@ mod custom_allocator {
                 .expect("flip failed");
 
             // Then
-            let get = call.get();
+            let get = call_builder.get();
             let get_result = client.call(&ink_e2e::bob(), &get).dry_run().await?;
             assert!(matches!(get_result.return_value(), true));
 

--- a/integration-tests/custom-environment/lib.rs
+++ b/integration-tests/custom-environment/lib.rs
@@ -97,10 +97,10 @@ mod runtime_call {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Topics>();
+            let mut call_builder = contract.call_builder::<Topics>();
 
             // when
-            let message = call.trigger();
+            let message = call_builder.trigger();
 
             let call_res = client
                 .call(&ink_e2e::alice(), &message)
@@ -128,9 +128,9 @@ mod runtime_call {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Topics>();
+            let mut call_builder = contract.call_builder::<Topics>();
 
-            let message = call.trigger();
+            let message = call_builder.trigger();
 
             // when
             let call_res = client

--- a/integration-tests/e2e-call-runtime/lib.rs
+++ b/integration-tests/e2e-call-runtime/lib.rs
@@ -40,7 +40,7 @@ pub mod e2e_call_runtime {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let call = contract.call::<Contract>();
+            let call_builder = contract.call_builder::<Contract>();
 
             let transfer_amount = 100_000_000_000u128;
 
@@ -54,7 +54,7 @@ pub mod e2e_call_runtime {
                 Value::u128(transfer_amount),
             ];
 
-            let get_balance = call.get_contract_balance();
+            let get_balance = call_builder.get_contract_balance();
             let pre_balance = client
                 .call(&ink_e2e::alice(), &get_balance)
                 .dry_run()
@@ -73,7 +73,7 @@ pub mod e2e_call_runtime {
                 .expect("runtime call failed");
 
             // then
-            let get_balance = call.get_contract_balance();
+            let get_balance = call_builder.get_contract_balance();
             let get_balance_res = client
                 .call(&ink_e2e::alice(), &get_balance)
                 .dry_run()

--- a/integration-tests/e2e-runtime-only-backend/lib.rs
+++ b/integration-tests/e2e-runtime-only-backend/lib.rs
@@ -73,10 +73,16 @@ pub mod flipper {
 
             // when
             let mut call_builder = contract.call_builder::<Flipper>();
-            let _flip_res = client.call(&ink_e2e::bob(), &call_builder.flip()).submit().await;
+            let _flip_res = client
+                .call(&ink_e2e::bob(), &call_builder.flip())
+                .submit()
+                .await;
 
             // then
-            let get_res = client.call(&ink_e2e::bob(), &call_builder.get()).dry_run().await?;
+            let get_res = client
+                .call(&ink_e2e::bob(), &call_builder.get())
+                .dry_run()
+                .await?;
             assert_eq!(get_res.return_value(), !INITIAL_VALUE);
 
             Ok(())

--- a/integration-tests/e2e-runtime-only-backend/lib.rs
+++ b/integration-tests/e2e-runtime-only-backend/lib.rs
@@ -72,11 +72,11 @@ pub mod flipper {
                 .expect("deploy failed");
 
             // when
-            let mut call = contract.call::<Flipper>();
-            let _flip_res = client.call(&ink_e2e::bob(), &call.flip()).submit().await;
+            let mut call_builder = contract.call_builder::<Flipper>();
+            let _flip_res = client.call(&ink_e2e::bob(), &call_builder.flip()).submit().await;
 
             // then
-            let get_res = client.call(&ink_e2e::bob(), &call.get()).dry_run().await?;
+            let get_res = client.call(&ink_e2e::bob(), &call_builder.get()).dry_run().await?;
             assert_eq!(get_res.return_value(), !INITIAL_VALUE);
 
             Ok(())
@@ -102,10 +102,10 @@ pub mod flipper {
                 .submit()
                 .await
                 .expect("deploy failed");
-            let call = contract.call::<Flipper>();
+            let call_builder = contract.call_builder::<Flipper>();
 
             let old_balance = client
-                .call(&ink_e2e::alice(), &call.get_contract_balance())
+                .call(&ink_e2e::alice(), &call_builder.get_contract_balance())
                 .submit()
                 .await
                 .expect("get_contract_balance failed")
@@ -130,7 +130,7 @@ pub mod flipper {
 
             // then
             let new_balance = client
-                .call(&ink_e2e::alice(), &call.get_contract_balance())
+                .call(&ink_e2e::alice(), &call_builder.get_contract_balance())
                 .submit()
                 .await
                 .expect("get_contract_balance failed")

--- a/integration-tests/erc20/lib.rs
+++ b/integration-tests/erc20/lib.rs
@@ -582,7 +582,8 @@ mod erc20 {
 
             let amount = 500_000_000u128;
             // tx
-            let transfer_from = call_builder.transfer_from(bob_account, charlie_account, amount);
+            let transfer_from =
+                call_builder.transfer_from(bob_account, charlie_account, amount);
             let transfer_from_result = client
                 .call(&ink_e2e::charlie(), &transfer_from)
                 .submit()
@@ -621,7 +622,8 @@ mod erc20 {
                 .await?;
 
             // `transfer_from` again, this time exceeding the approved amount
-            let transfer_from = call_builder.transfer_from(bob_account, charlie_account, 1);
+            let transfer_from =
+                call_builder.transfer_from(bob_account, charlie_account, 1);
             let transfer_from_result = client
                 .call(&ink_e2e::charlie(), &transfer_from)
                 .submit()

--- a/integration-tests/erc20/lib.rs
+++ b/integration-tests/erc20/lib.rs
@@ -528,10 +528,10 @@ mod erc20 {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = erc20.call::<Erc20>();
+            let mut call_builder = erc20.call_builder::<Erc20>();
 
             // when
-            let total_supply_msg = call.total_supply();
+            let total_supply_msg = call_builder.total_supply();
             let total_supply_res = client
                 .call(&ink_e2e::bob(), &total_supply_msg)
                 .dry_run()
@@ -539,14 +539,14 @@ mod erc20 {
 
             let bob_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Bob);
             let transfer_to_bob = 500_000_000u128;
-            let transfer = call.transfer(bob_account, transfer_to_bob);
+            let transfer = call_builder.transfer(bob_account, transfer_to_bob);
             let _transfer_res = client
                 .call(&ink_e2e::alice(), &transfer)
                 .submit()
                 .await
                 .expect("transfer failed");
 
-            let balance_of = call.balance_of(bob_account);
+            let balance_of = call_builder.balance_of(bob_account);
             let balance_of_res = client
                 .call(&ink_e2e::alice(), &balance_of)
                 .dry_run()
@@ -573,7 +573,7 @@ mod erc20 {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = erc20.call::<Erc20>();
+            let mut call_builder = erc20.call_builder::<Erc20>();
 
             // when
 
@@ -582,7 +582,7 @@ mod erc20 {
 
             let amount = 500_000_000u128;
             // tx
-            let transfer_from = call.transfer_from(bob_account, charlie_account, amount);
+            let transfer_from = call_builder.transfer_from(bob_account, charlie_account, amount);
             let transfer_from_result = client
                 .call(&ink_e2e::charlie(), &transfer_from)
                 .submit()
@@ -595,7 +595,7 @@ mod erc20 {
 
             // Bob approves Charlie to transfer up to amount on his behalf
             let approved_value = 1_000u128;
-            let approve_call = call.approve(charlie_account, approved_value);
+            let approve_call = call_builder.approve(charlie_account, approved_value);
             client
                 .call(&ink_e2e::bob(), &approve_call)
                 .submit()
@@ -604,7 +604,7 @@ mod erc20 {
 
             // `transfer_from` the approved amount
             let transfer_from =
-                call.transfer_from(bob_account, charlie_account, approved_value);
+                call_builder.transfer_from(bob_account, charlie_account, approved_value);
             let transfer_from_result = client
                 .call(&ink_e2e::charlie(), &transfer_from)
                 .submit()
@@ -614,14 +614,14 @@ mod erc20 {
                 "approved transfer_from should succeed"
             );
 
-            let balance_of = call.balance_of(bob_account);
+            let balance_of = call_builder.balance_of(bob_account);
             let balance_of_res = client
                 .call(&ink_e2e::alice(), &balance_of)
                 .dry_run()
                 .await?;
 
             // `transfer_from` again, this time exceeding the approved amount
-            let transfer_from = call.transfer_from(bob_account, charlie_account, 1);
+            let transfer_from = call_builder.transfer_from(bob_account, charlie_account, 1);
             let transfer_from_result = client
                 .call(&ink_e2e::charlie(), &transfer_from)
                 .submit()

--- a/integration-tests/events/lib.rs
+++ b/integration-tests/events/lib.rs
@@ -257,10 +257,10 @@ pub mod events {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Events>();
+            let mut call_builder = contract.call_builder::<Events>();
 
             // when
-            let flip = call.flip_with_foreign_event();
+            let flip = call_builder.flip_with_foreign_event();
             let flip_res = client
                 .call(&ink_e2e::bob(), &flip)
                 .submit()
@@ -300,10 +300,10 @@ pub mod events {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Events>();
+            let mut call_builder = contract.call_builder::<Events>();
 
             // when
-            let flip = call.flip_with_inline_event();
+            let flip = call_builder.flip_with_inline_event();
             let flip_res = client
                 .call(&ink_e2e::bob(), &flip)
                 .submit()
@@ -342,10 +342,10 @@ pub mod events {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let call = contract.call::<Events>();
+            let call_builder = contract.call_builder::<Events>();
 
             // when
-            let call = call.emit_32_byte_topic_event(None);
+            let call = call_builder.emit_32_byte_topic_event(None);
             let call_res = client
                 .call(&ink_e2e::bob(), &call)
                 .submit()
@@ -389,10 +389,10 @@ pub mod events {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Events>();
+            let mut call_builder = contract.call_builder::<Events>();
 
             // when
-            let call = call.flip_with_inline_custom_event();
+            let call = call_builder.flip_with_inline_custom_event();
             let call_res = client
                 .call(&ink_e2e::bob(), &call)
                 .submit()

--- a/integration-tests/flipper/lib.rs
+++ b/integration-tests/flipper/lib.rs
@@ -68,14 +68,14 @@ pub mod flipper {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Flipper>();
+            let mut call_builder = contract.call_builder::<Flipper>();
 
-            let get = call.get();
+            let get = call_builder.get();
             let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await?;
             assert!(matches!(get_res.return_value(), false));
 
             // when
-            let flip = call.flip();
+            let flip = call_builder.flip();
             let _flip_res = client
                 .call(&ink_e2e::bob(), &flip)
                 .submit()
@@ -83,7 +83,7 @@ pub mod flipper {
                 .expect("flip failed");
 
             // then
-            let get = call.get();
+            let get = call_builder.get();
             let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await?;
             assert!(matches!(get_res.return_value(), true));
 
@@ -101,10 +101,10 @@ pub mod flipper {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let call = contract.call::<Flipper>();
+            let call_builder = contract.call_builder::<Flipper>();
 
             // then
-            let get = call.get();
+            let get = call_builder.get();
             let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await?;
             assert!(matches!(get_res.return_value(), false));
 

--- a/integration-tests/lang-err-integration-tests/call-builder-delegate/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder-delegate/lib.rs
@@ -110,13 +110,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderDelegateTestRef::new(Default::default());
-            let call_builder_contract = client
+            let contract = client
                 .instantiate("call_builder_delegate", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call =
-                call_builder_contract.call_builder::<CallBuilderDelegateTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderDelegateTest>();
 
             let code_hash = client
                 .upload("incrementer", &origin)
@@ -126,7 +125,7 @@ mod call_builder {
                 .code_hash;
 
             let selector = ink::selector_bytes!("invalid_selector");
-            let call = call_builder_call.delegate(code_hash, selector);
+            let call = call_builder.delegate(code_hash, selector);
             let call_result = client
                 .call(&origin, &call)
                 .submit()
@@ -150,13 +149,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderDelegateTestRef::new(Default::default());
-            let call_builder_contract = client
+            let contract = client
                 .instantiate("call_builder_delegate", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call =
-                call_builder_contract.call_builder::<CallBuilderDelegateTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderDelegateTest>();
 
             let code_hash = client
                 .upload("incrementer", &origin)
@@ -168,7 +166,7 @@ mod call_builder {
             // Since `LangError`s can't be handled by the `CallBuilder::invoke()` method
             // we expect this to panic.
             let selector = ink::selector_bytes!("invalid_selector");
-            let call = call_builder_call.invoke(code_hash, selector);
+            let call = call_builder.invoke(code_hash, selector);
             let call_result = client.call(&origin, &call).dry_run().await;
 
             if let Err(ink_e2e::Error::CallDryRun(dry_run)) = call_result {

--- a/integration-tests/lang-err-integration-tests/call-builder-delegate/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder-delegate/lib.rs
@@ -116,7 +116,7 @@ mod call_builder {
                 .await
                 .expect("instantiate failed");
             let mut call_builder_call =
-                call_builder_contract.call::<CallBuilderDelegateTest>();
+                call_builder_contract.call_builder::<CallBuilderDelegateTest>();
 
             let code_hash = client
                 .upload("incrementer", &origin)
@@ -156,7 +156,7 @@ mod call_builder {
                 .await
                 .expect("instantiate failed");
             let mut call_builder_call =
-                call_builder_contract.call::<CallBuilderDelegateTest>();
+                call_builder_contract.call_builder::<CallBuilderDelegateTest>();
 
             let code_hash = client
                 .upload("incrementer", &origin)

--- a/integration-tests/lang-err-integration-tests/call-builder/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder/lib.rs
@@ -191,7 +191,8 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder_contract.call_builder::<CallBuilderTest>();
+            let mut call_builder_call =
+                call_builder_contract.call_builder::<CallBuilderTest>();
 
             let mut flipper_constructor = FlipperRef::new_default();
             let flipper = client

--- a/integration-tests/lang-err-integration-tests/call-builder/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder/lib.rs
@@ -186,13 +186,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderTestRef::new();
-            let call_builder_contract = client
+            let contract = client
                 .instantiate("call_builder", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call =
-                call_builder_contract.call_builder::<CallBuilderTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderTest>();
 
             let mut flipper_constructor = FlipperRef::new_default();
             let flipper = client
@@ -207,7 +206,7 @@ mod call_builder {
             let initial_value = get_call_result.return_value();
 
             let selector = ink::selector_bytes!("invalid_selector");
-            let call = call_builder_call.call(flipper.account_id, selector);
+            let call = call_builder.call(flipper.account_id, selector);
             let call_result = client
                 .call(&origin, &call)
                 .submit()
@@ -238,12 +237,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderTestRef::new();
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderTest>();
 
             let mut flipper_constructor = FlipperRef::new_default();
             let flipper = client
@@ -255,7 +254,7 @@ mod call_builder {
             // Since `LangError`s can't be handled by the `CallBuilder::invoke()` method
             // we expect this to panic.
             let invalid_selector = [0x00, 0x00, 0x00, 0x00];
-            let call = call_builder_call.invoke(flipper.account_id, invalid_selector);
+            let call = call_builder.invoke(flipper.account_id, invalid_selector);
             let call_result = client.call(&origin, &call).dry_run().await;
 
             if let Err(ink_e2e::Error::CallDryRun(dry_run)) = call_result {
@@ -281,12 +280,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderTestRef::new();
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -297,8 +296,7 @@ mod call_builder {
 
             let selector = ink::selector_bytes!("new");
             let init_value = true;
-            let call =
-                call_builder_call.call_instantiate(code_hash, selector, init_value);
+            let call = call_builder.call_instantiate(code_hash, selector, init_value);
             let call_result = client
                 .call(&origin, &call)
                 .submit()
@@ -323,12 +321,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderTestRef::new();
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -339,8 +337,7 @@ mod call_builder {
 
             let selector = ink::selector_bytes!("invalid_selector");
             let init_value = true;
-            let call =
-                call_builder_call.call_instantiate(code_hash, selector, init_value);
+            let call = call_builder.call_instantiate(code_hash, selector, init_value);
             let call_result = client
                 .call(&origin, &call)
                 .submit()
@@ -367,12 +364,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderTestRef::new();
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -383,8 +380,7 @@ mod call_builder {
 
             let selector = ink::selector_bytes!("revert_new");
             let init_value = false;
-            let call =
-                call_builder_call.call_instantiate(code_hash, selector, init_value);
+            let call = call_builder.call_instantiate(code_hash, selector, init_value);
 
             let call_result = client.call(&origin, &call).dry_run().await;
 
@@ -411,12 +407,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderTestRef::new();
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -427,8 +423,8 @@ mod call_builder {
 
             let selector = ink::selector_bytes!("try_new");
             let init_value = true;
-            let call = call_builder_call
-                .call_instantiate_fallible(code_hash, selector, init_value);
+            let call =
+                call_builder.call_instantiate_fallible(code_hash, selector, init_value);
             let call_result = client
                 .call(&origin, &call)
                 .submit()
@@ -455,12 +451,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderTestRef::new();
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -471,8 +467,8 @@ mod call_builder {
 
             let selector = ink::selector_bytes!("try_new");
             let init_value = false;
-            let call = call_builder_call
-                .call_instantiate_fallible(code_hash, selector, init_value);
+            let call =
+                call_builder.call_instantiate_fallible(code_hash, selector, init_value);
             let call_result = client
                 .call(&origin, &call)
                 .submit()
@@ -506,12 +502,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderTestRef::new();
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -522,8 +518,8 @@ mod call_builder {
 
             let selector = ink::selector_bytes!("try_revert_new");
             let init_value = true;
-            let call = call_builder_call
-                .call_instantiate_fallible(code_hash, selector, init_value);
+            let call =
+                call_builder.call_instantiate_fallible(code_hash, selector, init_value);
             let call_result = client.call(&origin, &call).dry_run().await;
 
             if let Err(ink_e2e::Error::CallDryRun(dry_run)) = call_result {
@@ -549,12 +545,12 @@ mod call_builder {
                 .await;
 
             let mut constructor = CallBuilderTestRef::new();
-            let call_builder = client
+            let contract = client
                 .instantiate("call_builder", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
+            let mut call_builder = contract.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -565,8 +561,8 @@ mod call_builder {
 
             let selector = ink::selector_bytes!("try_revert_new");
             let init_value = false;
-            let call = call_builder_call
-                .call_instantiate_fallible(code_hash, selector, init_value);
+            let call =
+                call_builder.call_instantiate_fallible(code_hash, selector, init_value);
             let call_result = client
                 .call(&origin, &call)
                 .submit()

--- a/integration-tests/lang-err-integration-tests/call-builder/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder/lib.rs
@@ -191,7 +191,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder_contract.call::<CallBuilderTest>();
+            let mut call_builder_call = call_builder_contract.call_builder::<CallBuilderTest>();
 
             let mut flipper_constructor = FlipperRef::new_default();
             let flipper = client
@@ -199,7 +199,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate `flipper` failed");
-            let flipper_call = flipper.call::<Flipper>();
+            let flipper_call = flipper.call_builder::<Flipper>();
 
             let flipper_get = flipper_call.get();
             let get_call_result = client.call(&origin, &flipper_get).dry_run().await?;
@@ -242,7 +242,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderTest>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
 
             let mut flipper_constructor = FlipperRef::new_default();
             let flipper = client
@@ -285,7 +285,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderTest>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -327,7 +327,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderTest>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -371,7 +371,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderTest>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -415,7 +415,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderTest>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -459,7 +459,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderTest>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -510,7 +510,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderTest>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)
@@ -553,7 +553,7 @@ mod call_builder {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<CallBuilderTest>();
+            let mut call_builder_call = call_builder.call_builder::<CallBuilderTest>();
 
             let code_hash = client
                 .upload("constructors_return_value", &origin)

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/lib.rs
@@ -184,9 +184,9 @@ pub mod constructors_return_value {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let call = contract.call::<ConstructorsReturnValue>();
+            let call_builder = contract.call_builder::<ConstructorsReturnValue>();
 
-            let get = call.get_value();
+            let get = call_builder.get_value();
             let value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()

--- a/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
+++ b/integration-tests/lang-err-integration-tests/contract-ref/lib.rs
@@ -89,15 +89,15 @@ mod contract_ref {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract_ref.call::<ContractRef>();
+            let mut call_builder = contract_ref.call_builder::<ContractRef>();
 
-            let get_check = call.get_check();
+            let get_check = call_builder.get_check();
             let get_call_result =
                 client.call(&ink_e2e::alice(), &get_check).dry_run().await?;
 
             let initial_value = get_call_result.return_value();
 
-            let flip_check = call.flip_check();
+            let flip_check = call_builder.flip_check();
             let flip_call_result = client
                 .call(&ink_e2e::alice(), &flip_check)
                 .submit()
@@ -134,9 +134,9 @@ mod contract_ref {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract_ref.call::<ContractRef>();
+            let mut call_builder = contract_ref.call_builder::<ContractRef>();
 
-            let get_check = call.get_check();
+            let get_check = call_builder.get_check();
             let get_call_result =
                 client.call(&ink_e2e::bob(), &get_check).dry_run().await?;
             let initial_value = get_call_result.return_value();

--- a/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/lib.rs
@@ -81,16 +81,16 @@ pub mod integration_flipper {
                 .submit()
                 .await
                 .expect("Instantiate `integration_flipper` failed");
-            let mut call = flipper.call::<Flipper>();
+            let mut call_builder = flipper.call_builder::<Flipper>();
 
-            let get = call.get();
+            let get = call_builder.get();
             let initial_value = client
                 .call(&ink_e2e::alice(), &get)
                 .dry_run()
                 .await?
                 .return_value();
 
-            let flip = call.flip();
+            let flip = call_builder.flip();
             let flip_call_result = client
                 .call(&ink_e2e::alice(), &flip)
                 .submit()
@@ -121,16 +121,16 @@ pub mod integration_flipper {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = flipper.call::<Flipper>();
+            let mut call_builder = flipper.call_builder::<Flipper>();
 
-            let get = call.get();
+            let get = call_builder.get();
             let initial_value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()
                 .await?
                 .return_value();
 
-            let err_flip = call.err_flip();
+            let err_flip = call_builder.err_flip();
             let err_flip_call_result =
                 client.call(&ink_e2e::bob(), &err_flip).submit().await;
 

--- a/integration-tests/lazyvec-integration-test/lib.rs
+++ b/integration-tests/lazyvec-integration-test/lib.rs
@@ -111,17 +111,17 @@ mod lazyvec_integration_tests {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<LazyVector>();
+            let mut call_builder = contract.call_builder::<LazyVector>();
 
             // when
-            let create = call.create_proposal(vec![0x41], 5, 1);
+            let create = call_builder.create_proposal(vec![0x41], 5, 1);
             let _ = client
                 .call(&ink_e2e::alice(), &create)
                 .submit()
                 .await
                 .expect("Calling `create_proposal` failed");
 
-            let approve = call.approve();
+            let approve = call_builder.approve();
             let _ = client
                 .call(&ink_e2e::alice(), &approve)
                 .submit()
@@ -143,7 +143,7 @@ mod lazyvec_integration_tests {
             assert_eq!(value, None);
 
             let value = client
-                .call(&ink_e2e::alice(), &call.get(0))
+                .call(&ink_e2e::alice(), &call_builder.get(0))
                 .dry_run()
                 .await
                 .expect("get trapped when it shouldn't")

--- a/integration-tests/mapping-integration-tests/lib.rs
+++ b/integration-tests/mapping-integration-tests/lib.rs
@@ -405,7 +405,7 @@ mod mapping_integration_tests {
 
             // then there should be 4 entries (that's what fits into the 256kb buffer)
             let received_mapping_value = client
-                .call(&ink_e2e::ferdie(), &let call_builder = contract.calltry_get_names())
+                .call(&ink_e2e::ferdie(), &call_builder.try_get_names())
                 .dry_run()
                 .await?
                 .return_value();

--- a/integration-tests/mapping-integration-tests/lib.rs
+++ b/integration-tests/mapping-integration-tests/lib.rs
@@ -162,10 +162,10 @@ mod mapping_integration_tests {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Mappings>();
+            let mut call_builder = contract.call_builder::<Mappings>();
 
             // when
-            let insert = call.insert_balance(1_000);
+            let insert = call_builder.insert_balance(1_000);
             let size = client
                 .call(&ink_e2e::alice(), &insert)
                 .submit()
@@ -174,7 +174,7 @@ mod mapping_integration_tests {
                 .return_value();
 
             // then
-            let get = call.get_balance();
+            let get = call_builder.get_balance();
             let balance = client
                 .call(&ink_e2e::alice(), &get)
                 .dry_run()
@@ -202,10 +202,10 @@ mod mapping_integration_tests {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Mappings>();
+            let mut call_builder = contract.call_builder::<Mappings>();
 
             // when
-            let insert = call.insert_balance(1_000);
+            let insert = call_builder.insert_balance(1_000);
             let _ = client
                 .call(&ink_e2e::bob(), &insert)
                 .submit()
@@ -214,7 +214,7 @@ mod mapping_integration_tests {
                 .return_value();
 
             // then
-            let contains = call.contains_balance();
+            let contains = call_builder.contains_balance();
             let is_there = client
                 .call(&ink_e2e::bob(), &contains)
                 .dry_run()
@@ -239,10 +239,10 @@ mod mapping_integration_tests {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Mappings>();
+            let mut call_builder = contract.call_builder::<Mappings>();
 
             // when
-            let first_insert = call.insert_balance(1_000);
+            let first_insert = call_builder.insert_balance(1_000);
             let _ = client
                 .call(&ink_e2e::charlie(), &first_insert)
                 .submit()
@@ -250,7 +250,7 @@ mod mapping_integration_tests {
                 .expect("Calling `insert_balance` failed")
                 .return_value();
 
-            let insert = call.insert_balance(10_000);
+            let insert = call_builder.insert_balance(10_000);
             let size = client
                 .call(&ink_e2e::charlie(), &insert)
                 .submit()
@@ -261,7 +261,7 @@ mod mapping_integration_tests {
             // then
             assert!(size.is_some());
 
-            let get = call.get_balance();
+            let get = call_builder.get_balance();
             let balance = client
                 .call(&ink_e2e::charlie(), &get)
                 .dry_run()
@@ -288,10 +288,10 @@ mod mapping_integration_tests {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Mappings>();
+            let mut call_builder = contract.call_builder::<Mappings>();
 
             // when
-            let insert = call.insert_balance(3_000);
+            let insert = call_builder.insert_balance(3_000);
             let _ = client
                 .call(&ink_e2e::dave(), &insert)
                 .submit()
@@ -299,7 +299,7 @@ mod mapping_integration_tests {
                 .expect("Calling `insert_balance` failed")
                 .return_value();
 
-            let remove = call.remove_balance();
+            let remove = call_builder.remove_balance();
             let _ = client
                 .call(&ink_e2e::dave(), &remove)
                 .submit()
@@ -307,7 +307,7 @@ mod mapping_integration_tests {
                 .expect("Calling `remove_balance` failed");
 
             // then
-            let get = call.get_balance();
+            let get = call_builder.get_balance();
             let balance = client
                 .call(&ink_e2e::dave(), &get)
                 .dry_run()
@@ -334,10 +334,10 @@ mod mapping_integration_tests {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Mappings>();
+            let mut call_builder = contract.call_builder::<Mappings>();
 
             // when
-            let insert = call.insert_balance(4_000);
+            let insert = call_builder.insert_balance(4_000);
             let _ = client
                 .call(&ink_e2e::eve(), &insert)
                 .submit()
@@ -345,7 +345,7 @@ mod mapping_integration_tests {
                 .expect("Calling `insert_balance` failed")
                 .return_value();
 
-            let take = call.take_balance();
+            let take = call_builder.take_balance();
             let balance = client
                 .call(&ink_e2e::eve(), &take)
                 .submit()
@@ -356,7 +356,7 @@ mod mapping_integration_tests {
             // then
             assert_eq!(balance, Some(4_000));
 
-            let contains = call.contains_balance();
+            let contains = call_builder.contains_balance();
             let is_there = client
                 .call(&ink_e2e::eve(), &contains)
                 .dry_run()
@@ -383,11 +383,11 @@ mod mapping_integration_tests {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Mappings>();
+            let mut call_builder = contract.call_builder::<Mappings>();
 
             // when the mapping value overgrows the buffer
             let name = ink_e2e::ferdie().public_key().to_account_id().to_string();
-            let insert = call.try_insert_name(name.clone());
+            let insert = call_builder.try_insert_name(name.clone());
             let mut names = Vec::new();
             while let Ok(_) = client.call(&ink_e2e::ferdie(), &insert).submit().await {
                 names.push(name.clone())
@@ -405,7 +405,7 @@ mod mapping_integration_tests {
 
             // then there should be 4 entries (that's what fits into the 256kb buffer)
             let received_mapping_value = client
-                .call(&ink_e2e::ferdie(), &call.try_get_names())
+                .call(&ink_e2e::ferdie(), &let call_builder = contract.calltry_get_names())
                 .dry_run()
                 .await?
                 .return_value();

--- a/integration-tests/multi-contract-caller/lib.rs
+++ b/integration-tests/multi-contract-caller/lib.rs
@@ -157,17 +157,17 @@ mod multi_contract_caller {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = multi_contract_caller.call::<MultiContractCaller>();
+            let mut call_builder = multi_contract_caller.call_builder::<MultiContractCaller>();
 
             // when
-            let get = call.get();
+            let get = call_builder.get();
             let value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()
                 .await?
                 .return_value();
             assert_eq!(value, 1234);
-            let change = call.change(6);
+            let change = call_builder.change(6);
             let _ = client
                 .call(&ink_e2e::bob(), &change)
                 .submit()
@@ -175,7 +175,7 @@ mod multi_contract_caller {
                 .expect("calling `change` failed");
 
             // then
-            let get = call.get();
+            let get = call_builder.get();
             let value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()
@@ -184,13 +184,13 @@ mod multi_contract_caller {
             assert_eq!(value, 1234 + 6);
 
             // when
-            let switch = call.switch();
+            let switch = call_builder.switch();
             let _ = client
                 .call(&ink_e2e::bob(), &switch)
                 .submit()
                 .await
                 .expect("calling `switch` failed");
-            let change = call.change(3);
+            let change = call_builder.change(3);
             let _ = client
                 .call(&ink_e2e::bob(), &change)
                 .submit()
@@ -198,7 +198,7 @@ mod multi_contract_caller {
                 .expect("calling `change` failed");
 
             // then
-            let get = call.get();
+            let get = call_builder.get();
             let value = client
                 .call(&ink_e2e::bob(), &get)
                 .dry_run()

--- a/integration-tests/multi-contract-caller/lib.rs
+++ b/integration-tests/multi-contract-caller/lib.rs
@@ -157,7 +157,8 @@ mod multi_contract_caller {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder = multi_contract_caller.call_builder::<MultiContractCaller>();
+            let mut call_builder =
+                multi_contract_caller.call_builder::<MultiContractCaller>();
 
             // when
             let get = call_builder.get();

--- a/integration-tests/static-buffer/lib.rs
+++ b/integration-tests/static-buffer/lib.rs
@@ -60,10 +60,10 @@ pub mod static_buffer {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let call = contract.call::<StaticBuffer>();
+            let call_builder = contract.call_builder::<StaticBuffer>();
 
             // when
-            let get = call.get_caller();
+            let get = call_builder.get_caller();
             // then panics if `INK_STATIC_BUFFER_SIZE` is less than 32 bytes.
             let res = client.call(&ink_e2e::bob(), &get).dry_run().await;
             println!("{}", super::BUFFER_SIZE);

--- a/integration-tests/trait-dyn-cross-contract-calls/lib.rs
+++ b/integration-tests/trait-dyn-cross-contract-calls/lib.rs
@@ -87,7 +87,7 @@ mod e2e_tests {
             .submit()
             .await
             .expect("instantiate failed");
-        let incrementer_call = incrementer.call::<Incrementer>();
+        let incrementer_call = incrementer.call_builder::<Incrementer>();
 
         let mut constructor = CallerRef::new(incrementer.account_id.clone());
 
@@ -100,7 +100,7 @@ mod e2e_tests {
             .submit()
             .await
             .expect("instantiate failed");
-        let mut caller_call = caller.call::<Caller>();
+        let mut caller_call = caller.call_builder::<Caller>();
 
         // Check through the caller that the value of the incrementer is zero
         let get = caller_call.get();

--- a/integration-tests/upgradeable-contracts/delegator/lib.rs
+++ b/integration-tests/upgradeable-contracts/delegator/lib.rs
@@ -113,7 +113,7 @@ pub mod delegator {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<Delegator>();
+            let mut call_builder_call = call_builder.call_builder::<Delegator>();
 
             let code_hash = client
                 .upload("delegatee", &origin)
@@ -133,9 +133,9 @@ pub mod delegator {
 
             // then
             let expected_value = 4;
-            let call = call_builder.call::<Delegator>();
+            let call = call_builder.call_builder::<Delegator>();
 
-            let call_get = call.get_counter();
+            let call_get = call_builder.get_counter();
             let call_get_result = client
                 .call(&origin, &call_get)
                 .dry_run()
@@ -166,7 +166,7 @@ pub mod delegator {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call::<Delegator>();
+            let mut call_builder_call = call_builder.call_builder::<Delegator>();
 
             let code_hash = client
                 .upload("delegatee", &origin)

--- a/integration-tests/upgradeable-contracts/delegator/lib.rs
+++ b/integration-tests/upgradeable-contracts/delegator/lib.rs
@@ -108,12 +108,12 @@ pub mod delegator {
                 .await;
 
             let mut constructor = DelegatorRef::new_default();
-            let call_builder = client
+            let contract = client
                 .instantiate("delegator", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<Delegator>();
+            let mut call_builder = contract.call_builder::<Delegator>();
 
             let code_hash = client
                 .upload("delegatee", &origin)
@@ -123,7 +123,7 @@ pub mod delegator {
                 .code_hash;
 
             // when
-            let call_delegate = call_builder_call.inc_delegate(code_hash);
+            let call_delegate = call_builder.inc_delegate(code_hash);
 
             let result = client.call(&origin, &call_delegate).submit().await;
             assert!(result.is_ok(), "delegate call failed.");
@@ -133,7 +133,7 @@ pub mod delegator {
 
             // then
             let expected_value = 4;
-            let call_builder = call_builder.call_builder::<Delegator>();
+            let call_builder = contract.call_builder::<Delegator>();
 
             let call_get = call_builder.get_counter();
             let call_get_result = client
@@ -161,12 +161,12 @@ pub mod delegator {
 
             // given
             let mut constructor = DelegatorRef::new(10);
-            let call_builder = client
+            let contract = client
                 .instantiate("delegator", &origin, &mut constructor)
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call_builder_call = call_builder.call_builder::<Delegator>();
+            let mut call_builder = contract.call_builder::<Delegator>();
 
             let code_hash = client
                 .upload("delegatee", &origin)
@@ -176,7 +176,7 @@ pub mod delegator {
                 .code_hash;
 
             // when
-            let call_delegate = call_builder_call.add_entry_delegate(code_hash);
+            let call_delegate = call_builder.add_entry_delegate(code_hash);
             let result = client.call(&origin, &call_delegate).submit().await;
             assert!(result.is_ok(), "delegate call failed.");
 
@@ -188,7 +188,7 @@ pub mod delegator {
             // Alice's address
             let address = AccountId::from(origin.public_key().to_account_id().0);
 
-            let call_get_value = call_builder_call.get_value(address);
+            let call_get_value = call_builder.get_value(address);
             let call_get_result = client
                 .call(&origin, &call_get_value)
                 .submit()

--- a/integration-tests/upgradeable-contracts/delegator/lib.rs
+++ b/integration-tests/upgradeable-contracts/delegator/lib.rs
@@ -133,7 +133,7 @@ pub mod delegator {
 
             // then
             let expected_value = 4;
-            let call = call_builder.call_builder::<Delegator>();
+            let call_builder = call_builder.call_builder::<Delegator>();
 
             let call_get = call_builder.get_counter();
             let call_get_result = client

--- a/integration-tests/upgradeable-contracts/set-code-hash/lib.rs
+++ b/integration-tests/upgradeable-contracts/set-code-hash/lib.rs
@@ -81,20 +81,20 @@ pub mod incrementer {
                 .submit()
                 .await
                 .expect("instantiate failed");
-            let mut call = contract.call::<Incrementer>();
+            let mut call_builder = contract.call_builder::<Incrementer>();
 
-            let get = call.get();
+            let get = call_builder.get();
             let get_res = client.call(&ink_e2e::alice(), &get).dry_run().await?;
             assert!(matches!(get_res.return_value(), 0));
 
-            let inc = call.inc();
+            let inc = call_builder.inc();
             let _inc_result = client
                 .call(&ink_e2e::alice(), &inc)
                 .submit()
                 .await
                 .expect("`inc` failed");
 
-            let get = call.get();
+            let get = call_builder.get();
             let get_res = client.call(&ink_e2e::alice(), &get).dry_run().await?;
             assert!(matches!(get_res.return_value(), 1));
 
@@ -107,7 +107,7 @@ pub mod incrementer {
                 .code_hash;
 
             let new_code_hash = new_code_hash.as_ref().try_into().unwrap();
-            let set_code = call.set_code(new_code_hash);
+            let set_code = call_builder.set_code(new_code_hash);
 
             let _set_code_result = client
                 .call(&ink_e2e::alice(), &set_code)
@@ -118,7 +118,7 @@ pub mod incrementer {
             // Then
             // Note that our contract's `AccountId` (so `contract_acc_id`) has stayed the
             // same between updates!
-            let inc = call.inc();
+            let inc = call_builder.inc();
 
             let _inc_result = client
                 .call(&ink_e2e::alice(), &inc)
@@ -126,7 +126,7 @@ pub mod incrementer {
                 .await
                 .expect("`inc` failed");
 
-            let get = call.get();
+            let get = call_builder.get();
             let get_res = client.call(&ink_e2e::alice(), &get).dry_run().await?;
 
             // Remember, we updated our incrementer contract to increment by `4`.


### PR DESCRIPTION
## Summary

I always stumble over this:

```rust
let mut call = contract.call::<Flipper>();
let get = call.get();
let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await?;
```

To me this makes more sense:

```rust
let mut call_builder = contract.call_builder::<Flipper>();
let get = call_builder.get();
let get_res = client.call(&ink_e2e::bob(), &get).dry_run().await?;
```

- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
