### PR TITLE
Use name-only syntax for `anonymous` ink! event item configuration argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Use name-only syntax for `anonymous` ink! event item configuration argument - [#2140](https://github.com/paritytech/ink/pull/2140)
+
 ## Version 5.0.0-rc.2
 
 ### Added

--- a/crates/ink/ir/src/error.rs
+++ b/crates/ink/ir/src/error.rs
@@ -54,6 +54,21 @@ macro_rules! format_err_spanned {
 }
 
 /// Creates a [`syn::Error`] with the format message and infers the
+/// [`Span`](`proc_macro2::Span`) using the [`ToTokens`](`quote::ToTokens`) implementation
+/// for the [`MetaValue`][crate::ast::MetaValue] (if possible).
+///
+/// See [`format_err_spanned`] for more details.
+macro_rules! format_err_spanned_value {
+    ($arg:expr, $($msg:tt)*) => {
+        if let Some(value) = $arg.value() {
+            format_err_spanned!(value, $($msg)*)
+        } else {
+            format_err_spanned!($arg, $($msg)*)
+        }
+    };
+}
+
+/// Creates a [`syn::Error`] with the format message and infers the
 /// [`Span`](`proc_macro2::Span`) using [`Spanned`](`syn::spanned::Spanned`).
 ///
 /// # Parameters

--- a/crates/ink/ir/src/ir/chain_extension.rs
+++ b/crates/ink/ir/src/ir/chain_extension.rs
@@ -81,15 +81,15 @@ impl TryFrom<ast::AttributeArgs> for Config {
         let mut ext_id: Option<ExtensionId> = None;
 
         for arg in args.clone().into_iter() {
-            if arg.name.is_ident("extension") {
+            if arg.name().is_ident("extension") {
                 if ext_id.is_some() {
-                    return Err(format_err_spanned!(
-                        arg.value,
+                    return Err(format_err_spanned_value!(
+                        arg,
                         "encountered duplicate ink! contract `extension` configuration argument",
-                    ))
+                    ));
                 }
 
-                if let Some(lit_int) = arg.value.as_lit_int() {
+                if let Some(lit_int) = arg.value().and_then(ast::MetaValue::as_lit_int) {
                     let id = lit_int.base10_parse::<u16>()
                         .map_err(|error| {
                             format_err_spanned!(
@@ -98,16 +98,16 @@ impl TryFrom<ast::AttributeArgs> for Config {
                         })?;
                     ext_id = Some(ExtensionId::from_u16(id));
                 } else {
-                    return Err(format_err_spanned!(
-                        arg.value,
+                    return Err(format_err_spanned_value!(
+                        arg,
                         "expected `u16` integer type for `N` in `extension = N`",
-                    ))
+                    ));
                 }
             } else {
                 return Err(format_err_spanned!(
                     arg,
                     "encountered unknown or unsupported chain extension configuration argument",
-                ))
+                ));
             }
         }
 

--- a/crates/ink/ir/src/ir/event/signature_topic.rs
+++ b/crates/ink/ir/src/ir/event/signature_topic.rs
@@ -89,14 +89,15 @@ impl TryFrom<ast::AttributeArgs> for Option<SignatureTopicArg> {
     fn try_from(args: ast::AttributeArgs) -> Result<Self, Self::Error> {
         let mut signature_topic: Option<SignatureTopicArg> = None;
         for arg in args.into_iter() {
-            if arg.name.is_ident("hash") {
+            if arg.name().is_ident("hash") {
                 if signature_topic.is_some() {
                     return Err(format_err!(
                         arg.span(),
                         "encountered duplicate ink! event configuration argument"
                     ));
                 }
-                signature_topic = Some(SignatureTopicArg::try_from(&arg.value)?);
+                signature_topic =
+                    arg.value().map(SignatureTopicArg::try_from).transpose()?;
             } else {
                 return Err(format_err_spanned!(
                     arg,

--- a/crates/ink/ir/src/ir/storage_item/config.rs
+++ b/crates/ink/ir/src/ir/storage_item/config.rs
@@ -33,21 +33,22 @@ impl TryFrom<ast::AttributeArgs> for StorageItemConfig {
     fn try_from(args: ast::AttributeArgs) -> Result<Self, Self::Error> {
         let mut derive: Option<syn::LitBool> = None;
         for arg in args.into_iter() {
-            if arg.name.is_ident("derive") {
+            if arg.name().is_ident("derive") {
                 if let Some(lit_bool) = derive {
                     return Err(duplicate_config_err(
                         lit_bool,
                         arg,
                         "derive",
                         "storage item",
-                    ))
+                    ));
                 }
-                if let ast::MetaValue::Lit(syn::Lit::Bool(lit_bool)) = &arg.value {
+                if let Some(lit_bool) = arg.value().and_then(ast::MetaValue::as_lit_bool)
+                {
                     derive = Some(lit_bool.clone())
                 } else {
                     return Err(format_err_spanned!(
                         arg,
-                        "expected a bool literal for `derive` ink! storage item configuration argument",
+                        "expected a bool literal value for `derive` ink! storage item configuration argument",
                     ));
                 }
             } else {

--- a/crates/ink/ir/src/ir/trait_def/config.rs
+++ b/crates/ink/ir/src/ir/trait_def/config.rs
@@ -57,31 +57,41 @@ impl TryFrom<ast::AttributeArgs> for TraitDefinitionConfig {
         let mut namespace: Option<(syn::LitStr, ast::MetaNameValue)> = None;
         let mut whitelisted_attributes = WhitelistedAttributes::default();
         for arg in args.into_iter() {
-            if arg.name.is_ident("namespace") {
+            if arg.name().is_ident("namespace") {
                 if let Some((_, meta_name_value)) = namespace {
                     return Err(duplicate_config_err(
                         meta_name_value,
                         arg,
                         "namespace",
                         "trait definition",
-                    ))
+                    ));
                 }
-                if let ast::MetaValue::Lit(syn::Lit::Str(lit_str)) = &arg.value {
+                let namespace_info = arg
+                    .name_value()
+                    .zip(arg.value().and_then(ast::MetaValue::as_lit_string));
+                if let Some((name_value, lit_str)) = namespace_info {
                     if syn::parse_str::<syn::Ident>(&lit_str.value()).is_err() {
                         return Err(format_err_spanned!(
                             lit_str,
                             "encountered invalid Rust identifier for the ink! namespace configuration parameter"
                         ));
                     }
-                    namespace = Some((lit_str.clone(), arg))
+                    namespace = Some((lit_str.clone(), name_value.clone()))
                 } else {
                     return Err(format_err_spanned!(
                         arg,
-                        "expected a string literal for `namespace` ink! trait definition configuration argument",
+                        "expected a string literal value for `namespace` ink! trait definition configuration argument",
                     ));
                 }
-            } else if arg.name.is_ident("keep_attr") {
-                whitelisted_attributes.parse_arg_value(&arg)?;
+            } else if arg.name().is_ident("keep_attr") {
+                if let Some(name_value) = arg.name_value() {
+                    whitelisted_attributes.parse_arg_value(name_value)?;
+                } else {
+                    return Err(format_err_spanned!(
+                        arg,
+                        "expected a string literal value for `keep_attr` ink! configuration argument",
+                    ));
+                }
             } else {
                 return Err(format_err_spanned!(
                     arg,

--- a/crates/ink/macro/src/lib.rs
+++ b/crates/ink/macro/src/lib.rs
@@ -657,7 +657,7 @@ pub fn trait_definition(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// contract.
 ///
 /// By default, a signature topic will be generated for the event. This allows consumers
-/// to filter and identify events of this type. Marking an event with `anonymous = true`
+/// to filter and identify events of this type. Marking an event with `anonymous`
 /// means no signature topic will be generated or emitted.
 /// Custom signature topic can be specified with `signature_topic = <32 byte hex string>`.
 ///
@@ -673,8 +673,8 @@ pub fn trait_definition(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     pub topic: [u8; 32],
 /// }
 ///
-/// // Setting `anonymous = true` means no signature topic will be emitted for the event.
-/// #[ink::event(anonymous = true)]
+/// // Setting `anonymous` means no signature topic will be emitted for the event.
+/// #[ink::event(anonymous)]
 /// pub struct MyAnonEvent {
 ///     pub field: u32,
 ///     #[ink(topic)]

--- a/crates/ink/tests/ui/contract/fail/config-keep-attr-missing-arg.stderr
+++ b/crates/ink/tests/ui/contract/fail/config-keep-attr-missing-arg.stderr
@@ -1,4 +1,4 @@
-error: ink! config options require an argument separated by '='
+error: expected a string literal value for `keep_attr` ink! configuration argument
  --> tests/ui/contract/fail/config-keep-attr-missing-arg.rs:1:17
   |
 1 | #[ink::contract(keep_attr)]

--- a/crates/ink/tests/ui/event/fail/anonymous_invalid_value.rs
+++ b/crates/ink/tests/ui/event/fail/anonymous_invalid_value.rs
@@ -1,4 +1,4 @@
-#[ink::event(anonymous)]
+#[ink::event(anonymous = true)]
 pub struct Event {
     #[ink(topic)]
     pub topic: [u8; 32],

--- a/crates/ink/tests/ui/event/fail/anonymous_invalid_value.stderr
+++ b/crates/ink/tests/ui/event/fail/anonymous_invalid_value.stderr
@@ -1,0 +1,5 @@
+error: encountered an unexpected value for `anonymous` ink! event item configuration argument. Did you mean #[ink::event(anonymous)] ?
+ --> tests/ui/event/fail/anonymous_invalid_value.rs:1:14
+  |
+1 | #[ink::event(anonymous = true)]
+  |              ^^^^^^^^^^^^^^^^

--- a/crates/ink/tests/ui/event/fail/signature_missing_value.rs
+++ b/crates/ink/tests/ui/event/fail/signature_missing_value.rs
@@ -1,0 +1,6 @@
+#[ink::event(signature_topic)]
+pub struct Event {
+    pub topic: [u8; 32],
+}
+
+fn main() {}

--- a/crates/ink/tests/ui/event/fail/signature_missing_value.stderr
+++ b/crates/ink/tests/ui/event/fail/signature_missing_value.stderr
@@ -1,0 +1,5 @@
+error: expected a string literal value for `signature_topic` ink! event item configuration argument
+ --> tests/ui/event/fail/signature_missing_value.rs:1:14
+  |
+1 | #[ink::event(signature_topic)]
+  |              ^^^^^^^^^^^^^^^

--- a/crates/ink/tests/ui/storage_item/fail/argument_derive_invalid_type.stderr
+++ b/crates/ink/tests/ui/storage_item/fail/argument_derive_invalid_type.stderr
@@ -1,4 +1,4 @@
-error: expected a bool literal for `derive` ink! storage item configuration argument
+error: expected a bool literal value for `derive` ink! storage item configuration argument
  --> tests/ui/storage_item/fail/argument_derive_invalid_type.rs:1:21
   |
 1 | #[ink::storage_item(derive = "false")]

--- a/crates/ink/tests/ui/storage_item/fail/argument_derive_missing_arg.stderr
+++ b/crates/ink/tests/ui/storage_item/fail/argument_derive_missing_arg.stderr
@@ -1,4 +1,4 @@
-error: ink! config options require an argument separated by '='
+error: expected a bool literal value for `derive` ink! storage item configuration argument
  --> tests/ui/storage_item/fail/argument_derive_missing_arg.rs:1:21
   |
 1 | #[ink::storage_item(derive)]

--- a/crates/ink/tests/ui/trait_def/fail/config_keep_attr_missing_arg.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/config_keep_attr_missing_arg.stderr
@@ -1,4 +1,4 @@
-error: ink! config options require an argument separated by '='
+error: expected a string literal value for `keep_attr` ink! configuration argument
  --> tests/ui/trait_def/fail/config_keep_attr_missing_arg.rs:1:25
   |
 1 | #[ink::trait_definition(keep_attr)]

--- a/crates/ink/tests/ui/trait_def/fail/config_namespace_invalid_2.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/config_namespace_invalid_2.stderr
@@ -1,4 +1,4 @@
-error: ink! config options require an argument separated by '='
+error: expected a string literal value for `namespace` ink! trait definition configuration argument
  --> tests/ui/trait_def/fail/config_namespace_invalid_2.rs:1:25
   |
 1 | #[ink::trait_definition(namespace)]

--- a/crates/ink/tests/ui/trait_def/fail/config_namespace_invalid_4.stderr
+++ b/crates/ink/tests/ui/trait_def/fail/config_namespace_invalid_4.stderr
@@ -1,4 +1,4 @@
-error: expected a string literal for `namespace` ink! trait definition configuration argument
+error: expected a string literal value for `namespace` ink! trait definition configuration argument
  --> tests/ui/trait_def/fail/config_namespace_invalid_4.rs:1:25
   |
 1 | #[ink::trait_definition(namespace = true)]

--- a/integration-tests/events/lib.rs
+++ b/integration-tests/events/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
-#[ink::event(anonymous = true)]
+#[ink::event(anonymous)]
 pub struct AnonymousEvent {
     #[ink(topic)]
     pub topic: [u8; 32],


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description

- Use name-only syntax for `anonymous` ink! event item configuration argument (i.e. `#[ink::event(anonymous)]` instead of `#[ink::event(anonymous = true|false)]`)
- Required updating `ink_ir::ast::AttributeArgs` to support name-only meta items e.g. `#[ink::event(anonymous)]`
- Fixes error message for `signature_topic` argument which previously referenced `anonymous` instead

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
