### PR TITLE
ERC-721: Failing transfer should preserve contract state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix the `StorageVec` type by excluding the `len_cached` field from its type info - [#2052](https://github.com/paritytech/ink/pull/2052)
 - Fix panic in `approve_for` in the ERC-721 example - [#2092](https://github.com/paritytech/ink/pull/2092)
 - ERC-721: `transfer_token_from` now ensures the token owner is correct - [#2093](https://github.com/paritytech/ink/pull/2093)
+- ERC-721: `transfer_token_from` fixed to preserve contract state on failure 
+[#2107](https://github.com/paritytech/ink/pull/2107)
 
 ## Version 5.0.0-rc
 


### PR DESCRIPTION
## Summary

- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

The error handling logic for the ERC-721 token implementation states:

> //! Any function that modifies the state returns a `Result` type and does not changes the
> //! state if the `Error` occurs.

Calling `transfer()` or `transfer_from` with a recipient address of `0x0` fails as expected, but it also removes the original token from its owner, contradicting the error-handling logic.

This PR resolves the issue by performing the recipient address check prior to making any changes to contract state in `transfer_token_from`. A regression test is also added.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
