### PR TITLE
Release `5.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Version 5.0.0
+
 ### Summary
 This is a release addressing the rest of severities described in the [OpenZeppelin report](https://blog.openzeppelin.com/security-review-ink-cargo-contract).
-In particular, one of the notable addressed issues is the proxy selector clashing attack.
+One of the notable addressed issues is the proxy selector clashing attack.
 As of this release, ink! only allows exactly one other message with a well-known reserved selector to be defined.
 You can read more about the change in the [#1827](https://github.com/paritytech/ink/pull/1827) and [#2031](https://github.com/paritytech/ink/pull/2031).
 
@@ -28,11 +30,14 @@ the development of new ink! contracts.
 ### Compatability
 
 - Rust: `>=1.70`
-- cargo-contract: `>=4.0.0-rc.3`, `>=4.0.0`
-- polkadot-sdk: `polkadot-v1.8.0` release (in the [`d250a6`](https://github.com/paritytech/polkadot-sdk/commit/d250a6e4270a77f28e2737a4faa3fb78c8ea7a85) commit) **if** using the new host functions introduced in [#2123](https://github.com/paritytech/ink/pull/2123) and [#2077](https://github.com/paritytech/ink/pull/2077)
+- `cargo-contract`: `>=4.0.0`
+- polkadot-sdk: [>= 0.9.3](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v0.9.3), but if using the new functions introduced in [#2123](https://github.com/paritytech/ink/pull/2123) and [#2077](https://github.com/paritytech/ink/pull/2077) [>= 1.8.0](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.8.0).
+- `polkadot-js/api` and `polkadot-js/api-contract`:  `>=10.12.1`
+- `substrate-contracts-node`: `>= 0.39.0`
 
+### Changelog
 
-## Added
+#### Added
 - `instantiate_v2` with additional limit parameters [#2123](https://github.com/paritytech/ink/pull/2123)
 - Custom signature topic in Events - [#2031](https://github.com/paritytech/ink/pull/2031)
 - [Linter] `non_fallible_api` lint - [#2004](https://github.com/paritytech/ink/pull/2004)
@@ -68,7 +73,7 @@ the development of new ink! contracts.
 - [Drink backend] Backend traits - [#1857](https://github.com/paritytech/ink/pull/1857)
 - [Drink backend] Abstract error and result structs - [#1844](https://github.com/paritytech/ink/pull/1844)
 
-### Changed
+#### Changed
 - Bump metadata version to 5 [#2126](https://github.com/paritytech/ink/pull/2126)
 - Use `MaxEncodedLen` for output buffer size [#2128](https://github.com/paritytech/ink/pull/2128)
 - `Mapping`: Reflect all possible failure cases in comments ‒ [#2079](https://github.com/paritytech/ink/pull/2079)
@@ -92,7 +97,7 @@ the development of new ink! contracts.
 - [E2E] crate refactoring - [#1830](https://github.com/paritytech/ink/pull/1830)
 - [E2E] improve call API, remove `build_message` + callback - [#1782](https://github.com/paritytech/ink/pull/1782)
 
-### Fixed
+#### Fixed
 - Fix alignment in allocator [#2100](https://github.com/paritytech/ink/pull/2100)
 - Fix the `StorageVec` type by excluding the `len_cached` field from its type info - [#2052](https://github.com/paritytech/ink/pull/2052)
 - Fix panic in `approve_for` in the ERC-721 example - [#2092](https://github.com/paritytech/ink/pull/2092)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ These are the main features we have introduced in this release. We also encourag
 to have a look at more detailed changelog entries to find out about any breaking changes that may affect
 the development of new ink! contracts.
 
+_We have created a migration guide from ink! 4 to ink! 5. It also contains an
+overview over all breaking changes and newly added features.
+You can view it [here](https://use.ink/faq/migrating-from-ink-4-to-5)._
+
 ### Compatability
 
 - Rust: `>=1.70`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Version 5.0.0
+
+### Added
+- `instantiate_v2` with additional limit parameters [#2123](https://github.com/paritytech/ink/pull/2123)
+- Custom signature topic in Events - [#2031](https://github.com/paritytech/ink/pull/2031)
+- [Linter] `non_fallible_api` lint - [#2004](https://github.com/paritytech/ink/pull/2004)
+- [Linter] Publish the linting crates on crates.io - [#2060](https://github.com/paritytech/ink/pull/2060)
+- [E2E] Added `create_call_builder` for testing existing contracts - [#2075](https://github.com/paritytech/ink/pull/2075)
+- `call_v2` cross-contract calls with additional limit parameters - [#2077](https://github.com/paritytech/ink/pull/2077)
+- `instantiate_v2` with additional limit parameters - [#2123](https://github.com/paritytech/ink/pull/2123)
+- `delegate_dependency` api calls - [#2076](https://github.com/paritytech/ink/pull/2076)
+- Allow mutable parameters in messages - [#2004](https://github.com/paritytech/ink/pull/2004)
+- Clean E2E configuration parsing - [#1922](https://github.com/paritytech/ink/pull/1922)
+- Make `set_code_hash` generic - [#1906](https://github.com/paritytech/ink/pull/1906)
+- Provide a `StorageVec` datastructure built on top of `Lazy` - [#1995](https://github.com/paritytech/ink/pull/1995)
+- Add fallible methods for `Mapping` and `Lazy` - [#1910](https://github.com/paritytech/ink/pull/1910)
+- [E2E] Allow testing with live-chain state - [#1949](https://github.com/paritytech/ink/pull/1949)
+- [E2E] Call builders and extra gas margin option - [#1917](https://github.com/paritytech/ink/pull/1917)
+- [Linter] `storage_never_freed` lint - [#1932](https://github.com/paritytech/ink/pull/1932)
+- [Linter] `strict_balance_equality` lint - [#1914](https://github.com/paritytech/ink/pull/1914)
+- [Linter] `no_main` lint - [#2001](https://github.com/paritytech/ink/pull/2001)
+- Reexport `scale` dependencies, introduce `#[ink::scale_derive]` - [#1890](https://github.com/paritytech/ink/pull/1890)
+- Upgradeable contracts example - [#1889](https://github.com/paritytech/ink/pull/1889)
+- Persist static buffer size in metadata - [#1880](https://github.com/paritytech/ink/pull/1880)
+- Modify static buffer size via environmental variables - [#1869](https://github.com/paritytech/ink/pull/1869)
+- Added `sr25519_verify` function to `ink_env` [#1840](https://github.com/paritytech/ink/pull/1840)
+- Events `2.0` - [#1827](https://github.com/paritytech/ink/pull/1827)
+- Add `set_block_number` to off-chain test api `Engine` - [#1806](https://github.com/paritytech/ink/pull/1806)
+- Stabilize `call_runtime` ‒ [#1749](https://github.com/paritytech/ink/pull/1749)
+- Schema generation - [#1765](https://github.com/paritytech/ink/pull/1765)
+- Restrict wildcard selectors to have exactly one other message - [#1708](https://github.com/paritytech/ink/pull/1708)
+- [Linter] Warn when primitive number is annotated as event topic - [#1837](https://github.com/paritytech/ink/pull/1837)
+- [Drink backend] allow for arbitrary runtime - [#1892](https://github.com/paritytech/ink/pull/1892)
+- [Drink backend] support runtime call - [#1891](https://github.com/paritytech/ink/pull/1891)
+- [Drink backend] Make tests generic `E2EBackend` trait - [#1867](https://github.com/paritytech/ink/pull/1867)
+- [Drink backend] Backend choice  ‒ [#1864](https://github.com/paritytech/ink/pull/1864)
+- [Drink backend] Backend traits - [#1857](https://github.com/paritytech/ink/pull/1857)
+- [Drink backend] Abstract error and result structs - [#1844](https://github.com/paritytech/ink/pull/1844)
+
+### Changed
+- Bump metadata version to 5 [#2126](https://github.com/paritytech/ink/pull/2126)
+- Use `MaxEncodedLen` for output buffer size [#2128](https://github.com/paritytech/ink/pull/2128)
+- `Mapping`: Reflect all possible failure cases in comments ‒ [#2079](https://github.com/paritytech/ink/pull/2079)
+- [E2E] Rename `.call` to `.call_builder` ‒ [#2078](https://github.com/paritytech/ink/pull/2078)
+- Improve syntax for ink! e2e `runtime_only` attribute argument - [#2083](https://github.com/paritytech/ink/pull/2083)
+- [E2E] Remove `additional_contracts` parameter [#2098](https://github.com/paritytech/ink/pull/2098)
+- [E2E] change node url backend config - [#2101](https://github.com/paritytech/ink/pull/2101)
+- Messages return `TypeSpec` directly - [#1999](https://github.com/paritytech/ink/pull/1999)
+- Fail when decoding from storage and not all bytes consumed - [#1897](https://github.com/paritytech/ink/pull/1897)
+- Support multiple chain extensions - [#1958](https://github.com/paritytech/ink/pull/1958)
+  - New example of how to use multiple chain extensions in one contract.
+  - Affects the usage of the `#[ink::chain_extension]` macro and the definition of the chain extension.
+- Split up `ink_linting` to mandatory and extra libraries - [#2032](https://github.com/paritytech/ink/pull/2032)
+- [E2E] resolve DispatchError error details for dry-runs - [#1994](https://github.com/paritytech/ink/pull/1994)
+- [E2E] update to new `drink` API - [#2005](https://github.com/paritytech/ink/pull/2005)
+- Reexport `scale` dependencies, introduce `#[ink::scale_derive]` ‒ [#1890](https://github.com/paritytech/ink/pull/1890)
+- Use of workspace dependencies and properties - [#1835](https://github.com/paritytech/ink/pull/1835)
+- Remove of unchecked arithmetic - [#1831](https://github.com/paritytech/ink/pull/1831)
+- Use `decode_all` for decoding cross contract call result - [#1810](https://github.com/paritytech/ink/pull/1810)
+- [E2E] build contracts at runtime instead of during codegen - [#1881](https://github.com/paritytech/ink/pull/1881)
+- [E2E] crate refactoring - [#1830](https://github.com/paritytech/ink/pull/1830)
+- [E2E] improve call API, remove `build_message` + callback - [#1782](https://github.com/paritytech/ink/pull/1782)
+
+### Fixed
+- Fix alignment in allocator [#2100](https://github.com/paritytech/ink/pull/2100)
+- Fix the `StorageVec` type by excluding the `len_cached` field from its type info - [#2052](https://github.com/paritytech/ink/pull/2052)
+- Fix panic in `approve_for` in the ERC-721 example - [#2092](https://github.com/paritytech/ink/pull/2092)
+- ERC-721: `transfer_token_from` now ensures the token owner is correct - [#2093](https://github.com/paritytech/ink/pull/2093)
+- `RootLayout::new()` is generic again to allow using `ink_metadata` in pure `PortableForm` contexts - [#1989](https://github.com/paritytech/ink/pull/1989)
+
+
 ## Version 5.0.0-rc.2
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Add Hash trait to Selector struct
 
 ## Version 5.0.0
 
@@ -47,6 +46,7 @@ See [the compatibility section](https://use.ink/faq/migrating-from-ink-4-to-5/#c
 ### Changelog
 
 #### Added
+- Add Hash trait to Selector struct - [#2149](https://github.com/paritytech/ink/pull/2149)
 - `instantiate_v2` with additional limit parameters [#2123](https://github.com/paritytech/ink/pull/2123)
 - Custom signature topic in Events - [#2031](https://github.com/paritytech/ink/pull/2031)
 - [Linter] `non_fallible_api` lint - [#2004](https://github.com/paritytech/ink/pull/2004)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-# Summary
+### Summary
 This is a release addressing the rest of severities described in the [OpenZeppelin report](https://blog.openzeppelin.com/security-review-ink-cargo-contract).
 In particular, one of the notable addressed issues is the proxy selector clashing attack.
 As of this release, ink! only allows exactly one other message with a well-known reserved selector to be defined.
@@ -25,13 +25,12 @@ These are the main features we have introduced in this release. We also encourag
 to have a look at more detailed changelog entries to find out about any breaking changes that may affect
 the development of new ink! contracts.
 
-# Compatability
+### Compatability
 
 - Rust: `>=1.70`
-- cargo-contract: `>=4.0.0-rc.3`
-- polkadot-sdk: [>=1.1.0](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.1.0) **if** using the new host functions introduced in [#2123](https://github.com/paritytech/ink/pull/2123) and [#2077](https://github.com/paritytech/ink/pull/2077)
+- cargo-contract: `>=4.0.0-rc.3`, `>=4.0.0`
+- polkadot-sdk: `polkadot-v1.8.0` release (in the [`d250a6`](https://github.com/paritytech/polkadot-sdk/commit/d250a6e4270a77f28e2737a4faa3fb78c8ea7a85) commit) **if** using the new host functions introduced in [#2123](https://github.com/paritytech/ink/pull/2123) and [#2077](https://github.com/paritytech/ink/pull/2077)
 
-# Changelog
 
 ## Added
 - `instantiate_v2` with additional limit parameters [#2123](https://github.com/paritytech/ink/pull/2123)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Version 5.0.0
-
+# Summary
 This is a release addressing the rest of severities described in the [OpenZeppelin report](https://blog.openzeppelin.com/security-review-ink-cargo-contract).
 In particular, one of the notable addressed issues is the proxy selector clashing attack.
 As of this release, ink! only allows exactly one other message with a well-known reserved selector to be defined.
-You can read more about the change in the [#1708](https://github.com/paritytech/ink/pull/1708).
+You can read more about the change in the [#1827](https://github.com/paritytech/ink/pull/1827) and [#2031](https://github.com/paritytech/ink/pull/2031).
 
 ink! 5.0.0 features a significant number of new features:
 - We have introduced a new API based on the calculated or specified selectors for the event definition. This allows events to be defined in separate files and modules, and be shared across multiple ink! contracts - [#1827](https://github.com/paritytech/ink/pull/1827) and [#2031](https://github.com/paritytech/ink/pull/2031).
@@ -26,15 +25,21 @@ These are the main features we have introduced in this release. We also encourag
 to have a look at more detailed changelog entries to find out about any breaking changes that may affect
 the development of new ink! contracts.
 
+# Compatability
 
-### Added
+- Rust: `>=1.70`
+- cargo-contract: `>=4.0.0-rc.3`
+- polkadot-sdk: [>=1.1.0](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.1.0) **if** using the new host functions introduced in [#2123](https://github.com/paritytech/ink/pull/2123) and [#2077](https://github.com/paritytech/ink/pull/2077)
+
+# Changelog
+
+## Added
 - `instantiate_v2` with additional limit parameters [#2123](https://github.com/paritytech/ink/pull/2123)
 - Custom signature topic in Events - [#2031](https://github.com/paritytech/ink/pull/2031)
 - [Linter] `non_fallible_api` lint - [#2004](https://github.com/paritytech/ink/pull/2004)
 - [Linter] Publish the linting crates on crates.io - [#2060](https://github.com/paritytech/ink/pull/2060)
 - [E2E] Added `create_call_builder` for testing existing contracts - [#2075](https://github.com/paritytech/ink/pull/2075)
 - `call_v2` cross-contract calls with additional limit parameters - [#2077](https://github.com/paritytech/ink/pull/2077)
-- `instantiate_v2` with additional limit parameters - [#2123](https://github.com/paritytech/ink/pull/2123)
 - `delegate_dependency` api calls - [#2076](https://github.com/paritytech/ink/pull/2076)
 - Allow mutable parameters in messages - [#2004](https://github.com/paritytech/ink/pull/2004)
 - Clean E2E configuration parsing - [#1922](https://github.com/paritytech/ink/pull/1922)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,15 @@ As of this release, ink! only allows exactly one other message with a well-known
 You can read more about the change in the [#1708](https://github.com/paritytech/ink/pull/1708).
 
 ink! 5.0.0 features a significant number of new features:
-- We have introduced a new API for the event definition based on the calculated or specified selectors. This allows events to be defined in separate files and modules, and be shared across multiple ink! contracts - [#1827](https://github.com/paritytech/ink/pull/1827) and [#2031](https://github.com/paritytech/ink/pull/2031).
-- [@pmikolajczyk41](https://github.com/pmikolajczyk41) has introduced an alternative E2E testing framework, [DRink!](https://github.com/inkdevhub/drink?tab=readme-ov-file#as-an-alternative-backend-to-inks-e2e-testing-framework), that support quasi-testing model, it allows the test simulate a running node as part of the E2E test, while improving debugging experience such as allowing to set break point and step through each stage of execution cycle.
+- We have introduced a new API based on the calculated or specified selectors for the event definition. This allows events to be defined in separate files and modules, and be shared across multiple ink! contracts - [#1827](https://github.com/paritytech/ink/pull/1827) and [#2031](https://github.com/paritytech/ink/pull/2031).
+- [@pmikolajczyk41](https://github.com/pmikolajczyk41) has introduced an alternative E2E testing framework, [DRink!](https://github.com/inkdevhub/drink?tab=readme-ov-file#as-an-alternative-backend-to-inks-e2e-testing-framework), that support quasi-testing model, it allows the test simulate a running node as part of the E2E test while improving debugging experience such as allowing to set breakpoint and step through each stage of execution cycle.
 - Following improvements in E2E, we have added a call builder API that allows to easily build calls while significantly reducing boilerplate code - [#1917](https://github.com/paritytech/ink/pull/1917) and [#2075](https://github.com/paritytech/ink/pull/2075)
-- Another notable introduction in 5.0.0 release is the support for multiple chain extensions that empowers developers
+- Another notable introduction in 5.0.0 release is the support for multiple chain extensions that empower developers
 to build even more sophisticated and advanced contracts for supported chains - [#1958](https://github.com/paritytech/ink/pull/1958).
-- To further address our consideration of intrinsic security of ink! smart contracts,
-we have disallowed unchecked arithmetic expressions. `cargo-contract` will fail compiling the contract with raw arithmetic operation - [#1831](https://github.com/paritytech/ink/pull/1831).
+- To further address our consideration of the intrinsic security of ink! smart contracts,
+we have disallowed unchecked arithmetic expressions. `cargo-contract` will fail to compile the contract with the raw arithmetic operation - [#1831](https://github.com/paritytech/ink/pull/1831).
 
-These are one the main features we have introduced in this release. We also encourage developers
+These are the main features we have introduced in this release. We also encourage developers
 to have a look at more detailed changelog entries to find out about any breaking changes that may affect
 the development of new ink! contracts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 5.0.0
 
+_ℹ️ We have created a migration guide from ink! 4 to ink! 5. It also contains an
+overview over all breaking changes and newly added features.
+
+You can view it [here](https://use.ink/faq/migrating-from-ink-4-to-5)._
+
+
 ### Summary
-This is a release addressing the rest of the severities described in the [OpenZeppelin security review](https://blog.openzeppelin.com/security-review-ink-cargo-contract) of ink! and `cargo-contract`.
+This release addresses the rest of the severities described in the [OpenZeppelin security review](https://blog.openzeppelin.com/security-review-ink-cargo-contract) of ink! and `cargo-contract`.
 One of the notable addressed issues is the proxy selector clashing attack.
 As of this release, ink! only allows exactly one other message with a well-known reserved selector to be defined.
 You can read more about the change in the [#1827](https://github.com/paritytech/ink/pull/1827) and [#2031](https://github.com/paritytech/ink/pull/2031).
@@ -27,16 +33,14 @@ These are the main features we have introduced in this release. We also encourag
 to have a look at more detailed changelog entries to find out about any breaking changes that may affect
 the development of new ink! contracts.
 
-_We have created a migration guide from ink! 4 to ink! 5. It also contains an
-overview over all breaking changes and newly added features.
-You can view it [here](https://use.ink/faq/migrating-from-ink-4-to-5)._
-
 ### Compatibility
 
-- Rust: `>=1.70`
-- `cargo-contract`: `>=4.0.0`
-- polkadot-sdk: [>= 0.9.3](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v0.9.3), but if using the new functions introduced in [#2123](https://github.com/paritytech/ink/pull/2123) and [#2077](https://github.com/paritytech/ink/pull/2077) [>= 1.8.0](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.8.0).
-- `polkadot-js/api` and `polkadot-js/api-contract`:  `>=10.12.1`
+See [the compatibility section](https://use.ink/faq/migrating-from-ink-4-to-5/#compatibility) of our migration guide for a detailed description. On a high level:
+
+- Rust: `>= 1.70`
+- `cargo-contract`: `>= 4.0.0`
+- polkadot-sdk: [>= 0.9.3](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v0.9.3). But if using the new functions introduced in [#2123](https://github.com/paritytech/ink/pull/2123) and [#2077](https://github.com/paritytech/ink/pull/2077) [>= 1.8.0](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.8.0) and if using the new functions introduced in [#2076](https://github.com/paritytech/ink/pull/2076) [>= 1.9.0](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.8.0).
+- `polkadot-js/api` and `polkadot-js/api-contract`: `>= 10.12.1`
 - `substrate-contracts-node`: `>= 0.39.0`
 
 ### Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ _We have created a migration guide from ink! 4 to ink! 5. It also contains an
 overview over all breaking changes and newly added features.
 You can view it [here](https://use.ink/faq/migrating-from-ink-4-to-5)._
 
-### Compatability
+### Compatibility
 
 - Rust: `>=1.70`
 - `cargo-contract`: `>=4.0.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version 5.0.0
 
+This is a release addressing the rest of severities described in the [OpenZeppelin report](https://blog.openzeppelin.com/security-review-ink-cargo-contract).
+In particular, one of the notable addressed issues is the proxy selector clashing attack.
+As of this release, ink! only allows exactly one other message with a well-known reserved selector to be defined.
+You can read more about the change in the [#1708](https://github.com/paritytech/ink/pull/1708).
+
+ink! 5.0.0 features a significant number of new features:
+- We have introduced a new API for the event definition based on the calculated or specified selectors. This allows events to be defined in separate files and modules, and be shared across multiple ink! contracts - [#1827](https://github.com/paritytech/ink/pull/1827) and [#2031](https://github.com/paritytech/ink/pull/2031).
+- [@pmikolajczyk41](https://github.com/pmikolajczyk41) has introduced an alternative E2E testing framework, [DRink!](https://github.com/inkdevhub/drink?tab=readme-ov-file#as-an-alternative-backend-to-inks-e2e-testing-framework), that support quasi-testing model, it allows the test simulate a running node as part of the E2E test, while improving debugging experience such as allowing to set break point and step through each stage of execution cycle.
+- Following improvements in E2E, we have added a call builder API that allows to easily build calls while significantly reducing boilerplate code - [#1917](https://github.com/paritytech/ink/pull/1917) and [#2075](https://github.com/paritytech/ink/pull/2075)
+- Another notable introduction in 5.0.0 release is the support for multiple chain extensions that empowers developers
+to build even more sophisticated and advanced contracts for supported chains - [#1958](https://github.com/paritytech/ink/pull/1958).
+- To further address our consideration of intrinsic security of ink! smart contracts,
+we have disallowed unchecked arithmetic expressions. `cargo-contract` will fail compiling the contract with raw arithmetic operation - [#1831](https://github.com/paritytech/ink/pull/1831).
+
+These are one the main features we have introduced in this release. We also encourage developers
+to have a look at more detailed changelog entries to find out about any breaking changes that may affect
+the development of new ink! contracts.
+
+
 ### Added
 - `instantiate_v2` with additional limit parameters [#2123](https://github.com/paritytech/ink/pull/2123)
 - Custom signature topic in Events - [#2031](https://github.com/paritytech/ink/pull/2031)
@@ -892,10 +911,10 @@ This is the 7th release candidate for ink! 3.0.
 Since our last release candidate we implemented a number of contract size improvements.
 With those improvements the size of our `erc20` example has reduced significantly:
 
-|          |             | Release Build with `cargo-contract` |
-|:---------|:------------|:------------------------------------|
-| `erc20`  | `3.0.0-rc6` | 29.3 K                              |
-| `erc20`  | `3.0.0-rc7` | 10.4 K                              |
+|         |             | Release Build with `cargo-contract` |
+| :------ | :---------- | :---------------------------------- |
+| `erc20` | `3.0.0-rc6` | 29.3 K                              |
+| `erc20` | `3.0.0-rc7` | 10.4 K                              |
 
 The savings apply partly to our other examples; for `erc20` they are most
 significant since it has been migrated to use a new [`Mapping`](https://paritytech.github.io/ink/ink_storage/lazy/struct.Mapping.html)
@@ -1358,15 +1377,15 @@ However, their APIs look very different. Whereas the `HashMap` provides a rich a
 
 The fundamental difference of both data structures is that `HashMap` is aware of the keys that have been stored in it and thus can reconstruct exactly which elements and storage regions apply to it. This enables it to provide iteration and automated deletion as well as efficient way to defragment its underlying storage to free some storage space again. This goes very well in the vein of Substrate's storage rent model where contracts have to pay for the storage they are using.
 
-| Data Structure | level of abstraction | caching | lazy | element type | container |
-|:--|:-:|:-:|:-:|:-:|:-:|
-| `T` | - | yes | no | `T` | primitive value |
-| `Lazy<T>` | high-level | yes | yes | `T` | single element container |
-| `LazyCell<T>` | low-level | yes | yes | `Option<T>` | single element, no container |
-| `Vec<T>` | high-level | yes | yes | `T` | Rust vector-like container |
-| `LazyIndexMap<T>` | low-level | yes | yes | `Option<T>` | similar to Solidity mapping |
-| `HashMap<K, V>` | high-level | yes | yes | `V` (key type `K`) | Rust map-like container |
-| `LazyHashMap<K, V>` | low-level | yes | yes | `Option<V>` (key type `K`) | similar to Solidity mapping |
+| Data Structure      | level of abstraction | caching | lazy  |        element type        |          container           |
+| :------------------ | :------------------: | :-----: | :---: | :------------------------: | :--------------------------: |
+| `T`                 |          -           |   yes   |  no   |            `T`             |       primitive value        |
+| `Lazy<T>`           |      high-level      |   yes   |  yes  |            `T`             |   single element container   |
+| `LazyCell<T>`       |      low-level       |   yes   |  yes  |        `Option<T>`         | single element, no container |
+| `Vec<T>`            |      high-level      |   yes   |  yes  |            `T`             |  Rust vector-like container  |
+| `LazyIndexMap<T>`   |      low-level       |   yes   |  yes  |        `Option<T>`         | similar to Solidity mapping  |
+| `HashMap<K, V>`     |      high-level      |   yes   |  yes  |     `V` (key type `K`)     |   Rust map-like container    |
+| `LazyHashMap<K, V>` |      low-level       |   yes   |  yes  | `Option<V>` (key type `K`) | similar to Solidity mapping  |
 
 There are many more! For more information about the specifics please take a look into [the `ink_storage` crate documentation](https://paritytech.github.io/ink/ink_storage/).
 
@@ -1552,18 +1571,18 @@ mod erc20 {
 
 We won't be going into the details for any of those but will briefly present the entire set of ink! specific attributes below:
 
-| Attribute | Where Applicable | Description |
-|:--|:--|:--|
-| `#[ink(storage)]` | On `struct` definitions. | Defines the ink! storage struct. There can only be one ink! storage definition per contract. |
-| `#[ink(event)]` | On `struct` definitions. | Defines an ink! event. A contract can define multiple such ink! events. |
-| `#[ink(anonymous)]` **new** | Applicable to ink! events. | Tells the ink! codegen to treat the ink! event as anonymous which omits the event signature as topic upon emitting. Very similar to anonymous events in Solidity. |
-| `#[ink(topic)]` | Applicate on ink! event field. | Tells the ink! codegen to provide a topic hash for the given field. Every ink! event can only have a limited number of such topic field. Similar semantics as to indexed event arguments in Solidity. |
-| `#[ink(message)]` | Applicable to methods. | Flags a method for the ink! storage struct as message making it available to the API for calling the contract. |
-| `#[ink(constructor)]` | Applicable to method. | Flags a method for the ink! storage struct as constructor making it available to the API for instantiating the contract. |
-| `#[ink(payable)]` **new** | Applicable to ink! messages. | Allows receiving value as part of the call of the ink! message. ink! constructors are implicitly payable. |
-| `#[ink(selector = "..")]` **new** | Applicable to ink! messages and ink! constructors. | Specifies a concrete dispatch selector for the flagged entity. This allows a contract author to precisely control the selectors of their APIs making it possible to rename their API without breakage. |
-| `#[ink(namespace = "..")]` **new** | Applicable to ink! trait implementation blocks. | Changes the resulting selectors of all the ink! messages and ink! constructors within the trait implementation. Allows to disambiguate between trait implementations with overlapping message or constructor names. Use only with great care and consideration! |
-| `#[ink(impl)]` **new** | Applicable to ink! implementation blocks. | Tells the ink! codegen that some implementation block shall be granted access to ink! internals even without it containing any ink! messages or ink! constructors. |
+| Attribute                          | Where Applicable                                   | Description                                                                                                                                                                                                                                                     |
+| :--------------------------------- | :------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `#[ink(storage)]`                  | On `struct` definitions.                           | Defines the ink! storage struct. There can only be one ink! storage definition per contract.                                                                                                                                                                    |
+| `#[ink(event)]`                    | On `struct` definitions.                           | Defines an ink! event. A contract can define multiple such ink! events.                                                                                                                                                                                         |
+| `#[ink(anonymous)]` **new**        | Applicable to ink! events.                         | Tells the ink! codegen to treat the ink! event as anonymous which omits the event signature as topic upon emitting. Very similar to anonymous events in Solidity.                                                                                               |
+| `#[ink(topic)]`                    | Applicate on ink! event field.                     | Tells the ink! codegen to provide a topic hash for the given field. Every ink! event can only have a limited number of such topic field. Similar semantics as to indexed event arguments in Solidity.                                                           |
+| `#[ink(message)]`                  | Applicable to methods.                             | Flags a method for the ink! storage struct as message making it available to the API for calling the contract.                                                                                                                                                  |
+| `#[ink(constructor)]`              | Applicable to method.                              | Flags a method for the ink! storage struct as constructor making it available to the API for instantiating the contract.                                                                                                                                        |
+| `#[ink(payable)]` **new**          | Applicable to ink! messages.                       | Allows receiving value as part of the call of the ink! message. ink! constructors are implicitly payable.                                                                                                                                                       |
+| `#[ink(selector = "..")]` **new**  | Applicable to ink! messages and ink! constructors. | Specifies a concrete dispatch selector for the flagged entity. This allows a contract author to precisely control the selectors of their APIs making it possible to rename their API without breakage.                                                          |
+| `#[ink(namespace = "..")]` **new** | Applicable to ink! trait implementation blocks.    | Changes the resulting selectors of all the ink! messages and ink! constructors within the trait implementation. Allows to disambiguate between trait implementations with overlapping message or constructor names. Use only with great care and consideration! |
+| `#[ink(impl)]` **new**             | Applicable to ink! implementation blocks.          | Tells the ink! codegen that some implementation block shall be granted access to ink! internals even without it containing any ink! messages or ink! constructors.                                                                                              |
 
 ### Merging of ink! Attributes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Version 5.0.0
 
 ### Summary
-This is a release addressing the rest of severities described in the [OpenZeppelin report](https://blog.openzeppelin.com/security-review-ink-cargo-contract).
+This is a release addressing the rest of the severities described in the [OpenZeppelin security review](https://blog.openzeppelin.com/security-review-ink-cargo-contract) of ink! and `cargo-contract`.
 One of the notable addressed issues is the proxy selector clashing attack.
 As of this release, ink! only allows exactly one other message with a well-known reserved selector to be defined.
 You can read more about the change in the [#1827](https://github.com/paritytech/ink/pull/1827) and [#2031](https://github.com/paritytech/ink/pull/2031).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -183,7 +183,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -361,7 +361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.0.0",
+ "event-listener 5.2.0",
  "event-listener-strategy 0.5.0",
  "futures-core",
  "pin-project-lite",
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c1cd5d253ecac3d3cf15e390fd96bd92a13b1d14497d81abf077304794fb04"
+checksum = "451e3cf68011bd56771c79db04a9e333095ab6349f7e47592b788e9b98720cc8"
 dependencies = [
  "async-channel",
  "async-io",
@@ -454,7 +454,7 @@ dependencies = [
  "async-signal",
  "blocking",
  "cfg-if",
- "event-listener 4.0.3",
+ "event-listener 5.2.0",
  "futures-lite",
  "rustix 0.38.31",
  "windows-sys 0.52.0",
@@ -492,7 +492,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "byte-slice-cast"
@@ -853,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "a0ba8f7aaa012f30d5b2861462f6708eccd49c3c39863fe083a308035f63d723"
 dependencies = [
  "jobserver",
  "libc",
@@ -889,15 +889,15 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -941,7 +941,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -999,9 +999,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
 dependencies = [
  "const-random-macro",
 ]
@@ -1121,9 +1121,9 @@ dependencies = [
  "contract-metadata",
  "escape8259",
  "hex",
- "indexmap 2.2.4",
- "ink_env 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ink_metadata 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 2.2.5",
+ "ink_env 5.0.0-rc.2",
+ "ink_metadata 5.0.0-rc.2",
  "itertools 0.12.1",
  "nom",
  "nom-supreme",
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -1344,14 +1344,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.116"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aff472b83efd22bfc0176aa8ba34617dd5c17364670eb201a5f06d339b8abf7"
+checksum = "2673ca5ae28334544ec2a6b18ebe666c42a2650abfb48abbd532ed409a44be2b"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1361,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.116"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf6e7a52c19013a9a0ec421c7d9c2d1125faf333551227e0a017288d71b47c3"
+checksum = "9df46fe0eb43066a332586114174c449a62c25689f85a08f28fdcc8e12c380b9"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1371,24 +1371,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.116"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589e83d02fc1d4fb78f5ad56ca08835341e23499d086d2821315869426d618dc"
+checksum = "886acf875df67811c11cd015506b3392b9e1820b1627af1a6f4e93ccdfc74d11"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.116"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2cb1fd8ffae4230c7cfbbaf3698dbeaf750fa8c5dadf7ed897df581b9b572a5"
+checksum = "1d151cc139c3080e07f448f93a1284577ab2283d2a44acd902c6fba9ec20b6de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1436,7 +1436,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1458,7 +1458,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core 0.20.8",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1579,7 +1579,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.48",
+ "syn 2.0.52",
  "termcolor",
  "toml",
  "walkdir",
@@ -1631,7 +1631,7 @@ dependencies = [
  "darling 0.20.8",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
@@ -1825,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.0.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72557800024fabbaa2449dd4bf24e37b93702d457a4d4f2b0dd1f0f039f20c1"
+checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1850,21 +1850,22 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
 dependencies = [
- "event-listener 5.0.0",
+ "event-listener 5.2.0",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "expander"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f86a749cf851891866c10515ef6c299b5c69661465e9c3bbe7e07a2b77fb0f7"
+checksum = "00e83c02035136f1592a47964ea60c05a50e4ed8b5892cfac197063850898d4d"
 dependencies = [
  "blake2",
  "fs-err",
+ "prettier-please",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2036,7 +2037,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-core-hashing",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2049,7 +2050,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2060,7 +2061,7 @@ checksum = "68672b9ec6fe72d259d3879dc212c5e42e977588cdac830c76f54d9f492aeb58"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2169,7 +2170,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2186,9 +2187,9 @@ checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -2295,7 +2296,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -2323,7 +2324,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2332,7 +2333,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -2341,7 +2342,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "allocator-api2",
  "serde",
 ]
@@ -2354,9 +2355,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2415,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -2606,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.4"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967d6dd42f16dbf0eb8040cb9e477933562684d3918f7d253f2ff9087fb3e7a3"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -2623,29 +2624,20 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "ink"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 dependencies = [
  "derive_more",
- "ink_env 5.0.0-rc.2",
+ "ink_env 5.0.0",
  "ink_ir",
  "ink_macro",
- "ink_metadata 5.0.0-rc.2",
- "ink_prelude 5.0.0-rc.2",
- "ink_primitives 5.0.0-rc.2",
+ "ink_metadata 5.0.0",
+ "ink_prelude 5.0.0",
+ "ink_primitives 5.0.0",
  "ink_storage",
  "pallet-contracts-uapi-next",
  "parity-scale-codec",
  "scale-info",
  "trybuild",
-]
-
-[[package]]
-name = "ink_allocator"
-version = "5.0.0-rc.2"
-dependencies = [
- "cfg-if",
- "quickcheck",
- "quickcheck_macros",
 ]
 
 [[package]]
@@ -2658,8 +2650,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ink_allocator"
+version = "5.0.0"
+dependencies = [
+ "cfg-if",
+ "quickcheck",
+ "quickcheck_macros",
+]
+
+[[package]]
 name = "ink_codegen"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 dependencies = [
  "blake2",
  "derive_more",
@@ -2667,19 +2668,19 @@ dependencies = [
  "heck",
  "impl-serde",
  "ink_ir",
- "ink_primitives 5.0.0-rc.2",
+ "ink_primitives 5.0.0",
  "itertools 0.12.1",
  "parity-scale-codec",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "ink_e2e"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 dependencies = [
  "cargo_metadata",
  "contract-build",
@@ -2688,8 +2689,8 @@ dependencies = [
  "impl-serde",
  "ink",
  "ink_e2e_macro",
- "ink_env 5.0.0-rc.2",
- "ink_primitives 5.0.0-rc.2",
+ "ink_env 5.0.0",
+ "ink_primitives 5.0.0",
  "jsonrpsee 0.22.1",
  "pallet-contracts",
  "parity-scale-codec",
@@ -2713,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "ink_e2e_macro"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 dependencies = [
  "darling 0.20.8",
  "derive_more",
@@ -2721,7 +2722,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.48",
+ "syn 2.0.52",
  "temp-env",
  "tracing-subscriber 0.3.18",
 ]
@@ -2729,6 +2730,8 @@ dependencies = [
 [[package]]
 name = "ink_engine"
 version = "5.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2b07ba4113fa49d1d36771190a666b74cd5cff4840be572fb8194af9ca034f"
 dependencies = [
  "blake2",
  "derive_more",
@@ -2742,13 +2745,11 @@ dependencies = [
 
 [[package]]
 name = "ink_engine"
-version = "5.0.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2b07ba4113fa49d1d36771190a666b74cd5cff4840be572fb8194af9ca034f"
+version = "5.0.0"
 dependencies = [
  "blake2",
  "derive_more",
- "ink_primitives 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_primitives 5.0.0",
  "pallet-contracts-uapi-next",
  "parity-scale-codec",
  "secp256k1",
@@ -2759,12 +2760,13 @@ dependencies = [
 [[package]]
 name = "ink_env"
 version = "5.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc1fd2c16521d8c585e7b0dbee65a9bbbb8d37cb78a57b57ca27a76bfc06266"
 dependencies = [
  "blake2",
  "cfg-if",
  "const_env",
  "derive_more",
- "ink",
  "ink_allocator 5.0.0-rc.2",
  "ink_engine 5.0.0-rc.2",
  "ink_prelude 5.0.0-rc.2",
@@ -2787,19 +2789,18 @@ dependencies = [
 
 [[package]]
 name = "ink_env"
-version = "5.0.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc1fd2c16521d8c585e7b0dbee65a9bbbb8d37cb78a57b57ca27a76bfc06266"
+version = "5.0.0"
 dependencies = [
  "blake2",
  "cfg-if",
  "const_env",
  "derive_more",
- "ink_allocator 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ink_engine 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ink_prelude 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ink_primitives 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ink_storage_traits 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink",
+ "ink_allocator 5.0.0",
+ "ink_engine 5.0.0",
+ "ink_prelude 5.0.0",
+ "ink_primitives 5.0.0",
+ "ink_storage_traits 5.0.0",
  "num-traits",
  "pallet-contracts-uapi-next",
  "parity-scale-codec",
@@ -2817,53 +2818,36 @@ dependencies = [
 
 [[package]]
 name = "ink_ir"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 dependencies = [
  "blake2",
  "either",
  "impl-serde",
- "ink_prelude 5.0.0-rc.2",
+ "ink_prelude 5.0.0",
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "ink_macro"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 dependencies = [
  "ink",
  "ink_codegen",
- "ink_env 5.0.0-rc.2",
+ "ink_env 5.0.0",
  "ink_ir",
- "ink_metadata 5.0.0-rc.2",
- "ink_prelude 5.0.0-rc.2",
- "ink_primitives 5.0.0-rc.2",
+ "ink_metadata 5.0.0",
+ "ink_prelude 5.0.0",
+ "ink_primitives 5.0.0",
  "ink_storage",
  "parity-scale-codec",
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.48",
+ "syn 2.0.52",
  "synstructure",
-]
-
-[[package]]
-name = "ink_metadata"
-version = "5.0.0-rc.2"
-dependencies = [
- "derive_more",
- "impl-serde",
- "ink_prelude 5.0.0-rc.2",
- "ink_primitives 5.0.0-rc.2",
- "linkme",
- "parity-scale-codec",
- "pretty_assertions",
- "scale-info",
- "schemars",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2874,8 +2858,8 @@ checksum = "505fb52d8a5dccd6ca160d20aacb0f8d6f9e13f8a0f1f53bf05e8a4e083129ea"
 dependencies = [
  "derive_more",
  "impl-serde",
- "ink_prelude 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ink_primitives 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_prelude 5.0.0-rc.2",
+ "ink_primitives 5.0.0-rc.2",
  "linkme",
  "parity-scale-codec",
  "scale-info",
@@ -2884,10 +2868,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "ink_prelude"
-version = "5.0.0-rc.2"
+name = "ink_metadata"
+version = "5.0.0"
 dependencies = [
- "cfg-if",
+ "derive_more",
+ "impl-serde",
+ "ink_prelude 5.0.0",
+ "ink_primitives 5.0.0",
+ "linkme",
+ "parity-scale-codec",
+ "pretty_assertions",
+ "scale-info",
+ "schemars",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2900,16 +2894,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ink_primitives"
-version = "5.0.0-rc.2"
+name = "ink_prelude"
+version = "5.0.0"
 dependencies = [
- "derive_more",
- "ink_prelude 5.0.0-rc.2",
- "parity-scale-codec",
- "scale-decode",
- "scale-encode",
- "scale-info",
- "xxhash-rust",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2919,7 +2907,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be98091b19e2e7f6cdc128b405863fbb6c59ef8e361f3a60589ef029f69f6a8"
 dependencies = [
  "derive_more",
- "ink_prelude 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_prelude 5.0.0-rc.2",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-encode",
+ "scale-info",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "ink_primitives"
+version = "5.0.0"
+dependencies = [
+ "derive_more",
+ "ink_prelude 5.0.0",
  "parity-scale-codec",
  "scale-decode",
  "scale-encode",
@@ -2929,17 +2930,17 @@ dependencies = [
 
 [[package]]
 name = "ink_storage"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 dependencies = [
  "array-init",
  "cfg-if",
  "derive_more",
  "ink",
- "ink_env 5.0.0-rc.2",
- "ink_metadata 5.0.0-rc.2",
- "ink_prelude 5.0.0-rc.2",
- "ink_primitives 5.0.0-rc.2",
- "ink_storage_traits 5.0.0-rc.2",
+ "ink_env 5.0.0",
+ "ink_metadata 5.0.0",
+ "ink_prelude 5.0.0",
+ "ink_primitives 5.0.0",
+ "ink_storage_traits 5.0.0",
  "itertools 0.12.1",
  "pallet-contracts-uapi-next",
  "parity-scale-codec",
@@ -2951,25 +2952,25 @@ dependencies = [
 [[package]]
 name = "ink_storage_traits"
 version = "5.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fbbf0e1933ba34732ad9ca35a3d0da48934068759e97dbb5d34762e3ab3d4"
 dependencies = [
  "ink_metadata 5.0.0-rc.2",
  "ink_prelude 5.0.0-rc.2",
  "ink_primitives 5.0.0-rc.2",
  "parity-scale-codec",
- "paste",
  "scale-info",
 ]
 
 [[package]]
 name = "ink_storage_traits"
-version = "5.0.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fbbf0e1933ba34732ad9ca35a3d0da48934068759e97dbb5d34762e3ab3d4"
+version = "5.0.0"
 dependencies = [
- "ink_metadata 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ink_prelude 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ink_primitives 5.0.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_metadata 5.0.0",
+ "ink_prelude 5.0.0",
+ "ink_primitives 5.0.0",
  "parity-scale-codec",
+ "paste",
  "scale-info",
 ]
 
@@ -3052,9 +3053,9 @@ checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -3350,7 +3351,7 @@ checksum = "ee9023a564f8bf7fe3da285a50c3e70de0df3e2bf277ff7c4e76d66008ef93b0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3386,15 +3387,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lru"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
  "hashbrown 0.14.3",
 ]
@@ -3417,7 +3418,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3431,7 +3432,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3442,7 +3443,7 @@ checksum = "9ea73aa640dc01d62a590d48c0c3521ed739d53b27f919b25c3551e233481654"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3453,7 +3454,7 @@ checksum = "ef9d79ae96aaba821963320eb2b6e34d17df1e5a83d8a1985c29cc5be59577b3"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -3558,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -3570,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.3"
+version = "0.32.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
+checksum = "4541eb06dce09c0241ebbaab7102f0a01a0c8994afed2e5d0d66775016e25ac2"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -3757,9 +3758,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -3839,7 +3840,7 @@ checksum = "e65fc5412a9f0a56a9c53e5f6f73351086e6ca125b0d38c3f612eef7d251d007"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4013,7 +4014,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4105,7 +4106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db65a500d4adf574893c726ae365e37e4fbb7f2cbd403f6eaa1b665457456adc"
 dependencies = [
  "polkavm-derive-impl 0.4.0",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4115,7 +4116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6380dbe1fb03ecc74ad55d841cfc75480222d153ba69ddcb00977866cbdabdb8"
 dependencies = [
  "polkavm-derive-impl 0.5.0",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4127,7 +4128,7 @@ dependencies = [
  "polkavm-common 0.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4139,14 +4140,14 @@ dependencies = [
  "polkavm-common 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "polling"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
+checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -4163,7 +4164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.3.1",
  "universal-hash",
 ]
 
@@ -4178,6 +4179,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettier-please"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22020dfcf177fcc7bf5deaf7440af371400c67c0de14c399938d8ed4fb4645d3"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.52",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -4262,7 +4273,7 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4388,7 +4399,7 @@ checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -4399,7 +4410,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -4414,9 +4425,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4447,16 +4458,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4564,7 +4576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.0.0",
+ "rustls-pemfile 2.1.1",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -4581,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
+checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
 dependencies = [
  "base64 0.21.7",
  "rustls-pki-types",
@@ -4591,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a716eb65e3158e90e17cd93d855216e27bde02745ab842f2cab4a39dba1bacf"
+checksum = "5ede67b28608b4c60685c7d54122d4400d90f62b40caee7700e700380a390fa8"
 
 [[package]]
 name = "rustls-webpki"
@@ -4635,9 +4647,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "safe_arch"
@@ -4760,7 +4772,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.48",
+ "syn 2.0.52",
  "thiserror",
 ]
 
@@ -4823,7 +4835,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "772575a524feeb803e5b0fcbc6dd9f367e579488197c94c6e4023aad2305774d"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "cfg-if",
  "hashbrown 0.13.2",
 ]
@@ -4984,7 +4996,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5017,7 +5029,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5051,7 +5063,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5068,7 +5080,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.3.1",
 ]
 
 [[package]]
@@ -5093,7 +5105,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.3.1",
 ]
 
 [[package]]
@@ -5326,12 +5338,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5383,7 +5395,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5483,7 +5495,7 @@ checksum = "7527f8dda7667c41009b2cd0efaddcb81709b9741bd5ee6d17b11bad835cc698"
 dependencies = [
  "quote",
  "sp-core-hashing",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5494,7 +5506,7 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5663,7 +5675,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5756,7 +5768,7 @@ version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e4d24d84a0beb44a71dcac1b41980e1edf7fb722c7f3046710136a283cd479b"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "hash-db",
  "lazy_static",
  "memory-db",
@@ -5802,7 +5814,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -5893,9 +5905,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "7.0.0"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7a45adc5b85ac35d2245833967772cc74af10899143ebfa4df3c7eb494edb0"
+checksum = "3ba4f214fe99d79ffcc266f431abbb32d3596788327b925d469c7bb6a3c84d3c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5916,9 +5928,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "7.0.0"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2493cf438497734b64cdeb55dbee9872bd598f7b08649e9a3bd56d7939360a80"
+checksum = "5f1dea1e33eefee513c197c24255670951a2c515a6ce2c7049fe86385400074f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -5995,7 +6007,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6069,7 +6081,7 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.48",
+ "syn 2.0.52",
  "thiserror",
  "tokio",
 ]
@@ -6103,7 +6115,7 @@ dependencies = [
  "quote",
  "scale-typegen",
  "subxt-codegen",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6154,9 +6166,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6171,7 +6183,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6182,9 +6194,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.13"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "temp-env"
@@ -6243,14 +6255,14 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6336,7 +6348,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6395,7 +6407,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.4",
+ "toml_edit 0.22.6",
 ]
 
 [[package]]
@@ -6413,9 +6425,9 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -6424,9 +6436,9 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -6435,22 +6447,22 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.4"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
- "indexmap 2.2.4",
+ "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -6500,7 +6512,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -6786,9 +6798,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -6811,9 +6823,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -6821,24 +6833,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6846,28 +6858,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.41.1"
+version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce14de623d48dda4c10698c4dadae2366b5c2c8e81bad981d5a0625a5fcf68c"
+checksum = "b9c7d2731df60006819b013f64ccc2019691deccf6e11a1804bc850cd6748f1a"
 dependencies = [
  "leb128",
 ]
@@ -7105,9 +7117,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "71.0.0"
+version = "201.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10dad39ea4623ed4c304fb42bd455eca6d212f7e5e0cb59681fed7e4d128a2e"
+checksum = "1ef6e1ef34d7da3e2b374fd2b1a9c0227aff6cad596e1b24df9b58d0f6222faa"
 dependencies = [
  "bumpalo",
  "leb128",
@@ -7118,9 +7130,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.86"
+version = "1.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b724419d3bffeff174745b924f6ed053095ac58f9ae72e87d2e0f8ef6df6df96"
+checksum = "453d5b37a45b98dee4f4cb68015fc73634d7883bbef1c65e6e9c78d454cf3f32"
 dependencies = [
  "wast",
 ]
@@ -7185,7 +7197,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -7212,7 +7224,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -7247,17 +7259,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -7274,9 +7286,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7292,9 +7304,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7310,9 +7322,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7328,9 +7340,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7346,9 +7358,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7364,9 +7376,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7382,15 +7394,24 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]
@@ -7425,7 +7446,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7463,7 +7484,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -7483,7 +7504,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version",
+ "rustc_version 0.4.0",
  "zeroize",
 ]
 
@@ -618,6 +618,7 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -807,7 +808,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.22",
  "serde",
  "serde_json",
  "thiserror",
@@ -1019,9 +1020,9 @@ checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
 
 [[package]]
 name = "contract-build"
-version = "4.0.0-rc.4"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0cace153488962932541d89bc7e8e515cf1c4606ea45fe55826d59505078fa4"
+checksum = "9f4e6c03a261bc36c858fb67f12c21045d372b731b2239372584ded4648b3538"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1038,8 +1039,8 @@ dependencies = [
  "parity-scale-codec",
  "parity-wasm",
  "regex",
- "rustc_version",
- "semver",
+ "rustc_version 0.4.0",
+ "semver 1.0.22",
  "serde",
  "serde_json",
  "strum 0.26.2",
@@ -1059,13 +1060,13 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "4.0.0-rc.4"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ab6d50dbdba63b7c4e61ca9830252c69e0e507a20f2f74fc2c6b6582e3bf1"
+checksum = "71d239a78947aa2d0c63a9936754927551f275d3064a221384427c2c2ff1504b"
 dependencies = [
  "anyhow",
  "impl-serde",
- "semver",
+ "semver 1.0.22",
  "serde",
  "serde_json",
  "url",
@@ -1252,7 +1253,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "platforms",
- "rustc_version",
+ "rustc_version 0.4.0",
  "subtle",
  "zeroize",
 ]
@@ -1433,7 +1434,7 @@ dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
 
@@ -1505,9 +1506,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85dfa5bfd4a46bd1cce0f21eb34f35ff9f7f6e5242fe94eac78dd7e19b3da5c"
+checksum = "f702c1985b7202b8dd6eaa2490d4c7da5a7fdeee88fab858438ccce4e0eee58b"
 dependencies = [
  "drink-test-macro",
  "frame-metadata 16.0.0",
@@ -1519,6 +1520,7 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-scale-codec-derive",
+ "paste",
  "scale-info",
  "sp-externalities",
  "sp-io",
@@ -1529,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "drink-test-macro"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f87ddbde004f8fff3e1b67380ec79672528919aae4711b48b468205788ed5"
+checksum = "27646ddbf1bf4919eea90312cc98f7780f50358365637d8889a06842590bca4d"
 dependencies = [
  "cargo_metadata",
  "contract-build",
@@ -1847,6 +1849,36 @@ dependencies = [
  "sp-std",
  "sp-storage",
  "static_assertions",
+]
+
+[[package]]
+name = "frame-election-provider-solution-type"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c3bff645e46577c69c272733c53fa3a77d1ee6e40dfb66157bc94b0740b8fc"
+dependencies = [
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "frame-election-provider-support"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ff3c76750b481f9fd633ccddeed955426adc28aee566dd7233b7ac22cda9f5"
+dependencies = [
+ "frame-election-provider-solution-type",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-npos-elections",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -2251,6 +2283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,6 +2683,7 @@ dependencies = [
  "cargo_metadata",
  "contract-build",
  "drink",
+ "frame-support",
  "funty",
  "impl-serde",
  "ink",
@@ -2653,6 +2692,7 @@ dependencies = [
  "ink_primitives",
  "jsonrpsee 0.22.2",
  "pallet-contracts",
+ "pallet-contracts-mock-network",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -3608,6 +3648,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "pallet-assets"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c54b67fb2fab83382f7cd860aa5e0e0d478c914f81b87a7c24df2d93f740a89"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-authority-discovery"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df2c0f34a853bf34ea89ad999e7ac30bec58ab3a76295258ec594e370da1668"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-session",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-authority-discovery",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-authorship"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1f02863403c1cf5e9f49fd492c8cdb329d4b45029f3f19f278b3ba832a2b81"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-babe"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91a0fdb62c2d72c3c680deca50121d4bf2d8ed4b24dedd85f5b98ac454e781b"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-balances"
 version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,6 +3734,24 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-broker"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16828306edf66de7412d769f4716fd54f9046713e8e63a774f75814c9ca7a898"
+dependencies = [
+ "bitvec",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
  "sp-runtime",
  "sp-std",
 ]
@@ -3654,6 +3786,43 @@ dependencies = [
  "staging-xcm-builder",
  "wasm-instrument",
  "wasmi",
+]
+
+[[package]]
+name = "pallet-contracts-mock-network"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e047c639be0ef340e1f9ad3c6bc4e714e6fb3e01edfba6d432201a68ebaa5d"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-assets",
+ "pallet-balances",
+ "pallet-contracts",
+ "pallet-contracts-proc-macro",
+ "pallet-contracts-uapi",
+ "pallet-insecure-randomness-collective-flip",
+ "pallet-message-queue",
+ "pallet-proxy",
+ "pallet-timestamp",
+ "pallet-utility",
+ "pallet-xcm",
+ "parity-scale-codec",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-parachains",
+ "scale-info",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-std",
+ "sp-tracing",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
+ "xcm-simulator",
 ]
 
 [[package]]
@@ -3692,6 +3861,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-insecure-randomness-collective-flip"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe899a5ccb1bf4934f9ea344b9c45040d6cae4f9553be642580738afe5ff8ea"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "safe-mix",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-message-queue"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31856e2c797c6a262c22b63ce195901ef48b66d7b80a8a1d0f3b5f1c88a51332"
+dependencies = [
+ "environmental",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-weights",
+]
+
+[[package]]
+name = "pallet-proxy"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d6b9f7210b6cd4dcf531c1f8729eaeb7dfbed8e8b1b01b1747240b0f8a715d"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-session"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42218759d10405996ae378968751a9b1142b47f6b887562f2df50cc14b1c7eaa"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
+]
+
+[[package]]
+name = "pallet-staking"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c4a35f3bd92c45c7e67da645711894f172c29adc1e8a567f2987ee5399ebab"
+dependencies = [
+ "frame-benchmarking",
+ "frame-election-provider-support",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-application-crypto",
+ "sp-io",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-timestamp"
 version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,6 +3994,60 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+]
+
+[[package]]
+name = "pallet-utility"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b879fb8c20405663309986621856050efc31969c2d2a209d78373356a62e27"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-vesting"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391edd70faa651c43c2bbd03fcb5cd3f0be8b45ed38231991fe46d33a4cc4ef5"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-xcm"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "085a71440a945fae1bc6077fd40bdf1780a7e31747b86b2012bba18b18f0d6ef"
+dependencies = [
+ "bounded-collections",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -3909,6 +4230,97 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-weights",
+]
+
+[[package]]
+name = "polkadot-primitives"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6d6b36fdda53a0c50c4c6fbbda8ff557c9cf5b0a9edaea1f9641756ec1981"
+dependencies = [
+ "bitvec",
+ "hex-literal",
+ "log",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-authority-discovery",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-runtime-metrics"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3881206c09c9aafc5a8a801013d4069f012a0a68eb7edf5f1ac423196f76481e"
+dependencies = [
+ "bs58",
+ "frame-benchmarking",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "sp-std",
+ "sp-tracing",
+]
+
+[[package]]
+name = "polkadot-runtime-parachains"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5003965d03a5b6c8b98350f8f10f42a6ce04875a048a98e4c1523e42cf3f72b4"
+dependencies = [
+ "bitflags 1.3.2",
+ "bitvec",
+ "derive_more",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-broker",
+ "pallet-message-queue",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-timestamp",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
+ "polkadot-runtime-metrics",
+ "rand",
+ "rand_chacha",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-executor",
 ]
 
 [[package]]
@@ -4330,11 +4742,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.22",
 ]
 
 [[package]]
@@ -4483,6 +4904,15 @@ name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "safe-mix"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3d055a2582e6b00ed7a31c1524040aa391092bf636328350813f3a0605215c"
+dependencies = [
+ "rustc_version 0.2.3",
+]
 
 [[package]]
 name = "safe_arch"
@@ -4780,12 +5210,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -5234,6 +5679,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-authority-discovery"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0addabbce9f90c614145067139122420cfc940c495d2c3c1acc4a3b5f392f914"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "sp-consensus-babe"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473409ca152309b11898dd53130a578b341bc285ca9410246cbf1acc02996126"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+ "sp-timestamp",
+]
+
+[[package]]
+name = "sp-consensus-slots"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c72408adadb54b6f4eb287729166528cdb83e08c796685edc9bee09571b6474"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-std",
+ "sp-timestamp",
+]
+
+[[package]]
 name = "sp-core"
 version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5430,6 +5922,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-npos-elections"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc47d1b765ddd3d73678edd25eed4c33193e67929060d729bd751790026077b"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5497,6 +6004,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "sp-session"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0399eb885209b51b2999fe35883a579b0848674f0679019ce262f19d0a853325"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
 ]
 
 [[package]]
@@ -7269,6 +7792,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "xcm-simulator"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d49e52e0195992a5e3b16279136b564aae754c7bf59aa915837c944f5af8a12"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "paste",
+ "polkadot-core-primitives",
+ "polkadot-parachain-primitives",
+ "polkadot-runtime-parachains",
+ "sp-io",
+ "sp-std",
+ "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ cfg-if = { version = "1.0" }
 contract-build = { version = "4.0.0-rc.3" }
 darling = { version = "0.20.8" }
 derive_more = { version = "0.99.17", default-features = false }
-drink = { version = "=0.13.0", default-features = false, features = ["std"] }
+drink = { version = "=0.14.0", default-features = false, features = ["std"] }
 either = { version = "1.5", default-features = false }
 funty = { version = "2.0.0" }
 heck = { version = "0.4.0" }
@@ -83,9 +83,10 @@ xxhash-rust = { version = "0.8" }
 const_env = { version = "0.1"}
 
 # Substrate dependencies
-# Substrate dependencies
+frame-support = { version = "30.0.0", default-features = false }
 pallet-contracts = { version = "29.0.0", default-features = false }
 pallet-contracts-uapi = { package = "pallet-contracts-uapi-next", version = "=6.0.3", default-features = false }
+pallet-contracts-mock-network = { version = "5.0.0", default-features = false }
 sp-core = { version = "30.0.0", default-features = false }
 sp-keyring = { version = "33.0.0", default-features = false }
 sp-runtime = { version = "33.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ homepage = "https://www.parity.io/"
 keywords = ["wasm", "parity", "webassembly", "blockchain", "edsl"]
 license = "Apache-2.0"
 repository = "https://github.com/paritytech/ink"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 
 [workspace.dependencies]
 arrayref = { version = "0.3" }
@@ -91,19 +91,19 @@ sp-runtime = { version = "31.0.1", default-features = false }
 sp-weights = { version = "27.0.0", default-features = false }
 
 # Local dependencies
-ink = { version = "=5.0.0-rc.2", path = "crates/ink", default-features = false }
-ink_allocator = { version = "=5.0.0-rc.2", path = "crates/allocator", default-features = false }
-ink_codegen = { version = "=5.0.0-rc.2", path = "crates/ink/codegen", default-features = false }
-ink_e2e_macro = { version = "=5.0.0-rc.2", path = "crates/e2e/macro", default-features = false }
-ink_engine = { version = "=5.0.0-rc.2", path = "crates/engine", default-features = false }
-ink_env = { version = "=5.0.0-rc.2", path = "crates/env", default-features = false }
-ink_ir = { version = "=5.0.0-rc.2", path = "crates/ink/ir", default-features = false }
-ink_macro = { version = "=5.0.0-rc.2", path = "crates/ink/macro", default-features = false }
-ink_metadata = { version = "=5.0.0-rc.2", path = "crates/metadata", default-features = false }
-ink_prelude = { version = "=5.0.0-rc.2", path = "crates/prelude", default-features = false }
-ink_primitives = { version = "=5.0.0-rc.2", path = "crates/primitives", default-features = false }
-ink_storage = { version = "=5.0.0-rc.2", path = "crates/storage", default-features = false }
-ink_storage_traits = { version = "=5.0.0-rc.2", path = "crates/storage/traits", default-features = false }
+ink = { version = "=5.0.0", path = "crates/ink", default-features = false }
+ink_allocator = { version = "=5.0.0", path = "crates/allocator", default-features = false }
+ink_codegen = { version = "=5.0.0", path = "crates/ink/codegen", default-features = false }
+ink_e2e_macro = { version = "=5.0.0", path = "crates/e2e/macro", default-features = false }
+ink_engine = { version = "=5.0.0", path = "crates/engine", default-features = false }
+ink_env = { version = "=5.0.0", path = "crates/env", default-features = false }
+ink_ir = { version = "=5.0.0", path = "crates/ink/ir", default-features = false }
+ink_macro = { version = "=5.0.0", path = "crates/ink/macro", default-features = false }
+ink_metadata = { version = "=5.0.0", path = "crates/metadata", default-features = false }
+ink_prelude = { version = "=5.0.0", path = "crates/prelude", default-features = false }
+ink_primitives = { version = "=5.0.0", path = "crates/primitives", default-features = false }
+ink_storage = { version = "=5.0.0", path = "crates/storage", default-features = false }
+ink_storage_traits = { version = "=5.0.0", path = "crates/storage/traits", default-features = false }
 
 [profile.release]
 panic = "abort"

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -23,6 +23,7 @@ ink_primitives = { workspace = true, default-features = true }
 cargo_metadata = { workspace = true }
 contract-build = { workspace = true }
 drink = { workspace = true, optional = true }
+pallet-contracts-mock-network = { workspace = true, optional = true }
 funty = { workspace = true }
 impl-serde = { workspace = true }
 jsonrpsee = { workspace = true, features = ["ws-client"] }
@@ -40,6 +41,7 @@ wasm-instrument = { workspace = true }
 which = { workspace = true }
 
 # Substrate
+frame-support = { workspace = true }
 pallet-contracts = { workspace = true }
 sp-core = { workspace = true }
 sp-keyring = { workspace = true }
@@ -66,5 +68,6 @@ std = [
 drink = [
     "dep:drink",
     "subxt-metadata",
+    "pallet-contracts-mock-network",
     "ink_e2e_macro/drink",
 ]

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -69,15 +69,15 @@ pub enum RuntimeOnly {
     #[darling(word)]
     #[darling(skip)]
     Default,
-    Runtime(syn::Path),
+    Sandbox(syn::Path),
 }
 
 #[cfg(any(test, feature = "drink"))]
 impl From<RuntimeOnly> for syn::Path {
     fn from(value: RuntimeOnly) -> Self {
         match value {
-            RuntimeOnly::Default => syn::parse_quote! { ::ink_e2e::MinimalRuntime },
-            RuntimeOnly::Runtime(path) => path,
+            RuntimeOnly::Default => syn::parse_quote! { ::ink_e2e::MinimalSandbox },
+            RuntimeOnly::Sandbox(path) => path,
         }
     }
 }
@@ -151,15 +151,15 @@ mod tests {
     #[test]
     fn config_works_runtime_only_with_custom_backend() {
         let input = quote! {
-            backend(runtime_only(runtime = ::ink_e2e::MinimalRuntime)),
+            backend(runtime_only(sandbox = ::ink_e2e::MinimalSandbox)),
         };
         let config =
             E2EConfig::from_list(&NestedMeta::parse_meta_list(input).unwrap()).unwrap();
 
         assert_eq!(
             config.backend(),
-            Backend::RuntimeOnly(RuntimeOnly::Runtime(
-                syn::parse_quote! { ::ink_e2e::MinimalRuntime }
+            Backend::RuntimeOnly(RuntimeOnly::Sandbox(
+                syn::parse_quote! { ::ink_e2e::MinimalSandbox }
             ))
         );
     }

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -68,10 +68,13 @@ pub use subxt_client::{
     Client,
     Error,
 };
-pub use subxt_signer::sr25519::{
+pub use subxt_signer::{
     self,
-    dev::*,
-    Keypair,
+    sr25519::{
+        self,
+        dev::*,
+        Keypair,
+    },
 };
 pub use tokio;
 pub use tracing_subscriber;

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -76,6 +76,9 @@ pub use subxt_signer::sr25519::{
 pub use tokio;
 pub use tracing_subscriber;
 
+#[cfg(feature = "drink")]
+pub use drink::runtime::MinimalSandbox;
+
 use ink::codegen::ContractCallBuilder;
 use ink_env::{
     call::FromAccountId,

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -50,6 +50,8 @@ pub use contract_results::{
     InstantiationResult,
     UploadResult,
 };
+#[cfg(feature = "drink")]
+pub use drink_client::Client as DrinkClient;
 pub use ink_e2e_macro::test;
 pub use node_proc::{
     TestNodeProcess,
@@ -73,11 +75,6 @@ pub use subxt_signer::sr25519::{
 };
 pub use tokio;
 pub use tracing_subscriber;
-#[cfg(feature = "drink")]
-pub use {
-    drink::runtime::MinimalRuntime,
-    drink_client::Client as DrinkClient,
-};
 
 use ink::codegen::ContractCallBuilder;
 use ink_env::{

--- a/crates/ink/codegen/Cargo.toml
+++ b/crates/ink/codegen/Cargo.toml
@@ -19,7 +19,7 @@ name = "ink_codegen"
 
 [dependencies]
 ink_primitives = { workspace = true }
-ir = { version = "=5.0.0-rc.2", package = "ink_ir", path = "../ir", default-features = false }
+ir = { version = "=5.0.0", package = "ink_ir", path = "../ir", default-features = false }
 quote = { workspace = true }
 syn = { workspace = true, features = ["parsing", "full", "extra-traits"] }
 proc-macro2 = { workspace = true }

--- a/integration-tests/call-builder-return-value/Cargo.toml
+++ b/integration-tests/call-builder-return-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder_return_value"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/call-builder-return-value/Cargo.toml
+++ b/integration-tests/call-builder-return-value/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "call_builder_return_value"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/call-runtime/Cargo.toml
+++ b/integration-tests/call-runtime/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "call-runtime"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/call-runtime/Cargo.toml
+++ b/integration-tests/call-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call-runtime"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/combined-extension/Cargo.toml
+++ b/integration-tests/combined-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "combined_extension"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/combined-extension/Cargo.toml
+++ b/integration-tests/combined-extension/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "combined_extension"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/conditional-compilation/Cargo.toml
+++ b/integration-tests/conditional-compilation/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "conditional-compilation"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/conditional-compilation/Cargo.toml
+++ b/integration-tests/conditional-compilation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conditional-compilation"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/contract-storage/Cargo.toml
+++ b/integration-tests/contract-storage/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "contract-storage"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-storage/Cargo.toml
+++ b/integration-tests/contract-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-storage"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-terminate/Cargo.toml
+++ b/integration-tests/contract-terminate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_terminate"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-terminate/Cargo.toml
+++ b/integration-tests/contract-terminate/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "contract_terminate"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-transfer/Cargo.toml
+++ b/integration-tests/contract-transfer/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "contract_transfer"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/contract-transfer/Cargo.toml
+++ b/integration-tests/contract-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_transfer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/cross-contract-calls/Cargo.toml
+++ b/integration-tests/cross-contract-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cross-contract-calls"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/cross-contract-calls/Cargo.toml
+++ b/integration-tests/cross-contract-calls/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "cross-contract-calls"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/cross-contract-calls/other-contract/Cargo.toml
+++ b/integration-tests/cross-contract-calls/other-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "other-contract"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/cross-contract-calls/other-contract/Cargo.toml
+++ b/integration-tests/cross-contract-calls/other-contract/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "other-contract"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/custom-allocator/Cargo.toml
+++ b/integration-tests/custom-allocator/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "custom-allocator"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/custom-allocator/Cargo.toml
+++ b/integration-tests/custom-allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom-allocator"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/custom-environment/Cargo.toml
+++ b/integration-tests/custom-environment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom-environment"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/custom-environment/Cargo.toml
+++ b/integration-tests/custom-environment/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "custom-environment"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/dns/Cargo.toml
+++ b/integration-tests/dns/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "dns"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/dns/Cargo.toml
+++ b/integration-tests/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "e2e_call_runtime"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/e2e-call-runtime/Cargo.toml
+++ b/integration-tests/e2e-call-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e2e_call_runtime"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/e2e-runtime-only-backend/Cargo.toml
+++ b/integration-tests/e2e-runtime-only-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e2e-runtime-only-backend"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/e2e-runtime-only-backend/Cargo.toml
+++ b/integration-tests/e2e-runtime-only-backend/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "e2e-runtime-only-backend"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/e2e-runtime-only-backend/lib.rs
+++ b/integration-tests/e2e-runtime-only-backend/lib.rs
@@ -147,7 +147,7 @@ pub mod flipper {
         }
 
         /// Just instantiate a contract using non-default runtime.
-        #[ink_e2e::test(backend(runtime_only(runtime = ink_e2e::MinimalRuntime)))]
+        #[ink_e2e::test(backend(runtime_only(sandbox = ink_e2e::MinimalSandbox)))]
         async fn custom_runtime<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
             client
                 .instantiate(

--- a/integration-tests/erc1155/Cargo.toml
+++ b/integration-tests/erc1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc1155"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc1155/Cargo.toml
+++ b/integration-tests/erc1155/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "erc1155"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc20/Cargo.toml
+++ b/integration-tests/erc20/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "erc20"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc20/Cargo.toml
+++ b/integration-tests/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc20"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc721/Cargo.toml
+++ b/integration-tests/erc721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "erc721"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/erc721/Cargo.toml
+++ b/integration-tests/erc721/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "erc721"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/events/Cargo.toml
+++ b/integration-tests/events/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "events"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/events/Cargo.toml
+++ b/integration-tests/events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "events"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/flipper/Cargo.toml
+++ b/integration-tests/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/flipper/Cargo.toml
+++ b/integration-tests/flipper/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "flipper"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/incrementer/Cargo.toml
+++ b/integration-tests/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/incrementer/Cargo.toml
+++ b/integration-tests/incrementer/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "incrementer"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder_delegate"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder-delegate/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "call_builder_delegate"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "call_builder"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/call-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "call_builder"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constructors_return_value"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/constructors-return-value/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "constructors_return_value"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "contract_ref"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/contract-ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract_ref"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_flipper"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
+++ b/integration-tests/lang-err-integration-tests/integration-flipper/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "integration_flipper"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lazyvec-integration-test/Cargo.toml
+++ b/integration-tests/lazyvec-integration-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazyvec-integration-tests"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/lazyvec-integration-test/Cargo.toml
+++ b/integration-tests/lazyvec-integration-test/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "lazyvec-integration-tests"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/mapping-integration-tests/Cargo.toml
+++ b/integration-tests/mapping-integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mapping-integration-tests"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/mapping-integration-tests/Cargo.toml
+++ b/integration-tests/mapping-integration-tests/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "mapping-integration-tests"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/mother/Cargo.toml
+++ b/integration-tests/mother/Cargo.toml
@@ -1,11 +1,7 @@
 [package]
 name = "mother"
 description = "Mother of all contracts"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/mother/Cargo.toml
+++ b/integration-tests/mother/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mother"
 description = "Mother of all contracts"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/multi-contract-caller/Cargo.toml
+++ b/integration-tests/multi-contract-caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multi-contract-caller"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/multi-contract-caller/Cargo.toml
+++ b/integration-tests/multi-contract-caller/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "multi-contract-caller"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/multi-contract-caller/accumulator/Cargo.toml
+++ b/integration-tests/multi-contract-caller/accumulator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "accumulator"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi-contract-caller/accumulator/Cargo.toml
+++ b/integration-tests/multi-contract-caller/accumulator/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "accumulator"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi-contract-caller/adder/Cargo.toml
+++ b/integration-tests/multi-contract-caller/adder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adder"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi-contract-caller/adder/Cargo.toml
+++ b/integration-tests/multi-contract-caller/adder/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "adder"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi-contract-caller/subber/Cargo.toml
+++ b/integration-tests/multi-contract-caller/subber/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "subber"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multi-contract-caller/subber/Cargo.toml
+++ b/integration-tests/multi-contract-caller/subber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subber"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/integration-tests/multisig/Cargo.toml
+++ b/integration-tests/multisig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multisig"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/multisig/Cargo.toml
+++ b/integration-tests/multisig/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "multisig"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/payment-channel/Cargo.toml
+++ b/integration-tests/payment-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payment_channel"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/payment-channel/Cargo.toml
+++ b/integration-tests/payment-channel/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "payment_channel"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/psp22-extension/Cargo.toml
+++ b/integration-tests/psp22-extension/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "psp22_extension"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/psp22-extension/Cargo.toml
+++ b/integration-tests/psp22-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_extension"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/rand-extension/Cargo.toml
+++ b/integration-tests/rand-extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_extension"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/rand-extension/Cargo.toml
+++ b/integration-tests/rand-extension/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "rand_extension"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/sr25519-verification/Cargo.toml
+++ b/integration-tests/sr25519-verification/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "sr25519_verification"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>", "George Oastler <goastler4@gmail.com>"]
 edition = "2021"
 publish = false

--- a/integration-tests/sr25519-verification/Cargo.toml
+++ b/integration-tests/sr25519-verification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sr25519_verification"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>", "George Oastler <goastler4@gmail.com>"]
 edition = "2021"
 publish = false

--- a/integration-tests/static-buffer/Cargo.toml
+++ b/integration-tests/static-buffer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "static-buffer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/static-buffer/Cargo.toml
+++ b/integration-tests/static-buffer/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "static-buffer"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-dyn-cross-contract-calls/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer-caller"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-dyn-cross-contract-calls/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "trait-incrementer-caller"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "trait-incrementer"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "dyn-traits"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
+++ b/integration-tests/trait-dyn-cross-contract-calls/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyn-traits"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-erc20/Cargo.toml
+++ b/integration-tests/trait-erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_erc20"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-erc20/Cargo.toml
+++ b/integration-tests/trait-erc20/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "trait_erc20"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-flipper/Cargo.toml
+++ b/integration-tests/trait-flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait_flipper"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-flipper/Cargo.toml
+++ b/integration-tests/trait-flipper/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "trait_flipper"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-incrementer/Cargo.toml
+++ b/integration-tests/trait-incrementer/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "trait-incrementer"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-incrementer/Cargo.toml
+++ b/integration-tests/trait-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trait-incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-incrementer/traits/Cargo.toml
+++ b/integration-tests/trait-incrementer/traits/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "traits"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/trait-incrementer/traits/Cargo.toml
+++ b/integration-tests/trait-incrementer/traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traits"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/delegator/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/delegator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegator"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/delegator/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/delegator/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "delegator"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/delegator/delegatee/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/delegator/delegatee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegatee"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/delegator/delegatee/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/delegator/delegatee/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "delegatee"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/delegator/delegatee2/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/delegator/delegatee2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delegatee2"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/delegator/delegatee2/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/delegator/delegatee2/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "delegatee2"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "incrementer"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated-incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/integration-tests/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "updated-incrementer"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/wildcard-selector/Cargo.toml
+++ b/integration-tests/wildcard-selector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wildcard-selector"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/integration-tests/wildcard-selector/Cargo.toml
+++ b/integration-tests/wildcard-selector/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "wildcard-selector"
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ homepage = "https://www.parity.io/"
 keywords = ["parity", "blockchain", "edsl", "dylint", "linting"]
 
 [workspace.dependencies]
-ink_linting_utils = { version = "=5.0.0-rc.2", path = "utils" }
+ink_linting_utils = { version = "=5.0.0", path = "utils" }
 curve25519-dalek = { version = "=4.1.1", default-features = false, features = [
     "digest",
     "zeroize",

--- a/linting/Cargo.toml
+++ b/linting/Cargo.toml
@@ -7,11 +7,7 @@ members = [
 ]
 
 [workspace.package]
-<<<<<<< HEAD
 version = "5.0.0"
-=======
-version = "5.0.0-rc.3"
->>>>>>> master
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -20,11 +16,7 @@ homepage = "https://www.parity.io/"
 keywords = ["parity", "blockchain", "edsl", "dylint", "linting"]
 
 [workspace.dependencies]
-<<<<<<< HEAD
 ink_linting_utils = { version = "=5.0.0", path = "utils" }
-=======
-ink_linting_utils = { version = "=5.0.0-rc.3", path = "utils" }
->>>>>>> master
 curve25519-dalek = { version = "=4.1.1", default-features = false, features = [
     "digest",
     "zeroize",

--- a/linting/extra/Cargo.toml
+++ b/linting/extra/Cargo.toml
@@ -22,7 +22,7 @@ if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
 ink_linting_utils = { workspace = true }
-ink_env = { version = "=5.0.0-rc.2", path = "../../crates/env", default-features = false }
+ink_env = { version = "=5.0.0", path = "../../crates/env", default-features = false }
 
 [dev-dependencies]
 dylint_testing = "2.6.0"
@@ -32,10 +32,10 @@ dylint_testing = "2.6.0"
 #
 # These cannot be moved to the workspace level because `cargo` does not provide
 # the `[[workspace.dev-dependencies]]` directive.
-ink = { version = "=5.0.0-rc.2", path = "../../crates/ink", default-features = false, features = ["std"] }
-ink_metadata = { version = "=5.0.0-rc.2", path = "../../crates/metadata", default-features = false }
-ink_primitives = { version = "=5.0.0-rc.2", path = "../../crates/primitives", default-features = false }
-ink_storage = { version = "=5.0.0-rc.2", path = "../../crates/storage", default-features = false }
+ink = { version = "=5.0.0", path = "../../crates/ink", default-features = false, features = ["std"] }
+ink_metadata = { version = "=5.0.0", path = "../../crates/metadata", default-features = false }
+ink_primitives = { version = "=5.0.0", path = "../../crates/primitives", default-features = false }
+ink_storage = { version = "=5.0.0", path = "../../crates/storage", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"] }
 

--- a/linting/extra/Cargo.toml
+++ b/linting/extra/Cargo.toml
@@ -22,11 +22,7 @@ if_chain = "1.0.2"
 log = "0.4.14"
 regex = "1.5.4"
 ink_linting_utils = { workspace = true }
-<<<<<<< HEAD
 ink_env = { version = "=5.0.0", path = "../../crates/env", default-features = false }
-=======
-ink_env = { version = "=5.0.0-rc.3", path = "../../crates/env", default-features = false }
->>>>>>> master
 
 [dev-dependencies]
 dylint_testing = "2.6.0"
@@ -36,17 +32,10 @@ dylint_testing = "2.6.0"
 #
 # These cannot be moved to the workspace level because `cargo` does not provide
 # the `[[workspace.dev-dependencies]]` directive.
-<<<<<<< HEAD
 ink = { version = "=5.0.0", path = "../../crates/ink", default-features = false, features = ["std"] }
 ink_metadata = { version = "=5.0.0", path = "../../crates/metadata", default-features = false }
 ink_primitives = { version = "=5.0.0", path = "../../crates/primitives", default-features = false }
 ink_storage = { version = "=5.0.0", path = "../../crates/storage", default-features = false }
-=======
-ink = { version = "=5.0.0-rc.3", path = "../../crates/ink", default-features = false, features = ["std"] }
-ink_metadata = { version = "=5.0.0-rc.3", path = "../../crates/metadata", default-features = false }
-ink_primitives = { version = "=5.0.0-rc.3", path = "../../crates/primitives", default-features = false }
-ink_storage = { version = "=5.0.0-rc.3", path = "../../crates/storage", default-features = false }
->>>>>>> master
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"] }
 

--- a/linting/mandatory/Cargo.toml
+++ b/linting/mandatory/Cargo.toml
@@ -32,19 +32,11 @@ dylint_testing = "2.6.0"
 #
 # These cannot be moved to the workspace level because `cargo` does not provide
 # the `[[workspace.dev-dependencies]]` directive.
-<<<<<<< HEAD
 ink = { version = "=5.0.0", path = "../../crates/ink", default-features = false, features = ["std"] }
 ink_env = { version = "=5.0.0", path = "../../crates/env", default-features = false }
 ink_metadata = { version = "=5.0.0", path = "../../crates/metadata", default-features = false }
 ink_primitives = { version = "=5.0.0", path = "../../crates/primitives", default-features = false }
 ink_storage = { version = "=5.0.0", path = "../../crates/storage", default-features = false }
-=======
-ink = { version = "=5.0.0-rc.3", path = "../../crates/ink", default-features = false, features = ["std"] }
-ink_env = { version = "=5.0.0-rc.3", path = "../../crates/env", default-features = false }
-ink_metadata = { version = "=5.0.0-rc.3", path = "../../crates/metadata", default-features = false }
-ink_primitives = { version = "=5.0.0-rc.3", path = "../../crates/primitives", default-features = false }
-ink_storage = { version = "=5.0.0-rc.3", path = "../../crates/storage", default-features = false }
->>>>>>> master
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"] }
 

--- a/linting/mandatory/Cargo.toml
+++ b/linting/mandatory/Cargo.toml
@@ -32,11 +32,11 @@ dylint_testing = "2.6.0"
 #
 # These cannot be moved to the workspace level because `cargo` does not provide
 # the `[[workspace.dev-dependencies]]` directive.
-ink = { version = "=5.0.0-rc.2", path = "../../crates/ink", default-features = false, features = ["std"] }
-ink_env = { version = "=5.0.0-rc.2", path = "../../crates/env", default-features = false }
-ink_metadata = { version = "=5.0.0-rc.2", path = "../../crates/metadata", default-features = false }
-ink_primitives = { version = "=5.0.0-rc.2", path = "../../crates/primitives", default-features = false }
-ink_storage = { version = "=5.0.0-rc.2", path = "../../crates/storage", default-features = false }
+ink = { version = "=5.0.0", path = "../../crates/ink", default-features = false, features = ["std"] }
+ink_env = { version = "=5.0.0", path = "../../crates/env", default-features = false }
+ink_metadata = { version = "=5.0.0", path = "../../crates/metadata", default-features = false }
+ink_primitives = { version = "=5.0.0", path = "../../crates/primitives", default-features = false }
+ink_storage = { version = "=5.0.0", path = "../../crates/storage", default-features = false }
 scale = { package = "parity-scale-codec", version = "3.4", default-features = false, features = ["derive"] }
 scale-info = { version = "2.6", default-features = false, features = ["derive"] }
 


### PR DESCRIPTION
### Summary
This is a release addressing the rest of the severities described in the [OpenZeppelin security review](https://blog.openzeppelin.com/security-review-ink-cargo-contract) of ink! and `cargo-contract`.
One of the notable addressed issues is the proxy selector clashing attack.
As of this release, ink! only allows exactly one other message with a well-known reserved selector to be defined.
You can read more about the change in the [#1827](https://github.com/paritytech/ink/pull/1827) and [#2031](https://github.com/paritytech/ink/pull/2031).

ink! 5.0.0 features a significant number of new features:
- We have introduced a new API based on the calculated or specified selectors for the event definition. This allows events to be defined in separate files and modules, and be shared across multiple ink! contracts - [#1827](https://github.com/paritytech/ink/pull/1827) and [#2031](https://github.com/paritytech/ink/pull/2031).
- [@pmikolajczyk41](https://github.com/pmikolajczyk41) has introduced an alternative E2E testing framework, [DRink!](https://github.com/inkdevhub/drink?tab=readme-ov-file#as-an-alternative-backend-to-inks-e2e-testing-framework), that support quasi-testing model, it allows the test simulate a running node as part of the E2E test while improving debugging experience such as allowing to set breakpoint and step through each stage of execution cycle.
- Following improvements in E2E, we have added a call builder API that allows to easily build calls while significantly reducing boilerplate code - [#1917](https://github.com/paritytech/ink/pull/1917) and [#2075](https://github.com/paritytech/ink/pull/2075)
- Another notable introduction in 5.0.0 release is the support for multiple chain extensions that empower developers
to build even more sophisticated and advanced contracts for supported chains - [#1958](https://github.com/paritytech/ink/pull/1958).
- To further address our consideration of the intrinsic security of ink! smart contracts,
we have disallowed unchecked arithmetic expressions. `cargo-contract` will fail to compile the contract with the raw arithmetic operation - [#1831](https://github.com/paritytech/ink/pull/1831).

These are the main features we have introduced in this release. We also encourage developers to have a look at more detailed changelog entries to find out about any breaking changes that may affect the development of new ink! contracts.

_We have created a migration guide from ink! 4 to ink! 5. It also contains an overview over all breaking changes and newly added features.
You can view it [here](https://use.ink/faq/migrating-from-ink-4-to-5)._

### Compatability

- Rust: `>=1.70`
- `cargo-contract`: `>=4.0.0`
- polkadot-sdk: [>= 0.9.3](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v0.9.3), but if using the new functions introduced in [#2123](https://github.com/paritytech/ink/pull/2123) and [#2077](https://github.com/paritytech/ink/pull/2077) [>= 1.8.0](https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.8.0).
- `polkadot-js/api` and `polkadot-js/api-contract`:  `>=10.12.1`
- `substrate-contracts-node`: `>= 0.39.0`

### Changelog

#### Added
- `instantiate_v2` with additional limit parameters [#2123](https://github.com/paritytech/ink/pull/2123)
- Custom signature topic in Events - [#2031](https://github.com/paritytech/ink/pull/2031)
- [Linter] `non_fallible_api` lint - [#2004](https://github.com/paritytech/ink/pull/2004)
- [Linter] Publish the linting crates on crates.io - [#2060](https://github.com/paritytech/ink/pull/2060)
- [E2E] Added `create_call_builder` for testing existing contracts - [#2075](https://github.com/paritytech/ink/pull/2075)
- `call_v2` cross-contract calls with additional limit parameters - [#2077](https://github.com/paritytech/ink/pull/2077)
- `delegate_dependency` api calls - [#2076](https://github.com/paritytech/ink/pull/2076)
- Allow mutable parameters in messages - [#2004](https://github.com/paritytech/ink/pull/2004)
- Clean E2E configuration parsing - [#1922](https://github.com/paritytech/ink/pull/1922)
- Make `set_code_hash` generic - [#1906](https://github.com/paritytech/ink/pull/1906)
- Provide a `StorageVec` datastructure built on top of `Lazy` - [#1995](https://github.com/paritytech/ink/pull/1995)
- Add fallible methods for `Mapping` and `Lazy` - [#1910](https://github.com/paritytech/ink/pull/1910)
- [E2E] Allow testing with live-chain state - [#1949](https://github.com/paritytech/ink/pull/1949)
- [E2E] Call builders and extra gas margin option - [#1917](https://github.com/paritytech/ink/pull/1917)
- [Linter] `storage_never_freed` lint - [#1932](https://github.com/paritytech/ink/pull/1932)
- [Linter] `strict_balance_equality` lint - [#1914](https://github.com/paritytech/ink/pull/1914)
- [Linter] `no_main` lint - [#2001](https://github.com/paritytech/ink/pull/2001)
- Reexport `scale` dependencies, introduce `#[ink::scale_derive]` - [#1890](https://github.com/paritytech/ink/pull/1890)
- Upgradeable contracts example - [#1889](https://github.com/paritytech/ink/pull/1889)
- Persist static buffer size in metadata - [#1880](https://github.com/paritytech/ink/pull/1880)
- Modify static buffer size via environmental variables - [#1869](https://github.com/paritytech/ink/pull/1869)
- Added `sr25519_verify` function to `ink_env` [#1840](https://github.com/paritytech/ink/pull/1840)
- Events `2.0` - [#1827](https://github.com/paritytech/ink/pull/1827)
- Add `set_block_number` to off-chain test api `Engine` - [#1806](https://github.com/paritytech/ink/pull/1806)
- Stabilize `call_runtime` ‒ [#1749](https://github.com/paritytech/ink/pull/1749)
- Schema generation - [#1765](https://github.com/paritytech/ink/pull/1765)
- Restrict wildcard selectors to have exactly one other message - [#1708](https://github.com/paritytech/ink/pull/1708)
- [Linter] Warn when primitive number is annotated as event topic - [#1837](https://github.com/paritytech/ink/pull/1837)
- [Drink backend] allow for arbitrary runtime - [#1892](https://github.com/paritytech/ink/pull/1892)
- [Drink backend] support runtime call - [#1891](https://github.com/paritytech/ink/pull/1891)
- [Drink backend] Make tests generic `E2EBackend` trait - [#1867](https://github.com/paritytech/ink/pull/1867)
- [Drink backend] Backend choice  ‒ [#1864](https://github.com/paritytech/ink/pull/1864)
- [Drink backend] Backend traits - [#1857](https://github.com/paritytech/ink/pull/1857)
- [Drink backend] Abstract error and result structs - [#1844](https://github.com/paritytech/ink/pull/1844)

#### Changed
- Use name-only syntax for `anonymous` ink! event item configuration argument - [#2140](https://github.com/paritytech/ink/pull/2140)
- Restrict syntax for setting default ink! e2e test runtime-only emulator - [#2143](https://github.com/paritytech/ink/pull/2143)
- Restrict syntax for setting ink! e2e test node to auto - [#2146](https://github.com/paritytech/ink/pull/2146)
- Bump Substrate crates - [#2141](https://github.com/paritytech/ink/pull/2141)
- Minor fixes - [#2144](https://github.com/paritytech/ink/pull/2144), [#2137](https://github.com/paritytech/ink/pull/2137), [#2132](https://github.com/paritytech/ink/pull/2132)
- Bump metadata version to 5 [#2126](https://github.com/paritytech/ink/pull/2126)
- Use `MaxEncodedLen` for output buffer size [#2128](https://github.com/paritytech/ink/pull/2128)
- `Mapping`: Reflect all possible failure cases in comments ‒ [#2079](https://github.com/paritytech/ink/pull/2079)
- [E2E] Rename `.call` to `.call_builder` ‒ [#2078](https://github.com/paritytech/ink/pull/2078)
- Improve syntax for ink! e2e `runtime_only` attribute argument - [#2083](https://github.com/paritytech/ink/pull/2083)
- [E2E] Remove `additional_contracts` parameter [#2098](https://github.com/paritytech/ink/pull/2098)
- [E2E] change node url backend config - [#2101](https://github.com/paritytech/ink/pull/2101)
- Messages return `TypeSpec` directly - [#1999](https://github.com/paritytech/ink/pull/1999)
- Fail when decoding from storage and not all bytes consumed - [#1897](https://github.com/paritytech/ink/pull/1897)
- Support multiple chain extensions - [#1958](https://github.com/paritytech/ink/pull/1958)
  - New example of how to use multiple chain extensions in one contract.
  - Affects the usage of the `#[ink::chain_extension]` macro and the definition of the chain extension.
- Split up `ink_linting` to mandatory and extra libraries - [#2032](https://github.com/paritytech/ink/pull/2032)
- [E2E] resolve DispatchError error details for dry-runs - [#1994](https://github.com/paritytech/ink/pull/1994)
- [E2E] update to new `drink` API - [#2005](https://github.com/paritytech/ink/pull/2005)
- Reexport `scale` dependencies, introduce `#[ink::scale_derive]` ‒ [#1890](https://github.com/paritytech/ink/pull/1890)
- Use of workspace dependencies and properties - [#1835](https://github.com/paritytech/ink/pull/1835)
- Remove of unchecked arithmetic - [#1831](https://github.com/paritytech/ink/pull/1831)
- Use `decode_all` for decoding cross contract call result - [#1810](https://github.com/paritytech/ink/pull/1810)
- [E2E] build contracts at runtime instead of during codegen - [#1881](https://github.com/paritytech/ink/pull/1881)
- [E2E] crate refactoring - [#1830](https://github.com/paritytech/ink/pull/1830)
- [E2E] improve call API, remove `build_message` + callback - [#1782](https://github.com/paritytech/ink/pull/1782)

#### Fixed
- Fix alignment in allocator [#2100](https://github.com/paritytech/ink/pull/2100)
- Fix the `StorageVec` type by excluding the `len_cached` field from its type info - [#2052](https://github.com/paritytech/ink/pull/2052)
- Fix panic in `approve_for` in the ERC-721 example - [#2092](https://github.com/paritytech/ink/pull/2092)
- ERC-721: `transfer_token_from` now ensures the token owner is correct - [#2093](https://github.com/paritytech/ink/pull/2093)
- `RootLayout::new()` is generic again to allow using `ink_metadata` in pure `PortableForm` contexts - [#1989](https://github.com/paritytech/ink/pull/1989)