### PR TITLE
[E2E] Remove `additional_contracts` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Mapping`: Reflect all possible failure cases in comments ‒ [#2079](https://github.com/paritytech/ink/pull/2079)
 - [E2E] Rename `.call` to `.call_builder` ‒ [#2078](https://github.com/paritytech/ink/pull/2078)
 - Improve syntax for ink! e2e `runtime_only` attribute argument - [#2083](https://github.com/paritytech/ink/pull/2083)
+- [E2E] Remove `additional_contracts` parameter [#2098](https://github.com/paritytech/ink/pull/2098)
 
 ### Fixed
 - Fix the `StorageVec` type by excluding the `len_cached` field from its type info - [#2052](https://github.com/paritytech/ink/pull/2052)

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -52,16 +52,8 @@ impl InkE2ETest {
             .environment()
             .unwrap_or_else(|| syn::parse_quote! { ::ink::env::DefaultEnvironment });
 
-        let additional_contracts = self.test.config.additional_contracts();
-
-        let exec_build_contracts = if additional_contracts.is_empty() {
-            quote! {
-                ::ink_e2e::build_root_and_contract_dependencies()
-            }
-        } else {
-            quote! {
-                ::ink_e2e::build_root_and_additional_contracts([ #( #additional_contracts ),* ])
-            }
+        let exec_build_contracts = quote! {
+            ::ink_e2e::build_root_and_contract_dependencies()
         };
 
         let node_url = self.test.config.node_url();

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -52,9 +52,6 @@ impl From<RuntimeOnly> for syn::Path {
 /// The End-to-End test configuration.
 #[derive(Debug, Default, PartialEq, Eq, darling::FromMeta)]
 pub struct E2EConfig {
-    /// Additional contracts that have to be built before executing the test.
-    #[darling(default)]
-    additional_contracts: String,
     /// The [`Environment`](https://docs.rs/ink_env/4.1.0/ink_env/trait.Environment.html) to use
     /// during test execution.
     ///
@@ -71,21 +68,6 @@ pub struct E2EConfig {
 }
 
 impl E2EConfig {
-    /// Returns a vector of additional contracts that have to be built
-    /// and imported before executing the test.
-    pub fn additional_contracts(&self) -> Vec<String> {
-        self.additional_contracts
-            .split(' ')
-            .filter_map(|s| {
-                if s.is_empty() {
-                    None
-                } else {
-                    Some(s.to_owned())
-                }
-            })
-            .collect()
-    }
-
     /// Custom environment for the contracts, if specified.
     pub fn environment(&self) -> Option<syn::Path> {
         self.environment.clone()
@@ -118,7 +100,6 @@ mod tests {
     #[test]
     fn config_works() {
         let input = quote! {
-            additional_contracts = "adder/Cargo.toml flipper/Cargo.toml",
             environment = crate::CustomEnvironment,
             backend(runtime_only),
             node_url = "ws://127.0.0.1:8000"
@@ -126,10 +107,6 @@ mod tests {
         let config =
             E2EConfig::from_list(&NestedMeta::parse_meta_list(input).unwrap()).unwrap();
 
-        assert_eq!(
-            config.additional_contracts(),
-            vec!["adder/Cargo.toml", "flipper/Cargo.toml"]
-        );
         assert_eq!(
             config.environment(),
             Some(syn::parse_quote! { crate::CustomEnvironment })

--- a/crates/e2e/src/client_utils.rs
+++ b/crates/e2e/src/client_utils.rs
@@ -61,8 +61,7 @@ impl ContractsRegistry {
             .unwrap_or_else(||
                 panic!(
                     "Unknown contract {contract}. Available contracts: {:?}.\n\
-                     For a contract to be built, add it as a dependency to the `Cargo.toml`, or add \
-                     the manifest path to `#[ink_e2e::test(additional_contracts = ..)]`",
+                     For a contract to be built, add it as a dependency to the `Cargo.toml`",
                     self.contracts.keys()
                 )
             );

--- a/crates/e2e/src/contract_build.rs
+++ b/crates/e2e/src/contract_build.rs
@@ -43,20 +43,6 @@ use std::{
 };
 
 /// Builds the "root" contract (the contract in which the E2E tests are defined) together
-/// with the additional contracts specified in the `additional_contracts` argument.
-pub fn build_root_and_additional_contracts<P>(
-    additional_contracts: impl IntoIterator<Item = P>,
-) -> Vec<PathBuf>
-where
-    PathBuf: From<P>,
-{
-    let contract_project = ContractProject::new();
-    let contract_manifests =
-        contract_project.root_with_additional_contracts(additional_contracts);
-    build_contracts(&contract_manifests)
-}
-
-/// Builds the "root" contract (the contract in which the E2E tests are defined) together
 /// with any contracts which are a dependency of the root contract.
 pub fn build_root_and_contract_dependencies() -> Vec<PathBuf> {
     let contract_project = ContractProject::new();

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -33,10 +33,7 @@ mod node_proc;
 mod subxt_client;
 mod xts;
 
-pub use crate::contract_build::{
-    build_root_and_additional_contracts,
-    build_root_and_contract_dependencies,
-};
+pub use crate::contract_build::build_root_and_contract_dependencies;
 pub use backend::{
     ChainBackend,
     ContractsBackend,

--- a/integration-tests/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -10,6 +10,7 @@ ink = { path = "../../../crates/ink", default-features = false }
 
 [dev-dependencies]
 ink_e2e = { path = "../../../crates/e2e" }
+updated-incrementer = { path = "updated-incrementer", default-features = false, features = ["ink-as-dependency"] }
 
 [lib]
 path = "lib.rs"

--- a/integration-tests/upgradeable-contracts/set-code-hash/lib.rs
+++ b/integration-tests/upgradeable-contracts/set-code-hash/lib.rs
@@ -72,7 +72,7 @@ pub mod incrementer {
 
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
-        #[ink_e2e::test(additional_contracts = "./updated-incrementer/Cargo.toml")]
+        #[ink_e2e::test]
         async fn set_code_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             // Given
             let mut constructor = IncrementerRef::new();


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
Removed `additiona_contracts` parameters from `ink_e2e::test` macro as this info is implied from the contract's manifest

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
