### PR TITLE
Linter: Add links to detailed lint description 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [Linter] Add links to detailed lint description ‒ [#2170](https://github.com/paritytech/ink/pull/2170)
+
 ### Fixed
 - Fix outdated docs for `[ink_e2e::test]` ‒ [#2162](https://github.com/paritytech/ink/pull/2162)
 

--- a/linting/extra/src/non_fallible_api.rs
+++ b/linting/extra/src/non_fallible_api.rs
@@ -239,7 +239,10 @@ impl<'a, 'tcx> APIUsageChecker<'a, 'tcx> {
                             "",
                             Applicability::Unspecified,
                         );
-                    },
+                        diag.help(
+                            "for further information visit https://use.ink/linter/rules/non_fallible_api".to_string(),
+                        );
+                },
                 )
             }
         }

--- a/linting/extra/src/primitive_topic.rs
+++ b/linting/extra/src/primitive_topic.rs
@@ -150,6 +150,9 @@ fn report_field(cx: &LateContext, event_def_id: DefId, field_name: &str) {
                         snippet,
                         Applicability::Unspecified,
                     );
+                    diag.help(
+                        "for further information visit https://use.ink/linter/rules/primitive_topic".to_string(),
+                    );
                 },
             )
         }

--- a/linting/extra/src/storage_never_freed.rs
+++ b/linting/extra/src/storage_never_freed.rs
@@ -223,7 +223,8 @@ fn report_field(cx: &LateContext, field_info: &FieldInfo) {
                 field.span,
                 "field's storage cannot be freed",
                 None,
-                "consider adding operations to remove elements available to the user"
+                "consider adding operations to remove elements available to the user\n\
+                for further information visit https://use.ink/linter/rules/storage_never_freed"
             )
 
         }

--- a/linting/extra/src/strict_balance_equality.rs
+++ b/linting/extra/src/strict_balance_equality.rs
@@ -606,6 +606,9 @@ impl<'tcx> StrictBalanceEquality {
                                 "",
                                 Applicability::Unspecified,
                             );
+                            diag.help(
+                                "for further information visit https://use.ink/linter/rules/strict_balance_equality".to_string(),
+                            );
                         },
                     )
                 }

--- a/linting/extra/ui/fail/non_fallible_api.stderr
+++ b/linting/extra/ui/fail/non_fallible_api.stderr
@@ -4,6 +4,7 @@ error: using a non-fallible `Mapping::insert` with an argument that may not fit 
 LL |             let _ = self.map_1.insert(a.clone(), &b);
    |                                ^^^^^^ help: consider using `try_insert`
    |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
    = note: `-D non-fallible-api` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(non_fallible_api)]`
 
@@ -12,66 +13,88 @@ error: using a non-fallible `Mapping::get` with an argument that may not fit int
    |
 LL |             let _ = self.map_1.get(a.clone());
    |                                ^^^ help: consider using `try_get`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: using a non-fallible `Mapping::take` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:49:32
    |
 LL |             let _ = self.map_1.take(a.clone());
    |                                ^^^^ help: consider using `try_take`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: using a non-fallible `Mapping::insert` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:52:32
    |
 LL |             let _ = self.map_2.insert(42, &v);
    |                                ^^^^^^ help: consider using `try_insert`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: using a non-fallible `Lazy::get` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:55:33
    |
 LL |             let _ = self.lazy_1.get();
    |                                 ^^^ help: consider using `try_get`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: using a non-fallible `Lazy::set` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:56:25
    |
 LL |             self.lazy_1.set(&a);
    |                         ^^^ help: consider using `try_set`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: using a non-fallible `Lazy::set` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:57:25
    |
 LL |             self.lazy_2.set(&(a.clone(), a.clone()));
    |                         ^^^ help: consider using `try_set`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: using a non-fallible `StorageVec::peek` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:60:32
    |
 LL |             let _ = self.vec_1.peek();
    |                                ^^^^ help: consider using `try_peek`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: using a non-fallible `StorageVec::get` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:61:32
    |
 LL |             let _ = self.vec_1.get(0);
    |                                ^^^ help: consider using `try_get`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: using a non-fallible `StorageVec::set` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:62:24
    |
 LL |             self.vec_1.set(0, &a.clone());
    |                        ^^^ help: consider using `try_set`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: using a non-fallible `StorageVec::pop` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:63:32
    |
 LL |             let _ = self.vec_1.pop();
    |                                ^^^ help: consider using `try_pop`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: using a non-fallible `StorageVec::push` with an argument that may not fit into the static buffer
   --> $DIR/non_fallible_api.rs:64:24
    |
 LL |             self.vec_1.push(&a.clone());
    |                        ^^^^ help: consider using `try_push`
+   |
+   = help: for further information visit https://use.ink/linter/rules/non_fallible_api
 
 error: aborting due to 12 previous errors
 

--- a/linting/extra/ui/fail/primitive_topic.stderr
+++ b/linting/extra/ui/fail/primitive_topic.stderr
@@ -4,6 +4,7 @@ error: using `#[ink(topic)]` for a field with a primitive number type
 LL |         value_1: u8,
    |         ^^^^^^^^^^^ help: consider removing `#[ink(topic)]`: `value_1: u8`
    |
