### PR TITLE
Restrict syntax for setting ink! e2e test node to auto

### DIFF
--- a/crates/e2e/macro/src/config.rs
+++ b/crates/e2e/macro/src/config.rs
@@ -40,6 +40,7 @@ impl Default for Backend {
 pub enum Node {
     /// A fresh node instance will be spawned for the lifetime of the test.
     #[darling(word)]
+    #[darling(skip)]
     Auto,
     /// The test will run against an already running node at the supplied URL.
     Url(String),
@@ -137,7 +138,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "ErrorUnknownField")]
-    fn config_works_backend_runtime_only_default_not_allowed() {
+    fn config_backend_runtime_only_default_not_allowed() {
         let input = quote! {
             backend(runtime_only(default)),
         };
@@ -164,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn config_works_backend_node_default_auto() {
+    fn config_works_backend_node() {
         let input = quote! {
             backend(node),
         };
@@ -172,15 +173,6 @@ mod tests {
             E2EConfig::from_list(&NestedMeta::parse_meta_list(input).unwrap()).unwrap();
 
         assert_eq!(config.backend(), Backend::Node(Node::Auto));
-    }
-
-    #[test]
-    fn config_works_backend_node_auto() {
-        let input = quote! {
-            backend(node(auto)),
-        };
-        let config =
-            E2EConfig::from_list(&NestedMeta::parse_meta_list(input).unwrap()).unwrap();
 
         match config.backend() {
             Backend::Node(node_config) => {
@@ -202,6 +194,18 @@ mod tests {
             }
             _ => panic!("Expected Backend::Node"),
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "ErrorUnknownField")]
+    fn config_backend_node_auto_not_allowed() {
+        let input = quote! {
+            backend(node(auto)),
+        };
+        let config =
+            E2EConfig::from_list(&NestedMeta::parse_meta_list(input).unwrap()).unwrap();
+
+        assert_eq!(config.backend(), Backend::Node(Node::Auto));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
- Currently, both `#[ink_e2e::test(backend(node))]` and `#[ink_e2e::test(backend(node(auto)))]` are valid syntax for setting the e2e test node to auto, this PR removes the latter syntax.
- This PR doesn't affect/change the syntax for setting an already running node (i.e. `#[ink_e2e::test(backend(node(url = ..)))]`)

See also #2143 for a similar change

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
