### PR TITLE
Add Hash trait to Selector struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add Hash trait to Selector struct
 
 ## Version 5.0.0-rc.3
 

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -1094,7 +1094,8 @@ where
 }
 
 /// The 4 byte selector to identify constructors and messages
-#[derive(Debug, Default, PartialEq, Eq, derive_more::From, JsonSchema, Hash)]
+#[cfg_attr(feature = "std", derive(Hash))]
+#[derive(Debug, Default, PartialEq, Eq, derive_more::From, JsonSchema)]
 pub struct Selector(#[schemars(with = "String")] [u8; 4]);
 
 impl serde::Serialize for Selector {

--- a/crates/metadata/src/specs.rs
+++ b/crates/metadata/src/specs.rs
@@ -52,7 +52,10 @@ use serde::{
     Serialize,
 };
 #[cfg(feature = "std")]
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    hash::Hash,
+};
 
 /// Describes a contract.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -1091,7 +1094,7 @@ where
 }
 
 /// The 4 byte selector to identify constructors and messages
-#[derive(Debug, Default, PartialEq, Eq, derive_more::From, JsonSchema)]
+#[derive(Debug, Default, PartialEq, Eq, derive_more::From, JsonSchema, Hash)]
 pub struct Selector(#[schemars(with = "String")] [u8; 4]);
 
 impl serde::Serialize for Selector {


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->
Add Hash trait to Selector struct

## Description
<!--- Describe your changes in detail -->
With this implementation, you can now use Selector as a key in hash maps or hash sets. The hash method hashes the underlying bytes of the selector array, making it suitable for hashing.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