+   = help: for further information visit https://use.ink/linter/rules/primitive_topic
    = note: `-D primitive-topic` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(primitive_topic)]`
 
@@ -12,18 +13,24 @@ error: using `#[ink(topic)]` for a field with a primitive number type
    |
 LL |         value_2: Balance,
    |         ^^^^^^^^^^^^^^^^ help: consider removing `#[ink(topic)]`: `value_2: Balance`
+   |
+   = help: for further information visit https://use.ink/linter/rules/primitive_topic
 
 error: using `#[ink(topic)]` for a field with a primitive number type
   --> $DIR/primitive_topic.rs:19:9
    |
 LL |         value_3: crate::TyAlias1,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `#[ink(topic)]`: `value_3: crate::TyAlias1`
+   |
+   = help: for further information visit https://use.ink/linter/rules/primitive_topic
 
 error: using `#[ink(topic)]` for a field with a primitive number type
   --> $DIR/primitive_topic.rs:22:9
    |
 LL |         value_4: crate::TyAlias2,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `#[ink(topic)]`: `value_4: crate::TyAlias2`
+   |
+   = help: for further information visit https://use.ink/linter/rules/primitive_topic
 
 error: aborting due to 4 previous errors
 

--- a/linting/extra/ui/fail/storage_never_freed.stderr
+++ b/linting/extra/ui/fail/storage_never_freed.stderr
@@ -5,6 +5,7 @@ LL |         map_1: Mapping<AccountId, AccountId>,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider adding operations to remove elements available to the user
+           for further information visit https://use.ink/linter/rules/storage_never_freed
 note: the lint level is defined here
   --> $DIR/storage_never_freed.rs:2:46
    |
@@ -18,6 +19,7 @@ LL |         map_2: Mapping<AccountId, AccountId>,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider adding operations to remove elements available to the user
+           for further information visit https://use.ink/linter/rules/storage_never_freed
 
 error: field's storage cannot be freed
   --> $DIR/storage_never_freed.rs:20:9
@@ -26,6 +28,7 @@ LL |         map_3: Mapping<AccountId, AccountId>,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider adding operations to remove elements available to the user
+           for further information visit https://use.ink/linter/rules/storage_never_freed
 
 error: field's storage cannot be freed
   --> $DIR/storage_never_freed.rs:21:9
@@ -34,6 +37,7 @@ LL |         map_alias: MapAlias2<AccountId, AccountId>,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider adding operations to remove elements available to the user
+           for further information visit https://use.ink/linter/rules/storage_never_freed
 
 error: field's storage cannot be freed
   --> $DIR/storage_never_freed.rs:15:9
