### PR TITLE
Improve syntax for ink! e2e `runtime_only` attribute argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Linter: Publish the linting crates on crates.io - [#2060](https://github.com/paritytech/ink/pull/2060)
 - [E2E] Added `create_call_builder` for testing existing contracts - [#2075](https://github.com/paritytech/ink/pull/2075)
 
+### Changed
+- Improve syntax for ink! e2e `runtime_only` attribute argument - [#2083](https://github.com/paritytech/ink/pull/2083)
+
 ### Fixed
 - Fix the `StorageVec` type by excluding the `len_cached` field from its type info - [#2052](https://github.com/paritytech/ink/pull/2052)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,12 +1301,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "da01daa5f6d41c91358398e8db4dde38e292378da1f28300b59ef4732b879454"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.4",
+ "darling_macro 0.20.4",
 ]
 
 [[package]]
@@ -1325,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "f44f6238b948a3c6c3073cdf53bb0c2d5e024ee27e0f35bfe9d556a12395808a"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1350,11 +1350,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "0d2d88bd93979b1feb760a6b5c531ac5ba06bd63e74894c377af02faee07b9cd"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.4",
  "quote",
  "syn 2.0.46",
 ]
@@ -2642,7 +2642,7 @@ dependencies = [
 name = "ink_e2e_macro"
 version = "5.0.0-rc"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.4",
  "derive_more",
  "ink_ir",
  "proc-macro2",
@@ -5858,7 +5858,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5086ce2a90e723083ff19b77f06805d00e732eac3e19c86f6cd643d4255d334"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.4",
  "parity-scale-codec",
  "proc-macro-error",
  "subxt-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ blake2 = { version = "0.10" }
 cargo_metadata = { version = "0.18.0" }
 cfg-if = { version = "1.0" }
 contract-build = { version = "4.0.0-rc.1" }
-darling = { version = "0.20.3" }
+darling = { version = "0.20.4" }
 derive_more = { version = "0.99.17", default-features = false }
 drink = { version = "=0.8.5" }
 either = { version = "1.5", default-features = false }

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -71,8 +71,8 @@ impl InkE2ETest {
                 build_full_client(&environment, exec_build_contracts, node_url)
             }
             #[cfg(any(test, feature = "drink"))]
-            Backend::RuntimeOnly { runtime } => {
-                build_runtime_client(exec_build_contracts, runtime)
+            Backend::RuntimeOnly(runtime) => {
+                build_runtime_client(exec_build_contracts, runtime.into())
             }
         };
 
@@ -154,12 +154,7 @@ fn build_full_client(
 }
 
 #[cfg(any(test, feature = "drink"))]
-fn build_runtime_client(
-    contracts: TokenStream2,
-    runtime: Option<syn::Path>,
-) -> TokenStream2 {
-    let runtime =
-        runtime.unwrap_or_else(|| syn::parse_quote! { ::ink_e2e::MinimalRuntime });
+fn build_runtime_client(contracts: TokenStream2, runtime: syn::Path) -> TokenStream2 {
     quote! {
         let contracts = #contracts;
         let mut client = ::ink_e2e::DrinkClient::<_, _, #runtime>::new(contracts);

--- a/integration-tests/e2e-runtime-only-backend/lib.rs
+++ b/integration-tests/e2e-runtime-only-backend/lib.rs
@@ -55,7 +55,7 @@ pub mod flipper {
         /// - flip the flipper
         /// - get the flipper's value
         /// - assert that the value is `true`
-        #[ink_e2e::test(backend(runtime_only()))]
+        #[ink_e2e::test(backend(runtime_only))]
         async fn it_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // given
             const INITIAL_VALUE: bool = false;
@@ -88,7 +88,7 @@ pub mod flipper {
         /// - transfer some funds to the contract using runtime call
         /// - get the contract's balance again
         /// - assert that the contract's balance increased by the transferred amount
-        #[ink_e2e::test(backend(runtime_only()))]
+        #[ink_e2e::test(backend(runtime_only))]
         async fn runtime_call_works() -> E2EResult<()> {
             // given
             let mut constructor = FlipperRef::new(false);


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

Use `#[darling(word)]` to enable writing `#[ink_e2e::test(backend(runtime_only))]` instead of `#[ink_e2e::test(backend(runtime_only()))]`


## Description
<!--- Describe your changes in detail -->

- Bump darling to 0.20.4
- Update parser for ink! e2e `runtime_only` attribute argument by using `#[darling(word)]` to enable writing `#[ink_e2e::test(backend(runtime_only))]` instead of `#[ink_e2e::test(backend(runtime_only()))]`

See <https://github.com/TedDriggs/darling/pull/260> and <https://github.com/TedDriggs/darling/blob/master/examples/heterogeneous_enum_and_word.rs> for details.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules