### PR TITLE
ERC-721 example: fix panic re: `approve_for` with nonexistent token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix the `StorageVec` type by excluding the `len_cached` field from its type info - [#2052](https://github.com/paritytech/ink/pull/2052)
+- Fix panic in `approve_for` in the ERC-721 example - [#2092](https://github.com/paritytech/ink/pull/2092)
 
 ## Version 5.0.0-rc
 


### PR DESCRIPTION
## Summary

- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

In the current ERC-721 example used in integration tests (which is the source of the erc-721 example in ink-examples), the `approve_for` function will panic with the text '"Error with AccountId"' if the token id does not exist. This PR changes the function to return an `Error::TokenNotFound` in this case instead.

I am using [Prusti](https://www.pm.inf.ethz.ch/research/prusti.html) to verify correctness properties of the contract; the presence of this bug prevents the verification of a "panic-freedom" property. 

## Description
<!--- Describe your changes in detail -->

Updated the logic and added a corresponding test.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules **No dependent changes**