@@ -42,6 +46,7 @@ LL |         vec_1: Vec<AccountId>,
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider adding operations to remove elements available to the user
+           for further information visit https://use.ink/linter/rules/storage_never_freed
 
 error: field's storage cannot be freed
   --> $DIR/storage_never_freed.rs:16:9
@@ -50,6 +55,7 @@ LL |         vec_2: Vec<bool>,
    |         ^^^^^^^^^^^^^^^^
    |
    = help: consider adding operations to remove elements available to the user
+           for further information visit https://use.ink/linter/rules/storage_never_freed
 
 error: field's storage cannot be freed
   --> $DIR/storage_never_freed.rs:17:9
@@ -58,6 +64,7 @@ LL |         vec_subscription: Vec<AccountId>,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider adding operations to remove elements available to the user
+           for further information visit https://use.ink/linter/rules/storage_never_freed
 
 error: aborting due to 7 previous errors
 

--- a/linting/extra/ui/fail/strict_balance_equality.stderr
+++ b/linting/extra/ui/fail/strict_balance_equality.stderr
@@ -4,6 +4,7 @@ error: dangerous strict balance equality
 LL |             if self.env().balance() == 10 { /* ... */ }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
    |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
    = note: `-D strict-balance-equality` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(strict_balance_equality)]`
 
@@ -12,66 +13,88 @@ error: dangerous strict balance equality
    |
 LL |             if value == 11 { /* ... */ }
    |                ^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:61:16
    |
 LL |             if self.env().balance() == threshold { /* ... */ }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:64:16
    |
 LL |             if self.get_balance_1() == 10 { /* ... */ }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:65:16
    |
 LL |             if self.get_balance_2() == 10 { /* ... */ }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:66:16
    |
 LL |             if self.get_balance_3() == 10 { /* ... */ }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:67:16
    |
 LL |             if self.get_balance_recursive(&10) == 10 { /* ... */ }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:71:16
    |
 LL |             if self.cmp_balance_1(&10) { /* ... */ }
    |                ^^^^^^^^^^^^^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:72:16
    |
 LL |             if self.cmp_balance_2(&self.env().balance(), &threshold) { /* ... */ }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:73:16
    |
 LL |             if self.cmp_balance_3(self.env().balance(), threshold) { /* ... */ }
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:78:16
    |
 LL |             if res_1 == 10 { /* ... */ }
    |                ^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: dangerous strict balance equality
   --> $DIR/strict_balance_equality.rs:81:16
    |
 LL |             if res_2 == 10 { /* ... */ }
    |                ^^^^^^^^^^^ help: consider using non-strict equality operators instead: `<`, `>`
+   |
+   = help: for further information visit https://use.ink/linter/rules/strict_balance_equality
 
 error: aborting due to 12 previous errors
 

--- a/linting/mandatory/src/no_main.rs
+++ b/linting/mandatory/src/no_main.rs
@@ -79,7 +79,8 @@ impl EarlyLintPass for NoMain {
                 krate.spans.inner_span,
                 "contract must be annotated with the `no_main` inner attribute",
                 None,
-                "consider annotating contract with `#![cfg_attr(not(feature = \"std\"), no_std, no_main)]` or `#![no_main]`"
+                "consider annotating contract with `#![cfg_attr(not(feature = \"std\"), no_std, no_main)]` or `#![no_main]`\n\
+                for further information visit https://use.ink/linter/rules/no_main"
             )
         }
     }


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [y] y/n | Is it dependant on the specific version of `cargo-contract` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

I'll create an accompanying `cargo-contract` PR so that the new version of these lints is used.

## Description

Closes https://github.com/paritytech/ink/issues/2169.

For the linter warnings, I've added a link to the detailed description of the lint on use.ink.

<img width="954" alt="image" src="https://github.com/paritytech/ink/assets/241530/040c8659-606a-4e52-b8c3-292e64157050">


## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
