### PR TITLE
`instantiate_v2` with additional limit parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Linter] Publish the linting crates on crates.io - [#2060](https://github.com/paritytech/ink/pull/2060)
 - [E2E] Added `create_call_builder` for testing existing contracts - [#2075](https://github.com/paritytech/ink/pull/2075)
 - `call_v2` cross-contract calls with additional limit parameters - [#2077](https://github.com/paritytech/ink/pull/2077)
+- `instantiate_v2` with additional limit parameters - [#2123](https://github.com/paritytech/ink/pull/2123)
 - `delegate_dependency` api calls - [#2076](https://github.com/paritytech/ink/pull/2076)
 
 ### Changed

--- a/crates/e2e/src/builders.rs
+++ b/crates/e2e/src/builders.rs
@@ -21,6 +21,7 @@ use ink_env::{
         },
         CreateBuilder,
         ExecutionInput,
+        LimitParamsV2,
     },
     Environment,
 };
@@ -32,7 +33,7 @@ pub type CreateBuilderPartial<E, ContractRef, Args, R> = CreateBuilder<
     E,
     ContractRef,
     Unset<<E as Environment>::Hash>,
-    Unset<u64>,
+    Set<LimitParamsV2<E>>,
     Unset<<E as Environment>::Balance>,
     Set<ExecutionInput<Args>>,
     Unset<ink_env::call::state::Salt>,

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -27,6 +27,8 @@ use crate::{
         CreateParams,
         DelegateCall,
         FromAccountId,
+        LimitParamsV1,
+        LimitParamsV2,
     },
     engine::{
         EnvInstance,
@@ -366,7 +368,7 @@ where
 /// - If given insufficient endowment.
 /// - If the returned account ID failed to decode properly.
 pub fn instantiate_contract<E, ContractRef, Args, Salt, R>(
-    params: &CreateParams<E, ContractRef, Args, Salt, R>,
+    params: &CreateParams<E, ContractRef, LimitParamsV2<E>, Args, Salt, R>,
 ) -> Result<
     ink_primitives::ConstructorResult<<R as ConstructorReturnType<ContractRef>>::Output>,
 >
@@ -379,6 +381,43 @@ where
 {
     <EnvInstance as OnInstance>::on_instance(|instance| {
         TypedEnvBackend::instantiate_contract::<E, ContractRef, Args, Salt, R>(
+            instance, params,
+        )
+    })
+}
+
+/// Instantiates another contract.
+///
+/// # Note
+///
+/// This is a low level way to instantiate another smart contract.
+///
+/// Prefer to use methods on a `ContractRef` or the
+/// [`CreateBuilder`](`crate::call::CreateBuilder`)
+/// through [`build_create`](`crate::call::build_create`) instead.
+///
+/// # Errors
+///
+/// - If the code hash is invalid.
+/// - If the arguments passed to the instantiation process are invalid.
+/// - If the instantiation process traps.
+/// - If the instantiation process runs out of gas.
+/// - If given insufficient endowment.
+/// - If the returned account ID failed to decode properly.
+pub fn instantiate_contract_v1<E, ContractRef, Args, Salt, R>(
+    params: &CreateParams<E, ContractRef, LimitParamsV1, Args, Salt, R>,
+) -> Result<
+    ink_primitives::ConstructorResult<<R as ConstructorReturnType<ContractRef>>::Output>,
+>
+where
+    E: Environment,
+    ContractRef: FromAccountId<E>,
+    Args: scale::Encode,
+    Salt: AsRef<[u8]>,
+    R: ConstructorReturnType<ContractRef>,
+{
+    <EnvInstance as OnInstance>::on_instance(|instance| {
+        TypedEnvBackend::instantiate_contract_v1::<E, ContractRef, Args, Salt, R>(
             instance, params,
         )
     })

--- a/crates/env/src/api.rs
+++ b/crates/env/src/api.rs
@@ -353,7 +353,8 @@ where
 ///
 /// # Note
 ///
-/// This is a low level way to instantiate another smart contract.
+/// This is a low level way to instantiate another smart contract, calling the latest
+/// `instantiate_v2` host function.
 ///
 /// Prefer to use methods on a `ContractRef` or the
 /// [`CreateBuilder`](`crate::call::CreateBuilder`)
@@ -390,7 +391,8 @@ where
 ///
 /// # Note
 ///
-/// This is a low level way to instantiate another smart contract.
+/// This is a low level way to instantiate another smart contract, calling the legacy
+/// `instantiate_v1` host function.
 ///
 /// Prefer to use methods on a `ContractRef` or the
 /// [`CreateBuilder`](`crate::call::CreateBuilder`)

--- a/crates/env/src/backend.rs
+++ b/crates/env/src/backend.rs
@@ -21,6 +21,8 @@ use crate::{
         CreateParams,
         DelegateCall,
         FromAccountId,
+        LimitParamsV1,
+        LimitParamsV2,
     },
     event::Event,
     hash::{
@@ -345,7 +347,22 @@ pub trait TypedEnvBackend: EnvBackend {
     /// For more details visit: [`instantiate_contract`][`crate::instantiate_contract`]
     fn instantiate_contract<E, ContractRef, Args, Salt, R>(
         &mut self,
-        params: &CreateParams<E, ContractRef, Args, Salt, R>,
+        params: &CreateParams<E, ContractRef, LimitParamsV2<E>, Args, Salt, R>,
+    ) -> Result<
+        ink_primitives::ConstructorResult<
+            <R as ConstructorReturnType<ContractRef>>::Output,
+        >,
+    >
+    where
+        E: Environment,
+        ContractRef: FromAccountId<E>,
+        Args: scale::Encode,
+        Salt: AsRef<[u8]>,
+        R: ConstructorReturnType<ContractRef>;
+
+    fn instantiate_contract_v1<E, ContractRef, Args, Salt, R>(
+        &mut self,
+        params: &CreateParams<E, ContractRef, LimitParamsV1, Args, Salt, R>,
     ) -> Result<
         ink_primitives::ConstructorResult<
             <R as ConstructorReturnType<ContractRef>>::Output,

--- a/crates/env/src/call/call_builder.rs
+++ b/crates/env/src/call/call_builder.rs
@@ -691,7 +691,7 @@ where
     /// limit parameter (equivalent to the `ref_time_limit` in the latest `call_v2`).
     ///
     /// This method instance is used to allow usage of the generated call builder methods
-    /// for messages which initialize the builder with the original [`CallV1`] type.
+    /// for messages which initialize the builder with the new [`Call`] type.
     pub fn call_v1(self) -> CallBuilder<E, Set<CallV1<E>>, Args, RetType> {
         let call_type = self.call_type.value();
         CallBuilder {

--- a/crates/env/src/call/create_builder.rs
+++ b/crates/env/src/call/create_builder.rs
@@ -166,13 +166,13 @@ where
 }
 
 /// todo: [AJ] docs
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LimitParamsV1 {
     gas_limit: u64,
 }
 
 /// todo: [AJ] docs
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LimitParamsV2<E>
 where
     E: Environment,
@@ -604,7 +604,7 @@ where
         RetType,
     > {
         CreateBuilder {
-            code_hash: (),
+            code_hash: self.code_hash,
             limits: Set(LimitParamsV1 {
                 gas_limit: self.limits.value().ref_time_limit,
             }),

--- a/crates/env/src/call/create_builder.rs
+++ b/crates/env/src/call/create_builder.rs
@@ -593,7 +593,9 @@ where
 {
     /// todo: [AJ] comment
     #[inline]
-    pub fn instantiate_v1(self) -> CreateBuilder<
+    pub fn instantiate_v1(
+        self,
+    ) -> CreateBuilder<
         E,
         ContractRef,
         CodeHash,

--- a/crates/env/src/call/create_builder.rs
+++ b/crates/env/src/call/create_builder.rs
@@ -593,6 +593,31 @@ where
 {
     /// todo: [AJ] comment
     #[inline]
+    pub fn instantiate_v1(self) -> CreateBuilder<
+        E,
+        ContractRef,
+        CodeHash,
+        Set<LimitParamsV1>,
+        Endowment,
+        Args,
+        Salt,
+        RetType,
+    > {
+        CreateBuilder {
+            code_hash: (),
+            limits: Set(LimitParamsV1 {
+                gas_limit: self.limits.value().ref_time_limit,
+            }),
+            endowment: self.endowment,
+            exec_input: self.exec_input,
+            salt: self.salt,
+            return_type: self.return_type,
+            _phantom: Default::default(),
+        }
+    }
+
+    /// todo: [AJ] comment
+    #[inline]
     pub fn ref_time_limit(self, ref_time_limit: u64) -> Self {
         CreateBuilder {
             limits: Set(LimitParamsV2 {

--- a/crates/env/src/call/create_builder.rs
+++ b/crates/env/src/call/create_builder.rs
@@ -20,7 +20,6 @@ use crate::{
             Set,
             Unset,
         },
-        CallV1,
         ExecutionInput,
         Selector,
     },

--- a/crates/env/src/call/create_builder.rs
+++ b/crates/env/src/call/create_builder.rs
@@ -20,6 +20,7 @@ use crate::{
             Set,
             Unset,
         },
+        CallV1,
         ExecutionInput,
         Selector,
     },
@@ -165,13 +166,15 @@ where
     }
 }
 
-/// todo: [AJ] docs
+/// Defines the limit params for the legacy `ext::instantiate_v1` host function,
+/// consisting of the `gas_limit` which is equivalent to the `ref_time_limit` in the new
+/// `ext::instantiate`.
 #[derive(Clone, Debug)]
 pub struct LimitParamsV1 {
     gas_limit: u64,
 }
 
-/// todo: [AJ] docs
+/// Defines the limit params for the new `ext::instantiate` host function.
 #[derive(Clone, Debug)]
 pub struct LimitParamsV2<E>
 where
@@ -242,19 +245,20 @@ impl<E, ContractRef, Args, Salt, R>
 where
     E: Environment,
 {
-    /// todo: [AJ] docs
+    /// Gets the `ref_time_limit` part of the weight limit for the contract instantiation.
     #[inline]
     pub fn ref_time_limit(&self) -> u64 {
         self.limits.ref_time_limit
     }
 
-    /// todo: [AJ] docs
+    /// Gets the `proof_time_limit` part of the weight limit for the contract
+    /// instantiation.
     #[inline]
     pub fn proof_time_limit(&self) -> u64 {
         self.limits.proof_time_limit
     }
 
-    /// todo: [AJ] docs
+    /// Gets the `storage_deposit_limit` for the contract instantiation.
     #[inline]
     pub fn storage_deposit_limit(&self) -> Option<&E::Balance> {
         self.limits.storage_deposit_limit.as_ref()
@@ -591,7 +595,12 @@ impl<E, ContractRef, CodeHash, Endowment, Args, Salt, RetType>
 where
     E: Environment,
 {
-    /// todo: [AJ] comment
+    /// Switch to the original `instantiate` host function API, which only allows the
+    /// `gas_limit` limit parameter (equivalent to the `ref_time_limit` in the latest
+    /// `instantiate_v2`).
+    ///
+    /// This method instance is used to allow usage of the generated builder methods
+    /// for constructors which initialize the builder with the new [`LimitParamsV2`] type.
     #[inline]
     pub fn instantiate_v1(
         self,
@@ -618,7 +627,7 @@ where
         }
     }
 
-    /// todo: [AJ] comment
+    /// Sets the `ref_time_limit` part of the weight limit for the contract instantiation.
     #[inline]
     pub fn ref_time_limit(self, ref_time_limit: u64) -> Self {
         CreateBuilder {
@@ -630,7 +639,8 @@ where
         }
     }
 
-    /// todo: [AJ] comment
+    /// Sets the `proof_time_limit` part of the weight limit for the contract
+    /// instantiation.
     #[inline]
     pub fn proof_time_limit(self, proof_time_limit: u64) -> Self {
         CreateBuilder {
@@ -642,7 +652,7 @@ where
         }
     }
 
-    /// todo: [AJ] comment
+    /// Sets the `storage_deposit_limit` for the contract instantiation.
     #[inline]
     pub fn storage_deposit_limit(self, storage_deposit_limit: E::Balance) -> Self {
         CreateBuilder {

--- a/crates/env/src/call/create_builder.rs
+++ b/crates/env/src/call/create_builder.rs
@@ -446,7 +446,6 @@ where
 /// # use contract::MyContractRef;
 /// let my_contract: MyContractRef = build_create::<MyContractRef>()
 ///     .code_hash(Hash::from([0x42; 32]))
-///     .gas_limit(4000)
 ///     .endowment(25)
 ///     .exec_input(
 ///         ExecutionInput::new(Selector::new(ink::selector_bytes!("my_constructor")))
@@ -491,7 +490,6 @@ where
 /// # use contract::{MyContractRef, ConstructorError};
 /// let my_contract: MyContractRef = build_create::<MyContractRef>()
 ///     .code_hash(Hash::from([0x42; 32]))
-///     .gas_limit(4000)
 ///     .endowment(25)
 ///     .exec_input(
 ///         ExecutionInput::new(Selector::new(ink::selector_bytes!("my_constructor")))

--- a/crates/env/src/call/mod.rs
+++ b/crates/env/src/call/mod.rs
@@ -55,6 +55,8 @@ pub use self::{
         CreateBuilder,
         CreateParams,
         FromAccountId,
+        LimitParamsV1,
+        LimitParamsV2,
     },
     execution_input::ExecutionInput,
     selector::Selector,

--- a/crates/env/src/engine/off_chain/impls.rs
+++ b/crates/env/src/engine/off_chain/impls.rs
@@ -22,6 +22,8 @@ use crate::{
         CreateParams,
         DelegateCall,
         FromAccountId,
+        LimitParamsV1,
+        LimitParamsV2,
     },
     event::{
         Event,
@@ -478,7 +480,7 @@ impl TypedEnvBackend for EnvInstance {
 
     fn instantiate_contract<E, ContractRef, Args, Salt, R>(
         &mut self,
-        params: &CreateParams<E, ContractRef, Args, Salt, R>,
+        params: &CreateParams<E, ContractRef, LimitParamsV2<E>, Args, Salt, R>,
     ) -> Result<
         ink_primitives::ConstructorResult<
             <R as ConstructorReturnType<ContractRef>>::Output,
@@ -492,7 +494,32 @@ impl TypedEnvBackend for EnvInstance {
         R: ConstructorReturnType<ContractRef>,
     {
         let _code_hash = params.code_hash();
-        let _gas_limit = params.gas_limit();
+        let _ref_time_limit = params.ref_time_limit();
+        let _proof_time_limit = params.proof_time_limit();
+        let _storage_deposit_limit = params.storage_deposit_limit();
+        let _endowment = params.endowment();
+        let _input = params.exec_input();
+        let _salt_bytes = params.salt_bytes();
+        unimplemented!("off-chain environment does not support contract instantiation")
+    }
+
+    fn instantiate_contract_v1<E, ContractRef, Args, Salt, R>(
+        &mut self,
+        params: &CreateParams<E, ContractRef, LimitParamsV1, Args, Salt, R>,
+    ) -> Result<
+        ink_primitives::ConstructorResult<
+            <R as ConstructorReturnType<ContractRef>>::Output,
+        >,
+    >
+    where
+        E: Environment,
+        ContractRef: FromAccountId<E>,
+        Args: scale::Encode,
+        Salt: AsRef<[u8]>,
+        R: ConstructorReturnType<ContractRef>,
+    {
+        let _code_hash = params.code_hash();
+        let _ref_time_limit = params.gas_limit();
         let _endowment = params.endowment();
         let _input = params.exec_input();
         let _salt_bytes = params.salt_bytes();

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -543,9 +543,9 @@ impl TypedEnvBackend for EnvInstance {
         }
     }
 
-    fn instantiate_contract<E, ContractRef, Args, Salt, RetType>(
+    fn instantiate_contract<E, ContractRef, Limits, Args, Salt, RetType>(
         &mut self,
-        params: &CreateParams<E, ContractRef, Args, Salt, RetType>,
+        params: &CreateParams<E, ContractRef, Limits, Args, Salt, RetType>,
     ) -> Result<
         ink_primitives::ConstructorResult<
             <RetType as ConstructorReturnType<ContractRef>>::Output,

--- a/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
+++ b/crates/ink/codegen/src/generator/as_dependency/contract_ref.rs
@@ -444,6 +444,7 @@ impl ContractRef<'_> {
         let selector_bytes = constructor.composed_selector().hex_lits();
         let input_bindings = generator::input_bindings(constructor.inputs());
         let input_types = generator::input_types(constructor.inputs());
+        let storage_ident = self.contract.module().storage().ident();
         let arg_list = generator::generate_argument_list(input_types.iter().cloned());
         let ret_type = constructor
             .output()
@@ -459,7 +460,7 @@ impl ContractRef<'_> {
                 Environment,
                 Self,
                 ::ink::env::call::utils::Unset<Hash>,
-                ::ink::env::call::utils::Unset<u64>,
+                ::ink::env::call::utils::Set<::ink::env::call::LimitParamsV2<<#storage_ident as ::ink::env::ContractEnv>::Env>>,
                 ::ink::env::call::utils::Unset<Balance>,
                 ::ink::env::call::utils::Set<::ink::env::call::ExecutionInput<#arg_list>>,
                 ::ink::env::call::utils::Unset<::ink::env::call::state::Salt>,

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -23,6 +23,8 @@ use ink_env::{
         CreateParams,
         DelegateCall,
         FromAccountId,
+        LimitParamsV1,
+        LimitParamsV2,
     },
     hash::{
         CryptoHash,
@@ -493,7 +495,7 @@ where
     /// For more details visit: [`ink_env::instantiate_contract`]
     pub fn instantiate_contract<ContractRef, Args, Salt, R>(
         self,
-        params: &CreateParams<E, ContractRef, Args, Salt, R>,
+        params: &CreateParams<E, ContractRef, LimitParamsV2<E>, Args, Salt, R>,
     ) -> Result<
         ink_primitives::ConstructorResult<
             <R as ConstructorReturnType<ContractRef>>::Output,
@@ -506,6 +508,24 @@ where
         R: ConstructorReturnType<ContractRef>,
     {
         ink_env::instantiate_contract::<E, ContractRef, Args, Salt, R>(params)
+    }
+
+    /// todo: [AJ] docs
+    pub fn instantiate_contract_v1<ContractRef, Args, Salt, R>(
+        self,
+        params: &CreateParams<E, ContractRef, LimitParamsV1, Args, Salt, R>,
+    ) -> Result<
+        ink_primitives::ConstructorResult<
+            <R as ConstructorReturnType<ContractRef>>::Output,
+        >,
+    >
+    where
+        ContractRef: FromAccountId<E>,
+        Args: scale::Encode,
+        Salt: AsRef<[u8]>,
+        R: ConstructorReturnType<ContractRef>,
+    {
+        ink_env::instantiate_contract_v1::<E, ContractRef, Args, Salt, R>(params)
     }
 
     /// Invokes a contract message and returns its result.

--- a/crates/ink/src/env_access.rs
+++ b/crates/ink/src/env_access.rs
@@ -424,7 +424,10 @@ where
         ink_env::emit_event::<E, Evt>(event)
     }
 
-    /// Instantiates another contract.
+    /// Instantiates another contract using the supplied code hash.
+    ///
+    /// Invokes the `instantiate_v2` host function which allows passing all weight and
+    /// storage limit parameters.
     ///
     /// # Example
     ///
@@ -461,7 +464,9 @@ where
     /// pub fn instantiate_contract(&self) -> MyContractRef {
     ///     let create_params = build_create::<OtherContractRef>()
     ///         .code_hash(Hash::from([0x42; 32]))
-    ///         .gas_limit(4000)
+    ///         .ref_time_limit(500_000_000)
+    ///         .proof_time_limit(100_000)
+    ///         .storage_deposit_limit(500_000_000_000)
     ///         .endowment(25)
     ///         .exec_input(
     ///             ExecutionInput::new(Selector::new(ink::selector_bytes!("new")))
@@ -510,7 +515,77 @@ where
         ink_env::instantiate_contract::<E, ContractRef, Args, Salt, R>(params)
     }
 
-    /// todo: [AJ] docs
+    /// Instantiates another contract using the supplied code hash.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # #[ink::contract]
+    /// # pub mod my_contract {
+    /// # // In order for this to actually work with another contract we'd need a way
+    /// # // to turn the `ink-as-dependency` crate feature on in doctests, which we
+    /// # // can't do.
+    /// # //
+    /// # // Instead we use our own contract's `Ref`, which is fine for this example
+    /// # // (just need something that implements the `ContractRef` trait).
+    /// # pub mod other_contract {
+    /// #     pub use super::MyContractRef as OtherContractRef;
+    /// # }
+    /// use ink::env::{
+    ///     DefaultEnvironment,
+    ///     call::{build_create, Selector, ExecutionInput}
+    /// };
+    /// use other_contract::OtherContractRef;
+    /// #
+    /// #     #[ink(storage)]
+    /// #     pub struct MyContract { }
+    /// #
+    /// #     impl MyContract {
+    /// #         #[ink(constructor)]
+    /// #         pub fn new() -> Self {
+    /// #             Self {}
+    /// #         }
+    /// #
+    ///
+    /// /// Instantiates another contract.
+    /// #[ink(message)]
+    /// pub fn instantiate_contract(&self) -> MyContractRef {
+    ///     let create_params = build_create::<OtherContractRef>()
+    ///         .instantiate_v1()
+    ///         .code_hash(Hash::from([0x42; 32]))
+    ///         .gas_limit(500_000_000)
+    ///         .endowment(25)
+    ///         .exec_input(
+    ///             ExecutionInput::new(Selector::new(ink::selector_bytes!("new")))
+    ///                 .push_arg(42)
+    ///                 .push_arg(true)
+    ///                 .push_arg(&[0x10u8; 32]),
+    ///         )
+    ///         .salt_bytes(&[0xCA, 0xFE, 0xBA, 0xBE])
+    ///         .returns::<OtherContractRef>()
+    ///         .params();
+    ///     self.env()
+    ///         .instantiate_contract_v1(&create_params)
+    ///         .unwrap_or_else(|error| {
+    ///             panic!(
+    ///                 "Received an error from the Contracts pallet while instantiating: {:?}",
+    ///                 error
+    ///             )
+    ///         })
+    ///         .unwrap_or_else(|error| panic!("Received a `LangError` while instatiating: {:?}", error))
+    /// }
+    /// #
+    /// #     }
+    /// # }
+    /// ```
+    ///
+    /// See [our `delegator` example](https://github.com/paritytech/ink/tree/master/integration-tests/integration%20tests/examples/delegator)
+    /// for a complete contract example.
+    ///
+    /// # Note
+    ///
+    /// For more details visit: [`ink_env::instantiate_contract_v1`]
+
     pub fn instantiate_contract_v1<ContractRef, Args, Salt, R>(
         self,
         params: &CreateParams<E, ContractRef, LimitParamsV1, Args, Salt, R>,

--- a/crates/ink/tests/ui/contract/fail/constructor-return-result-non-codec-error.stderr
+++ b/crates/ink/tests/ui/contract/fail/constructor-return-result-non-codec-error.stderr
@@ -33,14 +33,14 @@ error[E0277]: the trait bound `contract::Error: WrapperTypeDecode` is not satisf
              Arc<T>
    = note: required for `contract::Error` to implement `ink::parity_scale_codec::Decode`
    = note: required for `Result<ContractRef, contract::Error>` to implement `ConstructorReturnType<ContractRef>`
-note: required by a bound in `CreateBuilder::<E, ContractRef, CodeHash, GasLimit, Endowment, Args, Salt, Unset<ReturnType<()>>>::returns`
+note: required by a bound in `CreateBuilder::<E, ContractRef, CodeHash, Limits, Endowment, Args, Salt, Unset<ReturnType<()>>>::returns`
   --> $WORKSPACE/crates/env/src/call/create_builder.rs
    |
    |     pub fn returns<R>(
    |            ------- required by a bound in this associated function
 ...
    |         R: ConstructorReturnType<ContractRef>,
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CreateBuilder::<E, ContractRef, CodeHash, GasLimit, Endowment, Args, Salt, Unset<ReturnType<()>>>::returns`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `CreateBuilder::<E, ContractRef, CodeHash, Limits, Endowment, Args, Salt, Unset<ReturnType<()>>>::returns`
 
 error[E0277]: the trait bound `contract::Error: TypeInfo` is not satisfied
  --> tests/ui/contract/fail/constructor-return-result-non-codec-error.rs:4:16

--- a/crates/ink/tests/ui/contract/pass/constructor-return-result-cross-contract.rs
+++ b/crates/ink/tests/ui/contract/pass/constructor-return-result-cross-contract.rs
@@ -45,7 +45,6 @@ fn main() {
     let _: fn() -> CalleeRef = || {
         CalleeRef::new_self()
             .code_hash(ink_primitives::Clear::CLEAR_HASH)
-            .gas_limit(4000)
             .endowment(25)
             .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])
             .instantiate()
@@ -55,7 +54,6 @@ fn main() {
     let _: fn() -> CalleeRef = || {
         CalleeRef::new_storage_name()
             .code_hash(ink_primitives::Clear::CLEAR_HASH)
-            .gas_limit(4000)
             .endowment(25)
             .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])
             .instantiate()
@@ -65,7 +63,6 @@ fn main() {
     let _: fn() -> Result<CalleeRef, Error> = || {
         CalleeRef::new_result_self()
             .code_hash(ink_primitives::Clear::CLEAR_HASH)
-            .gas_limit(4000)
             .endowment(25)
             .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])
             .instantiate()
@@ -75,7 +72,6 @@ fn main() {
     let _: fn() -> Result<CalleeRef, Error> = || {
         CalleeRef::new_result_self()
             .code_hash(ink_primitives::Clear::CLEAR_HASH)
-            .gas_limit(4000)
             .endowment(25)
             .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])
             .instantiate()

--- a/integration-tests/cross-contract-calls/e2e_tests.rs
+++ b/integration-tests/cross-contract-calls/e2e_tests.rs
@@ -12,7 +12,7 @@ async fn flip_and_get<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
         .await
         .expect("other_contract upload failed");
 
-    let mut constructor = CrossContractCallsRef::new(other_contract_code.code_hash);
+    let mut constructor = CrossContractCallsRef::new_v1(other_contract_code.code_hash);
     let contract = client
         .instantiate("cross-contract-calls", &ink_e2e::alice(), &mut constructor)
         .submit()
@@ -35,6 +35,50 @@ async fn flip_and_get<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
 }
 
 #[ink_e2e::test]
+async fn instantiate_v2_with_limits<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
+    // given
+    let other_contract_code = client
+        .upload("other-contract", &ink_e2e::alice())
+        .submit()
+        .await
+        .expect("other_contract upload failed");
+
+    const REF_TIME_LIMIT: u64 = 500_000_000;
+    const PROOF_TIME_LIMIT: u64 = 100_000;
+    const STORAGE_DEPOSIT_LIMIT: u128 = 1_000_000_000;
+
+    let mut constructor = CrossContractCallsRef::new_v2_with_limits(other_contract_code.code_hash,
+        REF_TIME_LIMIT,
+        PROOF_TIME_LIMIT,
+        STORAGE_DEPOSIT_LIMIT
+    );
+    let contract = client
+        .instantiate("cross-contract-calls", &ink_e2e::alice(), &mut constructor)
+        .submit()
+        .await;
+
+    assert!(contract.is_ok());
+}
+
+#[ink_e2e::test]
+async fn instantiate_v2_no_limits<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
+    // given
+    let other_contract_code = client
+        .upload("other-contract", &ink_e2e::alice())
+        .submit()
+        .await
+        .expect("other_contract upload failed");
+
+    let mut constructor = CrossContractCallsRef::new_v2_no_limits(other_contract_code.code_hash);
+    let contract = client
+        .instantiate("cross-contract-calls", &ink_e2e::alice(), &mut constructor)
+        .submit()
+        .await;
+
+    assert!(contract.is_ok());
+}
+
+#[ink_e2e::test]
 async fn flip_and_get_v2<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
     // given
     let other_contract_code = client
@@ -43,7 +87,7 @@ async fn flip_and_get_v2<Client: E2EBackend>(mut client: Client) -> E2EResult<()
         .await
         .expect("other_contract upload failed");
 
-    let mut constructor = CrossContractCallsRef::new(other_contract_code.code_hash);
+    let mut constructor = CrossContractCallsRef::new_v1(other_contract_code.code_hash);
     let contract = client
         .instantiate("cross-contract-calls", &ink_e2e::alice(), &mut constructor)
         .submit()

--- a/integration-tests/cross-contract-calls/e2e_tests.rs
+++ b/integration-tests/cross-contract-calls/e2e_tests.rs
@@ -29,7 +29,7 @@ async fn flip_and_get<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
         .expect("Calling `flip_and_get` failed")
         .return_value();
 
-    assert_eq!(result, false);
+    assert!(!result);
 
     Ok(())
 }

--- a/integration-tests/cross-contract-calls/e2e_tests.rs
+++ b/integration-tests/cross-contract-calls/e2e_tests.rs
@@ -35,7 +35,9 @@ async fn flip_and_get<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
 }
 
 #[ink_e2e::test]
-async fn instantiate_v2_with_limits<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
+async fn instantiate_v2_with_limits<Client: E2EBackend>(
+    mut client: Client,
+) -> E2EResult<()> {
     // given
     let other_contract_code = client
         .upload("other-contract", &ink_e2e::alice())
@@ -47,10 +49,11 @@ async fn instantiate_v2_with_limits<Client: E2EBackend>(mut client: Client) -> E
     const PROOF_TIME_LIMIT: u64 = 100_000;
     const STORAGE_DEPOSIT_LIMIT: u128 = 1_000_000_000;
 
-    let mut constructor = CrossContractCallsRef::new_v2_with_limits(other_contract_code.code_hash,
+    let mut constructor = CrossContractCallsRef::new_v2_with_limits(
+        other_contract_code.code_hash,
         REF_TIME_LIMIT,
         PROOF_TIME_LIMIT,
-        STORAGE_DEPOSIT_LIMIT
+        STORAGE_DEPOSIT_LIMIT,
     );
     let contract = client
         .instantiate("cross-contract-calls", &ink_e2e::alice(), &mut constructor)
@@ -61,7 +64,9 @@ async fn instantiate_v2_with_limits<Client: E2EBackend>(mut client: Client) -> E
 }
 
 #[ink_e2e::test]
-async fn instantiate_v2_no_limits<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
+async fn instantiate_v2_no_limits<Client: E2EBackend>(
+    mut client: Client,
+) -> E2EResult<()> {
     // given
     let other_contract_code = client
         .upload("other-contract", &ink_e2e::alice())
@@ -69,7 +74,8 @@ async fn instantiate_v2_no_limits<Client: E2EBackend>(mut client: Client) -> E2E
         .await
         .expect("other_contract upload failed");
 
-    let mut constructor = CrossContractCallsRef::new_v2_no_limits(other_contract_code.code_hash);
+    let mut constructor =
+        CrossContractCallsRef::new_v2_no_limits(other_contract_code.code_hash);
     let contract = client
         .instantiate("cross-contract-calls", &ink_e2e::alice(), &mut constructor)
         .submit()

--- a/integration-tests/cross-contract-calls/lib.rs
+++ b/integration-tests/cross-contract-calls/lib.rs
@@ -11,11 +11,44 @@ mod cross_contract_calls {
     }
 
     impl CrossContractCalls {
-        /// Initializes the contract by instantiating the code at the given code hash and
-        /// storing the resulting account id.
+        /// Initializes the contract by instantiating the code at the given code hash via
+        /// `instantiate_v2` host function with the supplied weight and storage
+        /// limits.
         #[ink(constructor)]
-        pub fn new(other_contract_code_hash: Hash) -> Self {
+        pub fn new_v2_with_limits(
+            other_contract_code_hash: Hash,
+            ref_time_limit: u64,
+            proof_time_limit: u64,
+            storage_deposit_limit: Balance,
+        ) -> Self {
             let other_contract = OtherContractRef::new(true)
+                .code_hash(other_contract_code_hash)
+                .endowment(0)
+                .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])
+                .instantiate();
+
+            Self { other_contract }
+        }
+
+        /// Initializes the contract by instantiating the code at the given code hash via
+        /// the `instantiate_v2` host function with no weight or storage limits.
+        #[ink(constructor)]
+        pub fn new_v2_no_limits(other_contract_code_hash: Hash) -> Self {
+            let other_contract = OtherContractRef::new(true)
+                .code_hash(other_contract_code_hash)
+                .endowment(0)
+                .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])
+                .instantiate();
+
+            Self { other_contract }
+        }
+
+        /// Initializes the contract by instantiating the code at the given code hash via
+        /// the original `instantiate` host function.
+        #[ink(constructor)]
+        pub fn new_v1(other_contract_code_hash: Hash) -> Self {
+            let other_contract = OtherContractRef::new(true)
+                .v1()
                 .code_hash(other_contract_code_hash)
                 .endowment(0)
                 .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])

--- a/integration-tests/cross-contract-calls/lib.rs
+++ b/integration-tests/cross-contract-calls/lib.rs
@@ -25,6 +25,9 @@ mod cross_contract_calls {
                 .code_hash(other_contract_code_hash)
                 .endowment(0)
                 .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])
+                .ref_time_limit(ref_time_limit)
+                .proof_time_limit(proof_time_limit)
+                .storage_deposit_limit(storage_deposit_limit)
                 .instantiate();
 
             Self { other_contract }
@@ -48,7 +51,7 @@ mod cross_contract_calls {
         #[ink(constructor)]
         pub fn new_v1(other_contract_code_hash: Hash) -> Self {
             let other_contract = OtherContractRef::new(true)
-                .v1()
+                .instantiate_v1()
                 .code_hash(other_contract_code_hash)
                 .endowment(0)
                 .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])

--- a/integration-tests/lang-err-integration-tests/call-builder/lib.rs
+++ b/integration-tests/lang-err-integration-tests/call-builder/lib.rs
@@ -104,7 +104,6 @@ mod call_builder {
         ) -> Option<ink::LangError> {
             let mut params = ConstructorsReturnValueRef::new(init_value)
                 .code_hash(code_hash)
-                .gas_limit(0)
                 .endowment(0)
                 .salt_bytes(&[0xDE, 0xAD, 0xBE, 0xEF])
                 .params();
@@ -146,7 +145,6 @@ mod call_builder {
         > {
             let mut params = ConstructorsReturnValueRef::try_new(init_value)
                 .code_hash(code_hash)
-                .gas_limit(0)
                 .endowment(0)
                 .salt_bytes(&[0xDE, 0xAD, 0xBE, 0xEF])
                 .params();

--- a/integration-tests/upgradeable-contracts/README.md
+++ b/integration-tests/upgradeable-contracts/README.md
@@ -29,7 +29,7 @@ called again, since it will fail to load the migrated storage.
 
 ## [Delegator](delegator/)
 
-Delegator patter is based around a low level cross contract call function `delegate_call`.
+The Delegator pattern is based around the low level host function `delegate_call`.
 It allows a contract to delegate its execution to some on-chain uploaded code.
 
 It is different from a traditional cross-contract call

--- a/integration-tests/upgradeable-contracts/README.md
+++ b/integration-tests/upgradeable-contracts/README.md
@@ -49,3 +49,14 @@ This is because `Lazy` and `Mapping` interact with the storage directly instead 
 
 If your storage is completely layoutless (it only contains `Lazy` and `Mapping` fields), the order of fields and layout do not need to match for the same reason as mentioned above.
 
+### Delegate dependency locks
+
+The `delegator` contract depends upon the contract code to which it delegates. Since code
+can be deleted by anybody if there are no instances of the contract on the chain, this 
+would break the `delegator` contract. To prevent this, the `delegator` contract utilizes
+the `lock_delegate_dependency` and `unlock_delegate_dependency` host functions. Calling
+`lock_delegate_dependency` will prevent the code at the given hash from being deleted, 
+until `unlock_delegate_dependency` is called from within the `delegator` contract instance.
+Note that these two methods can be called by anybody executing the contract, so it is the
+responsibility of the contract developer to ensure correct access control.
+


### PR DESCRIPTION
**Requires version of `pallet-contracts` including `instantiate_v2` host function. Introduced in [this commit](https://github.com/paritytech/polkadot-sdk/commit/60310de7d6402b6e44624aaa9b5db2dd848545e7)**

Following up on https://github.com/paritytech/ink/pull/2077.

There is a new host function [`instantiate_v2`](https://github.com/paritytech/polkadot-sdk/blob/bd80dcf6858a0ec9e61b5aceab933979f7258d2b/substrate/frame/contracts/uapi/src/host.rs#L533) which allows passing both `Weight` parts: `ref_time_limit` and `proof_time_limit` and the `storage_deposit_limit`. The legacy `instantiate` function only provides the single `gas_limit` parameter, which is used as the value for `ref_time_limit`.

The [`instantiate` extrinsic](https://github.com/paritytech/polkadot-sdk/blob/0e124a05597b5575f79c90aae212fcf48a87e2ab/substrate/frame/contracts/src/lib.rs#L819) already requires these, so this just brings the cross-contract instantiation API into line with the extrinsic.

### Migration

If your target node does not yet support `instantiate_v2`, then you can continue to use the original `v1` host function, but it requires calling the `instantiate_v1` method on the builder e.g.

```
let create_params = build_create::<OtherContractRef>()
  .instantiate_v1()
  .code_hash(Hash::from([0x42; 32]))
  .gas_limit(500_000_000)
```

Otherwise if you **do not change your code, it will attempt to call the new instantiate_v2 function**, with no compiler warnings unless you are using `gas_limit` which is replaced by `ref_time_limit`.