### PR TITLE
Fix scale_derive options documentation

### DIFF
--- a/crates/ink/macro/src/lib.rs
+++ b/crates/ink/macro/src/lib.rs
@@ -1600,9 +1600,9 @@ synstructure::decl_derive!(
 /// traits without depending directly on the `parity-scale-codec` and `scale-info` crates.
 ///
 /// # Options
-///   - `encode`: derives `ink::scale::Encode`
-///   - `decode`: derives `ink::scale::Decode`
-///   - `type_info`: derives `ink::scale_info::TypeInfo`
+///   - `Encode`: derives `ink::scale::Encode`
+///   - `Decode`: derives `ink::scale::Decode`
+///   - `TypeInfo`: derives `ink::scale_info::TypeInfo`
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->
Options for `scale_derive` attribute macro are currently documented as `encode`, `decode` and `type_info` instead of `Encode`, `Decode` and `TypeInfo`