### PR TITLE
Fix outdated docs for `[ink_e2e::test]`

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -128,7 +128,5 @@ WebSocket/S
 StorageVec
 KiB
 GB
-BufferTooSmall
-KeyNotFound
 DRink!
 ^

--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -128,5 +128,5 @@ WebSocket/S
 StorageVec
 KiB
 GB
-DRink!
+DRink
 ^

--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -131,5 +131,4 @@ GB
 BufferTooSmall
 KeyNotFound
 DRink!
-ink_env
 ^

--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -130,5 +130,6 @@ KiB
 GB
 BufferTooSmall
 KeyNotFound
+DRink!
 ink_env
 ^

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
--Fix outdated docs for `[ink_e2e::test]` ‒ [#2162](https://github.com/paritytech/ink/pull/2162)
+- Fix outdated docs for `[ink_e2e::test]` ‒ [#2162](https://github.com/paritytech/ink/pull/2162)
 
 ## Version 5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+-Fix outdated docs for `[ink_e2e::test]` ‒ [#2162](https://github.com/paritytech/ink/pull/2162)
+
 ## Version 5.0.0
 
 ℹ️ _We've created a migration guide from ink! 4 to ink! 5. It also contains an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,6 +2718,8 @@ version = "5.0.0"
 dependencies = [
  "darling 0.20.8",
  "derive_more",
+ "ink",
+ "ink_e2e",
  "ink_ir",
  "proc-macro2",
  "quote",

--- a/crates/e2e/macro/Cargo.toml
+++ b/crates/e2e/macro/Cargo.toml
@@ -29,6 +29,8 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 
 [dev-dependencies]
+ink = { path = "../../ink" }
+ink_e2e = { path = "../", features = ["drink"] }
 temp-env = "0.3.6"
 
 [features]

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -23,7 +23,7 @@ use derive_more::From;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
-/// Generates code for the `[ink::e2e_test]` macro.
+/// Generates code for the `[ink_e2e::test]` macro.
 #[derive(From)]
 pub struct InkE2ETest {
     /// The test function to generate code for.
@@ -31,7 +31,7 @@ pub struct InkE2ETest {
 }
 
 impl InkE2ETest {
-    /// Generates the code for `#[ink:e2e_test]`.
+    /// Generates the code for `#[ink_e2e:test]`.
     pub fn generate_code(&self) -> TokenStream2 {
         #[cfg(clippy)]
         if true {

--- a/crates/e2e/macro/src/lib.rs
+++ b/crates/e2e/macro/src/lib.rs
@@ -34,7 +34,7 @@ use syn::Result;
 ///   and install it on your PATH, or provide a path to an executable using the
 ///   `CONTRACTS_NODE` environment variable.
 ///
-/// Before the test function is invoked the contract will be build. Any errors that occur
+/// Before the test function is invoked the contract will be built. Any errors that occur
 /// during the contract build will prevent the test function from being invoked.
 ///
 /// ## Header Arguments

--- a/crates/e2e/macro/src/lib.rs
+++ b/crates/e2e/macro/src/lib.rs
@@ -62,12 +62,13 @@ use syn::Result;
 ///
 /// #[ink_e2e::test(backend(runtime_only))]
 /// async fn runtime_call_works() -> E2EResult<()> {
-///   // ...
+///     // ...
 /// }
 /// ```
 ///
-/// In this configuration the test will not run against a node that is running in the background,
-/// but against an in-process slimmed down `pallet-contracts` execution environment.
+/// In this configuration the test will not run against a node that is running in the
+/// background, but against an in-process slimmed down `pallet-contracts` execution
+/// environment.
 ///
 /// Please see [the page on testing with DRink!](https://use.ink/basics/contract-testing/drink)
 /// in our documentation for more details.
@@ -85,23 +86,23 @@ use syn::Result;
 /// #[ink::contract]
 /// mod my_module {
 ///     #[ink(storage)]
-///     pub struct MyContract { }
+///     pub struct MyContract {}
 ///
 ///     impl MyContract {
 ///         #[ink(constructor)]
 ///         pub fn new() -> Self {
-///             Self { }
+///             Self {}
 ///         }
 ///
 ///         #[ink(message)]
-///         pub fn my_message(&self) { }
+///         pub fn my_message(&self) {}
 ///     }
 /// }
 ///
 /// type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 ///
 /// #[ink_e2e::test]
-/// async fn e2e_test(mut client: ::ink_e2e::Client<C,E>) -> E2EResult<()> {
+/// async fn e2e_test(mut client: ::ink_e2e::Client<C, E>) -> E2EResult<()> {
 ///     // given
 ///     use my_module::MyContract;
 ///     let mut constructor = MyContract::new();


### PR DESCRIPTION
Some of the docs related to `[ink_e2e::test]` were outdated. 

This PR updates the syntax and adds doc tests.