### PR TITLE
`[E2E]` fix flaky config tests with `temp_env` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,6 +2649,7 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.46",
+ "temp-env",
  "tracing-subscriber 0.3.18",
 ]
 
@@ -5944,6 +5945,15 @@ name = "target-lexicon"
 version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "tempfile"

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -28,5 +28,8 @@ syn = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 
+[dev-dependencies]
+temp-env = "0.3.6"
+
 [features]
 drink = []

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -173,11 +173,19 @@ mod tests {
             Backend::Node(node_config) => {
                 assert_eq!(node_config, Node::Auto);
 
-                std::env::remove_var("CONTRACTS_NODE_URL");
-                assert_eq!(node_config.url(), None);
+                temp_env::with_vars([("CONTRACTS_NODE_URL", None::<&str>)], || {
+                    assert_eq!(node_config.url(), None);
+                });
 
-                std::env::set_var("CONTRACTS_NODE_URL", "ws://127.0.0.1:9000");
-                assert_eq!(node_config.url(), Some(String::from("ws://127.0.0.1:9000")));
+                temp_env::with_vars(
+                    [("CONTRACTS_NODE_URL", Some("ws://127.0.0.1:9000"))],
+                    || {
+                        assert_eq!(
+                            node_config.url(),
+                            Some(String::from("ws://127.0.0.1:9000"))
+                        );
+                    },
+                );
             }
             _ => panic!("Expected Backend::Node"),
         }
@@ -195,11 +203,19 @@ mod tests {
             Backend::Node(node_config) => {
                 assert_eq!(node_config, Node::Url("ws://0.0.0.0:9999".to_owned()));
 
-                std::env::remove_var("CONTRACTS_NODE_URL");
-                assert_eq!(node_config.url(), Some("ws://0.0.0.0:9999".to_owned()));
+                temp_env::with_vars([("CONTRACTS_NODE_URL", None::<&str>)], || {
+                    assert_eq!(node_config.url(), Some("ws://0.0.0.0:9999".to_owned()));
+                });
 
-                std::env::set_var("CONTRACTS_NODE_URL", "ws://127.0.0.1:9000");
-                assert_eq!(node_config.url(), Some(String::from("ws://127.0.0.1:9000")));
+                temp_env::with_vars(
+                    [("CONTRACTS_NODE_URL", Some("ws://127.0.0.1:9000"))],
+                    || {
+                        assert_eq!(
+                            node_config.url(),
+                            Some(String::from("ws://127.0.0.1:9000"))
+                        );
+                    },
+                );
             }
             _ => panic!("Expected Backend::Node"),
         }


### PR DESCRIPTION
Tests running in parallel were interfering with each other because they use `set_env`. Fixing tests added in https://github.com/paritytech/ink/pull/2101