### PR TITLE
Remove `additional_contracts` from `trait-dyn-cross-contract-calls`

### DIFF
--- a/integration-tests/trait-dyn-cross-contract-calls/lib.rs
+++ b/integration-tests/trait-dyn-cross-contract-calls/lib.rs
@@ -62,7 +62,7 @@ mod e2e_tests {
     ///
     /// The test verifies that we can increment the value of the `Incrementer` contract
     /// through the `Caller` contract.
-    #[ink_e2e::test(additional_contracts = "contracts/incrementer/Cargo.toml")]
+    #[ink_e2e::test]
     async fn e2e_cross_contract_calls<Client: E2EBackend>(
         mut client: Client,
     ) -> E2EResult<()> {

--- a/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
@@ -16,4 +16,3 @@ default = ["std"]
 std = [
     "ink/std",
 ]
-ink-as-dependency = []


### PR DESCRIPTION
Removed the `ink-as-dependency` feature from the `traits` lib, because it was attempting to build the `traits` lib as contract, which it is not.