### PR TITLE
:t-rex: pin `curve25519-dalek` to `4.1.1` to fix linting CI

### DIFF
--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -17,7 +17,12 @@ keywords = ["parity", "blockchain", "edsl", "dylint", "linting"]
 
 [workspace.dependencies]
 ink_linting_utils = { version = "=5.0.0-rc", path = "utils" }
-
+curve25519-dalek = { version = "=4.1.1", default-features = false, features = [
+    "digest",
+    "zeroize",
+    "precomputed-tables",
+    "legacy_compatibility",
+] }
 [workspace.metadata.dylint]
 libraries = [
     { path = "mandatory" },

--- a/linting/mandatory/Cargo.toml
+++ b/linting/mandatory/Cargo.toml
@@ -22,6 +22,7 @@ if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
 ink_linting_utils = { workspace = true }
+curve25519-dalek = { workspace = true }
 
 [dev-dependencies]
 dylint_testing = "2.6.0"


### PR DESCRIPTION
CI currently broken. See https://github.com/dalek-cryptography/curve25519-dalek/issues/618 and https://github.com/dalek-cryptography/curve25519-dalek/pull/619

