### PR TITLE
 `[E2E]` change node url backend config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [E2E] Rename `.call` to `.call_builder` ‒ [#2078](https://github.com/paritytech/ink/pull/2078)
 - Improve syntax for ink! e2e `runtime_only` attribute argument - [#2083](https://github.com/paritytech/ink/pull/2083)
 - [E2E] Remove `additional_contracts` parameter [#2098](https://github.com/paritytech/ink/pull/2098)
+- [E2E] change node url backend config - [#2101](https://github.com/paritytech/ink/pull/2101)
 
 ### Fixed
 - Fix the `StorageVec` type by excluding the `len_cached` field from its type info - [#2052](https://github.com/paritytech/ink/pull/2052)

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use crate::{
-    config::Backend,
+    config::{
+        Backend,
+        Node,
+    },
     ir,
 };
 use derive_more::From;
@@ -56,11 +59,9 @@ impl InkE2ETest {
             ::ink_e2e::build_root_and_contract_dependencies()
         };
 
-        let node_url = self.test.config.node_url();
-
         let client_building = match self.test.config.backend() {
-            Backend::Full => {
-                build_full_client(&environment, exec_build_contracts, node_url)
+            Backend::Node(node_config) => {
+                build_full_client(&environment, exec_build_contracts, node_config)
             }
             #[cfg(any(test, feature = "drink"))]
             Backend::RuntimeOnly(runtime) => {
@@ -109,9 +110,9 @@ impl InkE2ETest {
 fn build_full_client(
     environment: &syn::Path,
     contracts: TokenStream2,
-    node_url: Option<String>,
+    node_config: Node,
 ) -> TokenStream2 {
-    match node_url {
+    match node_config.url() {
         Some(url) => {
             quote! {
                 let rpc = ::ink_e2e::RpcClient::from_url(#url)

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -35,13 +35,13 @@ impl Default for Backend {
 }
 
 /// Configure whether to automatically spawn a node instance for the test or to use
-/// an already running node at the supplied url
+/// an already running node at the supplied URL.
 #[derive(Clone, Eq, PartialEq, Debug, darling::FromMeta)]
 pub enum Node {
     /// A fresh node instance will be spawned for the lifetime of the test.
     #[darling(word)]
     Auto,
-    /// The test will run against an already running node at the supplied url.
+    /// The test will run against an already running node at the supplied URL.
     Url(String),
 }
 


### PR DESCRIPTION
Modifies the e2e configuration for backend node from `node_url = "<url>"` to `backend(node(url = "<url>"))`.

The previous configuration allowed `node_url` to be set even if using `backend(runtime_only)` which uses no node at all so the url is not used at all.

Follows up https://github.com/paritytech/ink/pull/2047