### PR TITLE
chore: fix typos

### DIFF
--- a/linting/extra/src/primitive_topic.rs
+++ b/linting/extra/src/primitive_topic.rs
@@ -64,7 +64,7 @@ declare_lint! {
     /// It typically doesn't make sense to annotate types like `u32` or `i32` as a topic, if those
     /// fields can take continuous values that could be anywhere between `::MIN` and `::MAX`. An
     /// example of a case where it doesn't make sense at all to have a topic on the storage field
-    /// is something like `value: Balance` in the examle below.
+    /// is something like `value: Balance` in the example below.
     ///
     /// ## Example
     /// ```rust


### PR DESCRIPTION
fix a typo: `examle`->`example`