### PR TITLE
Remove CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
           # FIXME: remove me after CI image gets nonroot
           chown -R nonroot:nonroot ./crate-docs
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-data
           path: ./crate-docs

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -74,7 +74,7 @@ jobs:
             substrate-contracts-node -lruntime::contracts=debug  2>&1 | tee /tmp/contracts-node.log &
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.7.1
+        uses: Swatinem/rust-cache@v2
 
       - name: Install `cargo-contract` `master`
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -42,21 +42,19 @@ jobs:
 
       - name: Install toolchain
         id: toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
           components: rust-src
-          override: true
 
       - name: Install cargo-dylint
-        uses: baptiste0928/cargo-install@1cd874a5478fdca35d868ccc74640c5aabbb8f1b # v3.0.0
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-dylint
           version: 1
 
       - name: Install dylint-link
-        uses: baptiste0928/cargo-install@1cd874a5478fdca35d868ccc74640c5aabbb8f1b # v3.0.0
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: dylint-link
           version: 1
@@ -79,10 +77,11 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.1
 
       - name: Install `cargo-contract` `master`
-        uses: actions-rs/cargo@v1
+        uses: baptiste0928/cargo-install@v3
         with:
-            command: install
-            args: --git https://github.com/paritytech/cargo-contract.git
+            crate: cargo-contract
+            git: https://github.com/paritytech/cargo-contract.git
+            branch: master
 
       - name: Output versions
         run: |

--- a/.github/workflows/measurements.yml
+++ b/.github/workflows/measurements.yml
@@ -67,7 +67,7 @@ jobs:
           echo "PR_NUMBER=\"${PR_NUMBER}\"" >> ${ARTIFACTS_DIR}/context.out
           rm -rf ${MEASUREMENTS_DIR}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.job }}-data
           path: ./artifacts

--- a/RELEASES_CHECKLIST.md
+++ b/RELEASES_CHECKLIST.md
@@ -58,7 +58,8 @@ in the future.
     - `ink_e2e` is dependent on the `cargo-contract` crates, which are dependent on the `ink` "core" crates.
     - Therefore, first release all `ink` crates except `ink_e2e`.
     - Release `cargo-contract` crates.
-    - Release `ink_e2e`
+    - Request update of `drink` client, which depends on the `cargo-contract` crates.
+    - Release `ink_e2e`.
 2. Do a dry run with `cargo release [new_version] -v --no-tag --no-push`
     - `[new_version]` should be the **exact** SemVer compatible version you are attempting
       to release e.g. `5.0.0`


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?

Remove CI warnings

## Description
Remove CI warnings:
 

`The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/toolchain@v1, actions-rs/cargo@v1.`

`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3.`

## Checklist before requesting a review
- [ ] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
