### PR TITLE
Use `MaxEncodedLen` for output buffer size

### DIFF
--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -22,7 +22,7 @@ ink_prelude = { workspace = true }
 ink_primitives = { workspace = true }
 pallet-contracts-uapi = { workspace = true }
 
-scale = { workspace = true }
+scale = { workspace = true, features = ["max-encoded-len"] }
 derive_more = { workspace = true, features = ["from", "display"] }
 num-traits = { workspace = true, features = ["i128"] }
 cfg-if = { workspace = true }

--- a/crates/env/src/engine/on_chain/buffer.rs
+++ b/crates/env/src/engine/on_chain/buffer.rs
@@ -149,6 +149,17 @@ impl<'a> ScopedBuffer<'a> {
         lhs
     }
 
+    /// Returns the first [`scale::MaxEncodedLen::max_encoded_len`] bytes of the buffer as
+    /// a mutable slice.
+    #[inline(always)]
+    pub fn take_max_encoded_len<T>(&mut self) -> &'a mut [u8]
+    where
+        T: scale::MaxEncodedLen,
+    {
+        let len = T::max_encoded_len();
+        self.take(len)
+    }
+
     /// Encode the given value into the scoped buffer and return the sub slice
     /// containing all the encoded bytes.
     #[inline(always)]

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -680,7 +680,7 @@ impl TypedEnvBackend for EnvInstance {
         E: Environment,
     {
         let mut scope = self.scoped_buffer();
-        let output = scope.take(32);
+        let output = scope.take_max_encoded_len::<E::Hash>();
         scope.append_encoded(account_id);
         let enc_account_id = scope.take_appended();
 
@@ -693,7 +693,7 @@ impl TypedEnvBackend for EnvInstance {
     where
         E: Environment,
     {
-        let output = &mut self.scoped_buffer().take(32);
+        let output = &mut self.scoped_buffer().take_max_encoded_len::<E::Hash>();
         ext::own_code_hash(output);
         let hash = scale::Decode::decode(&mut &output[..])?;
         Ok(hash)

--- a/crates/env/src/engine/on_chain/impls.rs
+++ b/crates/env/src/engine/on_chain/impls.rs
@@ -570,10 +570,7 @@ impl TypedEnvBackend for EnvInstance {
         let enc_code_hash = scoped.take_encoded(params.code_hash());
         let enc_endowment = scoped.take_encoded(params.endowment());
         let enc_input = scoped.take_encoded(params.exec_input());
-        // We support `AccountId` types with an encoding that requires up to
-        // 1024 bytes. Beyond that limit ink! contracts will trap for now.
-        // In the default configuration encoded `AccountId` require 32 bytes.
-        let out_address = &mut scoped.take(1024);
+        let out_address = &mut scoped.take_max_encoded_len::<E::AccountId>();
         let salt = params.salt_bytes().as_ref();
         let out_return_value = &mut scoped.take_rest();
 
@@ -616,10 +613,7 @@ impl TypedEnvBackend for EnvInstance {
         let enc_code_hash = scoped.take_encoded(params.code_hash());
         let enc_endowment = scoped.take_encoded(params.endowment());
         let enc_input = scoped.take_encoded(params.exec_input());
-        // We support `AccountId` types with an encoding that requires up to
-        // 1024 bytes. Beyond that limit ink! contracts will trap for now.
-        // In the default configuration encoded `AccountId` require 32 bytes.
-        let out_address = &mut scoped.take(1024);
+        let out_address = &mut scoped.take_max_encoded_len::<E::AccountId>();
         let salt = params.salt_bytes().as_ref();
         let out_return_value = &mut scoped.take_rest();
 

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -150,6 +150,7 @@ pub trait Environment: Clone {
     /// The type of hash.
     type Hash: 'static
         + scale::Codec
+        + scale::MaxEncodedLen
         + CodecAsType
         + Copy
         + Clone

--- a/crates/env/src/types.rs
+++ b/crates/env/src/types.rs
@@ -127,6 +127,7 @@ pub trait Environment: Clone {
     /// The account id type.
     type AccountId: 'static
         + scale::Codec
+        + scale::MaxEncodedLen
         + CodecAsType
         + Clone
         + PartialEq

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -17,7 +17,7 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 [dependencies]
 derive_more = { workspace = true, features = ["from", "display"] }
 ink_prelude = { workspace = true }
-scale = { workspace = true }
+scale = { workspace = true, features = ["max-encoded-len"] }
 scale-decode = { workspace = true, features = ["derive"], optional = true }
 scale-encode = { workspace = true, features = ["derive"], optional = true }
 scale-info = { workspace = true, features = ["derive"], optional = true }

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -17,6 +17,7 @@ use derive_more::From;
 use scale::{
     Decode,
     Encode,
+    MaxEncodedLen,
 };
 #[cfg(feature = "std")]
 use {
@@ -42,7 +43,7 @@ use {
     Hash,
     Decode,
     Encode,
-    scale::MaxEncodedLen,
+    MaxEncodedLen,
     From,
 )]
 #[cfg_attr(feature = "std", derive(TypeInfo, DecodeAsType, EncodeAsType))]

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -32,7 +32,18 @@ use {
 /// This is a mirror of the `AccountId` type used in the default configuration
 /// of PALLET contracts.
 #[derive(
-    Debug, Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Decode, Encode, From,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Decode,
+    Encode,
+    scale::MaxEncodedLen,
+    From,
 )]
 #[cfg_attr(feature = "std", derive(TypeInfo, DecodeAsType, EncodeAsType))]
 pub struct AccountId([u8; 32]);

--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -103,6 +103,7 @@ impl<'a> TryFrom<&'a [u8]> for AccountId {
     Hash,
     Decode,
     Encode,
+    MaxEncodedLen,
     From,
     Default,
 )]


### PR DESCRIPTION
[Suggestion](https://github.com/paritytech/ink/pull/2123#discussion_r1502981416) by @pgherveou.

Use `MaxEncodedLen::max_encoded_len()` instead of hardcoded sizes for allocating part of the buffer for the data of the return value of a host fn.

This allows the types for `AccountId` and `Hash` to be properly configurable, currently they are restricted to a max size of those hardcoded values.