### PR TITLE
Add `no-panic-handler` feature

### DIFF
--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -84,3 +84,6 @@ ink-debug = []
 
 # Disable the ink! provided global memory allocator.
 no-allocator = ["ink_allocator/no-allocator"]
+
+# Disable the ink! provided panic handler.
+no-panic-handler = []

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -55,7 +55,7 @@ pub const BUFFER_SIZE: usize = 16384;
 #[allow(unused_extern_crates)]
 extern crate rlibc;
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(any(feature = "std", feature = "no-panic-handler")))]
 #[allow(unused_variables)]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {

--- a/crates/ink/Cargo.toml
+++ b/crates/ink/Cargo.toml
@@ -55,3 +55,6 @@ show-codegen-docs = []
 
 # Disable the ink! provided global memory allocator.
 no-allocator = ["ink_env/no-allocator"]
+
+# Disable the ink! provided panic handler.
+no-panic-handler = ["ink_env/no-panic-handler"]


### PR DESCRIPTION
To enable `ink` to [be a dependency](https://github.com/paritytech/ink/issues/1674) from a `polkadot-sdk` runtime. Otherwise it clashes with the `sp_io` panic handler.

See https://github.com/paritytech/substrate-contracts-node/pull/228.