### PR TITLE
`[E2E]` build contracts before initializing node rpc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,7 @@ jobs:
           RUSTFLAGS:                     -Clink-arg=-z -Clink-arg=nostart-stop-gc
         run: |
           # run all tests with --all-features, which will run the e2e-tests feature if present
-          scripts/for_all_contracts_exec.sh --path integration-tests --ignore static-buffer -- cargo test \
+          RUST_LOG=debug scripts/for_all_contracts_exec.sh --path integration-tests/multi-contract-caller --ignore static-buffer -- cargo test \
             --all-features --manifest-path {}
           # run the static buffer test with a custom buffer size
           cargo clean --manifest-path integration-tests/static-buffer/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,7 @@ jobs:
           RUSTFLAGS:                     -Clink-arg=-z -Clink-arg=nostart-stop-gc
         run: |
           # run all tests with --all-features, which will run the e2e-tests feature if present
-          RUST_LOG=debug scripts/for_all_contracts_exec.sh --path integration-tests/multi-contract-caller --ignore static-buffer -- cargo test \
+          scripts/for_all_contracts_exec.sh --path integration-tests --ignore static-buffer -- cargo test \
             --all-features --manifest-path {}
           # run the static buffer test with a custom buffer size
           cargo clean --manifest-path integration-tests/static-buffer/Cargo.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix outdated docs for `[ink_e2e::test]` ‒ [#2162](https://github.com/paritytech/ink/pull/2162)
+- [E2E] build contracts before initializing node rpc ‒ [#2168](https://github.com/paritytech/ink/pull/2162)
 
 ## Version 5.0.0
 

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -115,12 +115,12 @@ fn build_full_client(
     match node_config.url() {
         Some(url) => {
             quote! {
+                let contracts = #contracts;
                 let rpc = ::ink_e2e::RpcClient::from_url(#url)
                     .await
                     .unwrap_or_else(|err|
                         ::core::panic!("Error connecting to node at {}: {err:?}", #url)
                     );
-                let contracts = #contracts;
                 let mut client = ::ink_e2e::Client::<
                     ::ink_e2e::PolkadotConfig,
                     #environment

--- a/crates/e2e/macro/src/codegen.rs
+++ b/crates/e2e/macro/src/codegen.rs
@@ -129,6 +129,7 @@ fn build_full_client(
         }
         None => {
             quote! {
+                let contracts = #contracts;
                 let node_rpc = ::ink_e2e::TestNodeProcess::<::ink_e2e::PolkadotConfig>
                     ::build_with_env_or_default()
                     .spawn()
@@ -136,7 +137,6 @@ fn build_full_client(
                     .unwrap_or_else(|err|
                         ::core::panic!("Error spawning substrate-contracts-node: {err:?}")
                     );
-                let contracts = #contracts;
                 let mut client = ::ink_e2e::Client::<
                     ::ink_e2e::PolkadotConfig,
                     #environment


### PR DESCRIPTION
Fix for the flaky `multi-contract-caller` integration test, which sometimes fails with:

`Rpc(ClientError(RestartNeeded(Transport(WebSocket connection error: connection closed`

This PR changes the test macro codegen to first build the contracts before initializing the node connection. Since this test builds 3 different sub-contracts, it takes longer to build all contracts therefore increasing the likelihood of the connection dropping