### PR TITLE
Restrict syntax for setting default ink! e2e test runtime-only emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Restrict syntax for setting default ink! e2e test runtime-only emulator - [#2143](https://github.com/paritytech/ink/pull/2143)
+
 ## Version 5.0.0-rc.2
 
 ### Added

--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -66,6 +66,7 @@ impl Node {
 #[derive(Clone, Eq, PartialEq, Debug, darling::FromMeta)]
 pub enum RuntimeOnly {
     #[darling(word)]
+    #[darling(skip)]
     Default,
     Runtime(syn::Path),
 }
@@ -130,6 +131,18 @@ mod tests {
             config.environment(),
             Some(syn::parse_quote! { crate::CustomEnvironment })
         );
+
+        assert_eq!(config.backend(), Backend::RuntimeOnly(RuntimeOnly::Default));
+    }
+
+    #[test]
+    #[should_panic(expected = "ErrorUnknownField")]
+    fn config_works_backend_runtime_only_default_not_allowed() {
+        let input = quote! {
+            backend(runtime_only(default)),
+        };
+        let config =
+            E2EConfig::from_list(&NestedMeta::parse_meta_list(input).unwrap()).unwrap();
 
         assert_eq!(config.backend(), Backend::RuntimeOnly(RuntimeOnly::Default));
     }


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
- Currently, both `#[ink_e2e::test(backend(runtime_only))]` and `#[ink_e2e::test(backend(runtime_only(default)))]` are valid syntax for setting the default drink! runtime emulator, this PR removes the latter syntax.
- This PR doesn't affect/change the syntax for setting a custom runtime-only emulator (i.e. `#[ink_e2e::test(backend(runtime_only(runtime = ..)))]`)

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
