### PR TITLE
Restore display name for event metadata arg type

### DIFF
--- a/crates/ink/codegen/src/generator/mod.rs
+++ b/crates/ink/codegen/src/generator/mod.rs
@@ -62,7 +62,10 @@ pub use self::{
     event::Event,
     ink_test::InkTest,
     item_impls::ItemImpls,
-    metadata::Metadata,
+    metadata::{
+        generate_type_spec,
+        Metadata,
+    },
     selector::{
         SelectorBytes,
         SelectorId,

--- a/crates/ink/codegen/src/lib.rs
+++ b/crates/ink/codegen/src/lib.rs
@@ -39,6 +39,8 @@ mod enforced_error;
 mod generator;
 mod traits;
 
+pub use generator::generate_type_spec;
+
 use self::{
     enforced_error::EnforcedErrors,
     traits::{

--- a/crates/ink/macro/src/event/metadata.rs
+++ b/crates/ink/macro/src/event/metadata.rs
@@ -60,9 +60,10 @@ fn event_metadata_derive_struct(s: synstructure::Structure) -> syn::Result<Token
                 .attrs
                 .iter()
                 .filter_map(|attr| attr.extract_docs());
+            let ty_spec = ink_codegen::generate_type_spec(field_ty);
             Ok(quote_spanned!(field_span =>
                 ::ink::metadata::EventParamSpec::new(::core::stringify!(#field_name))
-                    .of_type(::ink::metadata::TypeSpec::of_type::<#field_ty>())
+                    .of_type(#ty_spec)
                     .indexed(#indexed)
                     .docs([ #( #docs ),* ])
                     .done()

--- a/crates/ink/macro/src/tests/event_metadata.rs
+++ b/crates/ink/macro/src/tests/event_metadata.rs
@@ -72,17 +72,32 @@ fn struct_with_fields_no_topics() {
                             .signature_topic(<Self as ::ink::env::Event>::SIGNATURE_TOPIC)
                             .args([
                                 ::ink::metadata::EventParamSpec::new(::core::stringify!(field_1))
-                                    .of_type(::ink::metadata::TypeSpec::of_type::<u32>())
+                                    .of_type(::ink::metadata::TypeSpec::with_name_segs::<u32, _>(
+                                        ::core::iter::Iterator::map(
+                                            ::core::iter::IntoIterator::into_iter([::core::stringify!(u32)]),
+                                            ::core::convert::AsRef::as_ref
+                                        )
+                                    ))
                                     .indexed(false)
                                     .docs([])
                                     .done(),
                                 ::ink::metadata::EventParamSpec::new(::core::stringify!(field_2))
-                                    .of_type(::ink::metadata::TypeSpec::of_type::<u64>())
+                                    .of_type(::ink::metadata::TypeSpec::with_name_segs::<u64, _>(
+                                        ::core::iter::Iterator::map(
+                                            ::core::iter::IntoIterator::into_iter([::core::stringify!(u64)]),
+                                            ::core::convert::AsRef::as_ref
+                                        )
+                                    ))
                                     .indexed(false)
                                     .docs([])
                                     .done(),
                                 ::ink::metadata::EventParamSpec::new(::core::stringify!(field_3))
-                                    .of_type(::ink::metadata::TypeSpec::of_type::<u128>())
+                                    .of_type(::ink::metadata::TypeSpec::with_name_segs::<u128, _>(
+                                        ::core::iter::Iterator::map(
+                                            ::core::iter::IntoIterator::into_iter([::core::stringify!(u128)]),
+                                            ::core::convert::AsRef::as_ref
+                                        )
+                                    ))
                                     .indexed(false)
                                     .docs([])
                                     .done()
@@ -125,17 +140,32 @@ fn struct_with_fields_and_some_topics() {
                             .signature_topic(<Self as ::ink::env::Event>::SIGNATURE_TOPIC)
                             .args([
                                 ::ink::metadata::EventParamSpec::new(::core::stringify!(field_1))
-                                    .of_type(::ink::metadata::TypeSpec::of_type::<u32>())
+                                    .of_type(::ink::metadata::TypeSpec::with_name_segs::<u32, _>(
+                                        ::core::iter::Iterator::map(
+                                            ::core::iter::IntoIterator::into_iter([::core::stringify!(u32)]),
+                                            ::core::convert::AsRef::as_ref
+                                        )
+                                    ))
                                     .indexed(false)
                                     .docs([])
                                     .done(),
                                 ::ink::metadata::EventParamSpec::new(::core::stringify!(field_2))
-                                    .of_type(::ink::metadata::TypeSpec::of_type::<u64>())
+                                    .of_type(::ink::metadata::TypeSpec::with_name_segs::<u64, _>(
+                                        ::core::iter::Iterator::map(
+                                            ::core::iter::IntoIterator::into_iter([::core::stringify!(u64)]),
+                                            ::core::convert::AsRef::as_ref
+                                        )
+                                    ))
                                     .indexed(true)
                                     .docs([])
                                     .done(),
                                 ::ink::metadata::EventParamSpec::new(::core::stringify!(field_3))
-                                    .of_type(::ink::metadata::TypeSpec::of_type::<u128>())
+                                    .of_type(::ink::metadata::TypeSpec::with_name_segs::<u128, _>(
+                                        ::core::iter::Iterator::map(
+                                            ::core::iter::IntoIterator::into_iter([::core::stringify!(u128)]),
+                                            ::core::convert::AsRef::as_ref
+                                        )
+                                    ))
                                     .indexed(true)
                                     .docs([])
                                     .done()


### PR DESCRIPTION
Restore the `displayName` property of the type of an event argument. 

It should have been ported across as part of #1827.